### PR TITLE
Reorganize README files for CLI and server

### DIFF
--- a/README-CLI.md
+++ b/README-CLI.md
@@ -1,0 +1,1112 @@
+# LLM Adapter CLI Manual
+
+Complete reference for the `llm-adapter` command-line interface.
+
+## Installation
+
+```bash
+npm install llm-adapter
+```
+
+The CLI is available as `llm-adapter` after installation.
+
+## Command Overview
+
+```bash
+llm-adapter <command> [options]
+```
+
+| Command | Description |
+|---------|-------------|
+| `run` | Non-streaming LLM call |
+| `stream` | Streaming LLM call |
+| `vector run` | Non-streaming vector operation |
+| `vector stream` | Streaming vector operation |
+| `vector embed` | Embed texts (with optional upsert) |
+| `vector query` | Query a vector store |
+| `vector upsert` | Upsert vectors to a store |
+| `vector delete` | Delete vectors by ID |
+| `vector collections` | Manage collections |
+| `embeddings run` | Execute embedding operation |
+| `serve` | Start HTTP/SSE server |
+
+---
+
+## LLM Commands
+
+### `llm-adapter run`
+
+Execute a non-streaming LLM call.
+
+```bash
+llm-adapter run --spec '<json>' [options]
+llm-adapter run --file <path> [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `-s, --spec <json>` | Spec as JSON string |
+| `-f, --file <path>` | Path to spec JSON file |
+| `-p, --plugins <path>` | Path to plugins directory (default: `./plugins`) |
+| `--batch-id <id>` | Batch identifier for grouped logging |
+| `--pretty` | Pretty print output |
+
+**Example:**
+
+```bash
+llm-adapter run --spec '{
+  "messages": [
+    {"role": "user", "content": [{"type": "text", "text": "Hello, how are you?"}]}
+  ],
+  "llmPriority": [
+    {"provider": "anthropic", "model": "claude-sonnet-4-20250514"}
+  ],
+  "settings": {"temperature": 0.7}
+}'
+```
+
+### `llm-adapter stream`
+
+Execute a streaming LLM call. Returns Server-Sent Events.
+
+```bash
+llm-adapter stream --spec '<json>' [options]
+llm-adapter stream --file <path> [options]
+```
+
+**Options:** Same as `run`.
+
+**Example:**
+
+```bash
+llm-adapter stream --spec '{
+  "messages": [{"role": "user", "content": [{"type": "text", "text": "Write a poem"}]}],
+  "llmPriority": [{"provider": "openai", "model": "gpt-4"}],
+  "settings": {}
+}'
+```
+
+---
+
+## Vector Commands
+
+### `llm-adapter vector run`
+
+Execute any vector operation from a VectorCallSpec.
+
+```bash
+llm-adapter vector run --spec '<json>' [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `-s, --spec <json>` | Spec as JSON string |
+| `-f, --file <path>` | Path to spec JSON file |
+| `-p, --plugins <path>` | Path to plugins directory (default: `./plugins`) |
+| `--batch-id <id>` | Batch identifier for grouped logging |
+| `--pretty` | Pretty print output |
+
+### `llm-adapter vector stream`
+
+Stream vector operation events (useful for batch operations).
+
+```bash
+llm-adapter vector stream --spec '<json>' [options]
+```
+
+**Options:** Same as `vector run`.
+
+### `llm-adapter vector embed`
+
+Embed texts and optionally upsert to a vector store.
+
+```bash
+llm-adapter vector embed --spec '<json>' [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `-s, --spec <json>` | Spec as JSON string |
+| `-f, --file <path>` | Path to spec JSON file |
+| `-p, --plugins <path>` | Path to plugins directory |
+| `--batch-id <id>` | Batch identifier |
+| `--pretty` | Pretty print output |
+| `--stream` | Stream progress events |
+
+**Examples:**
+
+```bash
+# Embed texts
+llm-adapter vector embed --spec '{
+  "operation": "embed",
+  "store": "qdrant-local",
+  "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+  "input": {"texts": ["Hello world", "Machine learning is fascinating"]}
+}'
+
+# Embed with custom batch size
+llm-adapter vector embed --spec '{
+  "operation": "embed",
+  "store": "qdrant-local",
+  "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+  "input": {"texts": ["Text 1", "Text 2", "Text 3", "Text 4", "Text 5"]},
+  "settings": {"batchSize": 2}
+}'
+
+# Stream progress for large batches
+llm-adapter vector embed --stream --spec '{
+  "operation": "embed",
+  "store": "qdrant-local",
+  "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+  "input": {"texts": ["Text 1", "Text 2", "Text 3", "Text 4", "Text 5"]}
+}'
+```
+
+### `llm-adapter vector query`
+
+Query a vector store.
+
+```bash
+llm-adapter vector query --spec '<json>' [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `-s, --spec <json>` | Spec as JSON string |
+| `-f, --file <path>` | Path to spec JSON file |
+| `-p, --plugins <path>` | Path to plugins directory |
+| `--batch-id <id>` | Batch identifier |
+| `--pretty` | Pretty print output |
+
+**Examples:**
+
+```bash
+# Query with text (auto-embedded)
+llm-adapter vector query --spec '{
+  "operation": "query",
+  "store": "qdrant-local",
+  "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+  "input": {"query": "What is machine learning?", "topK": 5}
+}'
+
+# Query with pre-computed vector
+llm-adapter vector query --spec '{
+  "operation": "query",
+  "store": "qdrant-local",
+  "input": {"vector": [0.1, 0.2, 0.3], "topK": 5}
+}'
+
+# Query with metadata filter
+llm-adapter vector query --spec '{
+  "operation": "query",
+  "store": "qdrant-local",
+  "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+  "input": {
+    "query": "What is ML?",
+    "topK": 10,
+    "filter": {"category": "tech"}
+  }
+}'
+
+# Query specific collection
+llm-adapter vector query --spec '{
+  "operation": "query",
+  "store": "qdrant-local",
+  "collection": "my-docs",
+  "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+  "input": {"query": "search terms", "topK": 5}
+}'
+```
+
+### `llm-adapter vector upsert`
+
+Upsert pre-computed vectors to a store.
+
+```bash
+llm-adapter vector upsert --spec '<json>' [options]
+```
+
+**Options:** Same as `vector query`.
+
+**Example:**
+
+```bash
+llm-adapter vector upsert --spec '{
+  "operation": "upsert",
+  "store": "qdrant-local",
+  "input": {
+    "points": [
+      {"id": "doc1", "vector": [0.1, 0.2, 0.3], "payload": {"text": "Hello"}},
+      {"id": "doc2", "vector": [0.4, 0.5, 0.6], "payload": {"text": "World"}}
+    ]
+  }
+}'
+```
+
+### `llm-adapter vector delete`
+
+Delete vectors by ID.
+
+```bash
+llm-adapter vector delete --spec '<json>' [options]
+```
+
+**Options:** Same as `vector query`.
+
+**Example:**
+
+```bash
+llm-adapter vector delete --spec '{
+  "operation": "delete",
+  "store": "qdrant-local",
+  "input": {"ids": ["doc1", "doc2"]}
+}'
+```
+
+### `llm-adapter vector collections`
+
+Manage collections (list, create, delete, check existence).
+
+```bash
+llm-adapter vector collections --spec '<json>' [options]
+```
+
+**Options:** Same as `vector query`.
+
+**Examples:**
+
+```bash
+# List collections
+llm-adapter vector collections --spec '{
+  "operation": "collections",
+  "store": "qdrant-local",
+  "input": {"collectionOp": "list"}
+}'
+
+# Check if collection exists
+llm-adapter vector collections --spec '{
+  "operation": "collections",
+  "store": "qdrant-local",
+  "input": {"collectionOp": "exists", "collection": "my-docs"}
+}'
+
+# Create collection
+llm-adapter vector collections --spec '{
+  "operation": "collections",
+  "store": "qdrant-local",
+  "input": {
+    "collectionOp": "create",
+    "collection": "my-docs",
+    "dimensions": 1536,
+    "options": {"distance": "Cosine"}
+  }
+}'
+
+# Delete collection
+llm-adapter vector collections --spec '{
+  "operation": "collections",
+  "store": "qdrant-local",
+  "input": {"collectionOp": "delete", "collection": "my-docs"}
+}'
+```
+
+---
+
+## Embeddings Commands
+
+### `llm-adapter embeddings run`
+
+Execute an embedding operation.
+
+```bash
+llm-adapter embeddings run --spec '<json>' [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `-s, --spec <json>` | Spec as JSON string |
+| `-f, --file <path>` | Path to spec JSON file |
+| `-p, --plugins <path>` | Path to plugins directory |
+| `--batch-id <id>` | Batch identifier |
+| `--pretty` | Pretty print output |
+
+**Examples:**
+
+```bash
+# Embed single text
+llm-adapter embeddings run --spec '{
+  "operation": "embed",
+  "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+  "input": {"text": "Hello world"}
+}'
+
+# Embed multiple texts
+llm-adapter embeddings run --spec '{
+  "operation": "embed",
+  "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+  "input": {"texts": ["Hello", "World"]}
+}'
+```
+
+---
+
+## Server Command
+
+### `llm-adapter serve`
+
+Start the HTTP/SSE server. See [README-SERVER.md](README-SERVER.md) for complete server documentation.
+
+```bash
+llm-adapter serve [options]
+```
+
+**Common Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--host <host>` | Host to bind | `127.0.0.1` |
+| `--port <port>` | Port to bind (0 = ephemeral) | `0` |
+| `-p, --plugins <path>` | Path to plugins directory | `./plugins` |
+| `--batch-id <id>` | Batch identifier | |
+
+**Example:**
+
+```bash
+llm-adapter serve --port 3000
+```
+
+---
+
+## Spec Reference
+
+### LLMCallSpec
+
+The specification for LLM calls (`run` and `stream` commands).
+
+```typescript
+{
+  // System prompt (optional)
+  "systemPrompt": "You are a helpful assistant.",
+
+  // Messages (required)
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Hello"}
+      ]
+    }
+  ],
+
+  // Provider priority list (required) - tries in order until success
+  "llmPriority": [
+    {
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-20250514",
+      "settings": {}  // Optional per-provider settings override
+    },
+    {
+      "provider": "openai",
+      "model": "gpt-4"
+    }
+  ],
+
+  // Settings (required, can be empty object)
+  "settings": {
+    "temperature": 0.7,
+    "topP": 1.0,
+    "maxTokens": 4096,
+    "stop": ["END"],
+    "seed": 42,
+    "frequencyPenalty": 0,
+    "presencePenalty": 0,
+
+    // Extended thinking/reasoning
+    "reasoning": {
+      "enabled": true,
+      "effort": "medium",
+      "budget": 10000,
+      "exclude": false
+    },
+
+    // Tool settings
+    "maxToolIterations": 10,
+    "toolCountdownEnabled": true,
+    "toolFinalPromptEnabled": true,
+    "parallelToolExecution": false,
+    "preserveToolResults": 3,
+    "preserveReasoning": 3,
+    "toolResultMaxChars": 50000
+  },
+
+  // Tools (optional)
+  "functionToolNames": ["test.echo", "test.random"],
+  "tools": [
+    {
+      "name": "custom_tool",
+      "description": "A custom tool",
+      "parametersJsonSchema": {
+        "type": "object",
+        "properties": {
+          "param": {"type": "string"}
+        }
+      }
+    }
+  ],
+  "mcpServers": ["testmcp"],
+  "toolChoice": "auto",
+
+  // Vector/RAG (optional)
+  "vectorContext": {
+    "stores": ["qdrant-local"],
+    "mode": "auto",
+    "topK": 5,
+    "embeddingPriority": [{"provider": "openrouter-embeddings"}]
+  },
+
+  // Retry configuration (optional)
+  "rateLimitRetryDelays": [1, 2, 5, 10],
+
+  // Metadata for logging (optional)
+  "metadata": {
+    "correlationId": "request-123",
+    "userId": "user-456"
+  }
+}
+```
+
+### Message Content Types
+
+#### Text Content
+
+```json
+{"type": "text", "text": "Hello, world!"}
+```
+
+#### Image Content
+
+```json
+{
+  "type": "image",
+  "source": {"type": "base64", "data": "..."},
+  "mimeType": "image/png"
+}
+```
+
+Or from URL:
+
+```json
+{
+  "type": "image",
+  "source": {"type": "url", "url": "https://example.com/image.png"}
+}
+```
+
+#### Document Content
+
+From file path (recommended):
+
+```json
+{
+  "type": "document",
+  "source": {"type": "filepath", "path": "/path/to/document.pdf"}
+}
+```
+
+From base64:
+
+```json
+{
+  "type": "document",
+  "source": {"type": "base64", "data": "..."},
+  "mimeType": "application/pdf",
+  "filename": "document.pdf"
+}
+```
+
+From URL:
+
+```json
+{
+  "type": "document",
+  "source": {"type": "url", "url": "https://example.com/doc.pdf"},
+  "mimeType": "application/pdf"
+}
+```
+
+From provider file ID:
+
+```json
+{
+  "type": "document",
+  "source": {"type": "file_id", "fileId": "file-abc123"},
+  "mimeType": "application/pdf"
+}
+```
+
+**Supported Document Types:**
+
+| Extension | MIME Type |
+|-----------|-----------|
+| .pdf | application/pdf |
+| .csv | text/csv |
+| .txt | text/plain |
+| .json | application/json |
+| .html, .htm | text/html |
+| .md, .markdown | text/markdown |
+| .docx | application/vnd.openxmlformats-officedocument.wordprocessingml.document |
+| .xlsx | application/vnd.openxmlformats-officedocument.spreadsheetml.sheet |
+
+### VectorCallSpec
+
+The specification for vector operations.
+
+```typescript
+{
+  // Operation type (required)
+  "operation": "embed" | "upsert" | "query" | "delete" | "collections",
+
+  // Vector store ID (required)
+  "store": "qdrant-local",
+
+  // Collection name (optional, uses store default)
+  "collection": "my-collection",
+
+  // Embedding provider priority (required for operations that need embeddings)
+  "embeddingPriority": [
+    {"provider": "openrouter-embeddings"}
+  ],
+
+  // Operation-specific input (required)
+  "input": { ... },
+
+  // Operation settings (optional)
+  "settings": {
+    "batchSize": 10,
+    "includePayload": true,
+    "includeVector": false
+  },
+
+  // Metadata (optional)
+  "metadata": {
+    "correlationId": "request-123"
+  }
+}
+```
+
+#### Input by Operation
+
+**embed:**
+```json
+{
+  "texts": ["Text to embed", "Another text"],
+  "ids": ["id1", "id2"],
+  "payloads": [{"meta": "data1"}, {"meta": "data2"}],
+  "upsert": true
+}
+```
+
+**query:**
+```json
+{
+  "query": "Search text",
+  "topK": 5,
+  "filter": {"category": "tech"},
+  "scoreThreshold": 0.7
+}
+```
+
+Or with pre-computed vector:
+```json
+{
+  "vector": [0.1, 0.2, 0.3],
+  "topK": 5
+}
+```
+
+**upsert:**
+```json
+{
+  "points": [
+    {"id": "doc1", "vector": [0.1, 0.2], "payload": {"text": "Hello"}}
+  ]
+}
+```
+
+**delete:**
+```json
+{
+  "ids": ["doc1", "doc2"]
+}
+```
+
+**collections:**
+```json
+{
+  "collectionOp": "list" | "exists" | "create" | "delete",
+  "collection": "collection-name",
+  "dimensions": 1536,
+  "options": {"distance": "Cosine"}
+}
+```
+
+### EmbeddingCallSpec
+
+The specification for embedding operations.
+
+```typescript
+{
+  // Operation (required)
+  "operation": "embed",
+
+  // Embedding provider priority (required)
+  "embeddingPriority": [
+    {"provider": "openrouter-embeddings"}
+  ],
+
+  // Input (required)
+  "input": {
+    "text": "Single text to embed"
+  }
+  // OR
+  "input": {
+    "texts": ["Multiple", "texts", "to embed"]
+  },
+
+  // Metadata (optional)
+  "metadata": {
+    "correlationId": "request-123"
+  }
+}
+```
+
+---
+
+## VectorContextConfig (RAG Integration)
+
+When using LLM calls with vector stores for RAG:
+
+```typescript
+{
+  "messages": [...],
+  "llmPriority": [...],
+  "settings": {},
+  "vectorContext": {
+    // Which stores to query (required)
+    "stores": ["qdrant-local"],
+
+    // Mode (required)
+    "mode": "auto" | "tool" | "both",
+
+    // Query config
+    "topK": 5,
+    "scoreThreshold": 0.7,
+    "filter": {"category": "tech"},
+    "collection": "my-docs",
+    "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+
+    // Query construction (auto/both modes)
+    "overrideEmbeddingQuery": "exact query to use",
+    "queryConstruction": {
+      "messagesToInclude": 1,
+      "includeAssistantMessages": true,
+      "includeSystemPrompt": "if-in-range"
+    },
+
+    // Auto-inject config (auto/both modes)
+    "injectAs": "system" | "user_context",
+    "injectTemplate": "Relevant context:\n{{results}}",
+    "resultFormat": "- {{payload.text}} (score: {{score}})",
+    "maxContextTokens": 4000,
+
+    // Tool mode config (tool/both modes)
+    "toolName": "vector_search",
+    "toolDescription": "Search the knowledge base",
+    "toolSchemaOverrides": {
+      "toolDescription": "Search product docs",
+      "params": {
+        "query": {"name": "search_query", "description": "Your search"},
+        "topK": {"name": "limit", "description": "Max results"}
+      }
+    },
+
+    // Parameter locking (tool mode only)
+    "locks": {
+      "store": "qdrant-local",
+      "topK": 5,
+      "filter": {"tenant": "acme"},
+      "scoreThreshold": 0.7,
+      "collection": "docs"
+    }
+  }
+}
+```
+
+### Mode Descriptions
+
+| Mode | Behavior |
+|------|----------|
+| `auto` | Query vectors using user message, inject results before LLM call |
+| `tool` | Create a `vector_search` tool the LLM can call on-demand |
+| `both` | Auto-inject initial context + provide tool for follow-up queries |
+
+---
+
+## Per-Provider Settings
+
+Override settings for specific providers:
+
+```json
+{
+  "messages": [...],
+  "llmPriority": [
+    {
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-20250514",
+      "settings": {
+        "temperature": 0.3,
+        "reasoning": {"enabled": true, "budget": 5000}
+      }
+    },
+    {
+      "provider": "openai",
+      "model": "gpt-4"
+    }
+  ],
+  "settings": {
+    "temperature": 0.7,
+    "maxTokens": 4096
+  }
+}
+```
+
+Anthropic gets `{temperature: 0.3, maxTokens: 4096, reasoning: {enabled: true, budget: 5000}}`.
+OpenAI gets `{temperature: 0.7, maxTokens: 4096}`.
+
+---
+
+## Tool Configuration
+
+### Using Plugin Tools
+
+Reference tools defined in `plugins/tools/*.json`:
+
+```json
+{
+  "messages": [...],
+  "llmPriority": [...],
+  "settings": {},
+  "functionToolNames": ["test.echo", "test.random"]
+}
+```
+
+### Inline Tool Definitions
+
+Define tools directly in the spec:
+
+```json
+{
+  "messages": [...],
+  "llmPriority": [...],
+  "settings": {},
+  "tools": [
+    {
+      "name": "get_weather",
+      "description": "Get current weather for a location",
+      "parametersJsonSchema": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string",
+            "description": "City name"
+          },
+          "unit": {
+            "type": "string",
+            "enum": ["celsius", "fahrenheit"],
+            "description": "Temperature unit"
+          }
+        },
+        "required": ["location"]
+      }
+    }
+  ]
+}
+```
+
+### MCP Servers
+
+Use MCP server tools:
+
+```json
+{
+  "messages": [...],
+  "llmPriority": [...],
+  "settings": {},
+  "mcpServers": ["testmcp"]
+}
+```
+
+### Tool Choice
+
+Control tool selection:
+
+```json
+{
+  "toolChoice": "auto"
+}
+```
+
+| Value | Behavior |
+|-------|----------|
+| `"auto"` | Model decides when to use tools |
+| `"required"` | Model must use a tool |
+| `"none"` | Model cannot use tools |
+| `{"type": "tool", "name": "tool_name"}` | Force specific tool |
+
+---
+
+## Using Spec Files
+
+Instead of inline JSON, use spec files:
+
+```bash
+# Create spec file
+cat > my-spec.json << 'EOF'
+{
+  "messages": [
+    {"role": "user", "content": [{"type": "text", "text": "Hello"}]}
+  ],
+  "llmPriority": [
+    {"provider": "anthropic", "model": "claude-sonnet-4-20250514"}
+  ],
+  "settings": {}
+}
+EOF
+
+# Use spec file
+llm-adapter run --file my-spec.json
+llm-adapter stream --file my-spec.json
+```
+
+---
+
+## Environment Variables
+
+### Logging
+
+| Variable | Purpose | Values |
+|----------|---------|--------|
+| `LLM_ADAPTER_BATCH_ID` | Batch identifier for logs | string |
+| `LLM_ADAPTER_BATCH_DIR` | Use batch-based directories | "1" or "0" |
+| `LLM_ADAPTER_DISABLE_FILE_LOGS` | Disable file logging | "1" or unset |
+| `LLM_ADAPTER_DISABLE_CONSOLE_LOGS` | Disable console logging | "1" or unset |
+
+### Provider API Keys
+
+Set in your environment or `.env` file:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
+export GOOGLE_API_KEY=...
+export OPENROUTER_API_KEY=sk-or-...
+export EMBEDDING_API_KEY=...
+export VECTOR_STORE_API_KEY=...
+```
+
+---
+
+## Output Formats
+
+### Non-Streaming Response
+
+```json
+{
+  "type": "response",
+  "data": {
+    "content": [{"type": "text", "text": "Response text"}],
+    "stopReason": "end_turn",
+    "usage": {
+      "inputTokens": 10,
+      "outputTokens": 50
+    },
+    "model": "claude-sonnet-4-20250514",
+    "provider": "anthropic"
+  }
+}
+```
+
+### Streaming Events
+
+Each event is a JSON object:
+
+```json
+{"type": "message_start", ...}
+{"type": "delta", "text": "Hello"}
+{"type": "delta", "text": " world"}
+{"type": "tool_use", "name": "test.echo", "input": {...}}
+{"type": "tool_result", "toolCallId": "...", "result": {...}}
+{"type": "message_stop", ...}
+```
+
+### Vector Operation Results
+
+**Query:**
+```json
+{
+  "type": "response",
+  "data": {
+    "operation": "query",
+    "results": [
+      {"id": "doc1", "score": 0.95, "payload": {"text": "..."}},
+      {"id": "doc2", "score": 0.87, "payload": {"text": "..."}}
+    ]
+  }
+}
+```
+
+**Embed:**
+```json
+{
+  "type": "response",
+  "data": {
+    "operation": "embed",
+    "vectors": [[0.1, 0.2, ...], [0.3, 0.4, ...]],
+    "dimensions": 1536
+  }
+}
+```
+
+---
+
+## Examples
+
+### Simple Chat
+
+```bash
+llm-adapter run --spec '{
+  "messages": [{"role": "user", "content": [{"type": "text", "text": "What is 2+2?"}]}],
+  "llmPriority": [{"provider": "anthropic", "model": "claude-sonnet-4-20250514"}],
+  "settings": {}
+}'
+```
+
+### Multi-Turn Conversation
+
+```bash
+llm-adapter run --spec '{
+  "systemPrompt": "You are a math tutor.",
+  "messages": [
+    {"role": "user", "content": [{"type": "text", "text": "What is calculus?"}]},
+    {"role": "assistant", "content": [{"type": "text", "text": "Calculus is..."}]},
+    {"role": "user", "content": [{"type": "text", "text": "Can you give an example?"}]}
+  ],
+  "llmPriority": [{"provider": "openai", "model": "gpt-4"}],
+  "settings": {"temperature": 0.5}
+}'
+```
+
+### With Document
+
+```bash
+llm-adapter run --spec '{
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Summarize this document"},
+        {"type": "document", "source": {"type": "filepath", "path": "/path/to/doc.pdf"}}
+      ]
+    }
+  ],
+  "llmPriority": [{"provider": "anthropic", "model": "claude-sonnet-4-20250514"}],
+  "settings": {}
+}'
+```
+
+### With Tool Calls
+
+```bash
+llm-adapter run --spec '{
+  "messages": [{"role": "user", "content": [{"type": "text", "text": "Echo hello"}]}],
+  "llmPriority": [{"provider": "anthropic", "model": "claude-sonnet-4-20250514"}],
+  "settings": {},
+  "functionToolNames": ["test.echo"]
+}'
+```
+
+### RAG with Auto-Inject
+
+```bash
+llm-adapter run --spec '{
+  "messages": [{"role": "user", "content": [{"type": "text", "text": "What is machine learning?"}]}],
+  "llmPriority": [{"provider": "anthropic", "model": "claude-sonnet-4-20250514"}],
+  "settings": {},
+  "vectorContext": {
+    "stores": ["qdrant-local"],
+    "mode": "auto",
+    "topK": 5,
+    "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+    "injectAs": "system",
+    "injectTemplate": "Use this context to answer:\n{{results}}"
+  }
+}'
+```
+
+### RAG with Tool Mode
+
+```bash
+llm-adapter run --spec '{
+  "systemPrompt": "You can search the knowledge base when needed.",
+  "messages": [{"role": "user", "content": [{"type": "text", "text": "Find info about neural networks"}]}],
+  "llmPriority": [{"provider": "anthropic", "model": "claude-sonnet-4-20250514"}],
+  "settings": {},
+  "vectorContext": {
+    "stores": ["qdrant-local"],
+    "mode": "tool",
+    "toolName": "search_knowledge_base",
+    "toolDescription": "Search the knowledge base for relevant information",
+    "embeddingPriority": [{"provider": "openrouter-embeddings"}]
+  }
+}'
+```
+
+### Provider Fallback
+
+```bash
+llm-adapter run --spec '{
+  "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}],
+  "llmPriority": [
+    {"provider": "anthropic", "model": "claude-sonnet-4-20250514"},
+    {"provider": "openai", "model": "gpt-4"},
+    {"provider": "openrouter", "model": "anthropic/claude-3-opus"}
+  ],
+  "settings": {}
+}'
+```
+
+### Extended Thinking
+
+```bash
+llm-adapter run --spec '{
+  "messages": [{"role": "user", "content": [{"type": "text", "text": "Solve this complex problem..."}]}],
+  "llmPriority": [{"provider": "anthropic", "model": "claude-sonnet-4-20250514"}],
+  "settings": {
+    "reasoning": {
+      "enabled": true,
+      "effort": "high",
+      "budget": 20000
+    }
+  }
+}'
+```

--- a/README-SERVER.md
+++ b/README-SERVER.md
@@ -1,0 +1,1018 @@
+# LLM Adapter Server Manual
+
+Complete reference for the LLM Adapter HTTP/SSE server.
+
+## Quick Start
+
+```bash
+# Start server on port 3000
+llm-adapter serve --port 3000
+
+# Make a request
+curl http://127.0.0.1:3000/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role":"user","content":[{"type":"text","text":"Hello"}]}],
+    "llmPriority": [{"provider":"anthropic","model":"claude-sonnet-4-20250514"}],
+    "settings": {}
+  }'
+```
+
+---
+
+## Starting the Server
+
+### Via CLI
+
+```bash
+llm-adapter serve [options]
+```
+
+### Programmatically
+
+```typescript
+import { createServer } from 'llm-adapter/server';
+
+const server = await createServer({
+  port: 3000,
+  host: '127.0.0.1'
+});
+
+console.log(server.url);  // http://127.0.0.1:3000
+
+// Shutdown
+await server.close();
+```
+
+---
+
+## Server Options
+
+### Basic Options
+
+| Option | CLI Flag | Default | Description |
+|--------|----------|---------|-------------|
+| `host` | `--host <host>` | `127.0.0.1` | Host to bind |
+| `port` | `--port <port>` | `0` | Port to bind (0 = ephemeral) |
+| `pluginsPath` | `-p, --plugins <path>` | `./plugins` | Path to plugins directory |
+| `batchId` | `--batch-id <id>` | | Batch identifier for logging |
+
+### Request Handling
+
+| Option | CLI Flag | Default | Description |
+|--------|----------|---------|-------------|
+| `maxRequestBytes` | `--max-request-bytes <n>` | `26214400` (25MB) | Maximum request body size |
+| `bodyReadTimeoutMs` | `--body-read-timeout-ms <n>` | `10000` | Timeout for reading request body |
+| `requestTimeoutMs` | `--request-timeout-ms <n>` | `0` (disabled) | Overall request timeout |
+| `streamIdleTimeoutMs` | `--stream-idle-timeout-ms <n>` | `60000` | Timeout for idle streaming connections |
+
+### Concurrency Limits
+
+| Option | CLI Flag | Default | Description |
+|--------|----------|---------|-------------|
+| `maxConcurrentRequests` | `--max-concurrent-requests <n>` | `128` | Max concurrent non-streaming requests |
+| `maxConcurrentStreams` | `--max-concurrent-streams <n>` | `32` | Max concurrent streaming requests |
+| `maxQueueSize` | `--max-queue-size <n>` | `1000` | Max queued requests |
+| `queueTimeoutMs` | `--queue-timeout-ms <n>` | `30000` | Timeout for queued requests |
+
+### Vector-Specific Limits
+
+| Option | CLI Flag | Default | Description |
+|--------|----------|---------|-------------|
+| `maxConcurrentVectorRequests` | `--max-concurrent-vector-requests <n>` | `128` | Max concurrent vector requests |
+| `maxConcurrentVectorStreams` | `--max-concurrent-vector-streams <n>` | `32` | Max concurrent vector streams |
+| `vectorMaxQueueSize` | `--vector-max-queue-size <n>` | `1000` | Max queued vector requests |
+| `vectorQueueTimeoutMs` | `--vector-queue-timeout-ms <n>` | `30000` | Timeout for queued vector requests |
+
+### Embedding-Specific Limits
+
+| Option | CLI Flag | Default | Description |
+|--------|----------|---------|-------------|
+| `maxConcurrentEmbeddingRequests` | `--max-concurrent-embedding-requests <n>` | `128` | Max concurrent embedding requests |
+| `embeddingMaxQueueSize` | `--embedding-max-queue-size <n>` | `1000` | Max queued embedding requests |
+| `embeddingQueueTimeoutMs` | `--embedding-queue-timeout-ms <n>` | `30000` | Timeout for queued embedding requests |
+
+### Security: Authentication
+
+| Option | CLI Flag | Default | Description |
+|--------|----------|---------|-------------|
+| `auth.enabled` | `--auth-enabled` | `false` | Enable authentication |
+| `auth.allowBearer` | `--no-auth-allow-bearer` | `true` | Allow Bearer token auth |
+| `auth.allowApiKeyHeader` | `--no-auth-allow-api-key-header` | `true` | Allow x-api-key header |
+| `auth.headerName` | `--auth-header-name <name>` | | Custom auth header name |
+| `auth.realm` | `--auth-realm <realm>` | | Authentication realm |
+| `auth.apiKeys` | (config only) | | Array of valid API keys |
+| `auth.hashedKeys` | (config only) | | Array of SHA-256 hashed keys |
+
+### Security: Rate Limiting
+
+| Option | CLI Flag | Default | Description |
+|--------|----------|---------|-------------|
+| `rateLimit.enabled` | `--rate-limit-enabled` | `false` | Enable rate limiting |
+| `rateLimit.requestsPerMinute` | `--rate-limit-requests-per-minute <n>` | | Requests per minute per client |
+| `rateLimit.burst` | `--rate-limit-burst <n>` | | Burst allowance |
+| `rateLimit.trustProxyHeaders` | `--rate-limit-trust-proxy-headers` | `false` | Trust X-Forwarded-For headers |
+
+### Security: CORS and Headers
+
+| Option | CLI Flag | Default | Description |
+|--------|----------|---------|-------------|
+| `cors.enabled` | `--cors-enabled` | `false` | Enable CORS |
+| `cors.allowedOrigins` | (config only) | | Array of allowed origins or `"*"` |
+| `cors.allowedHeaders` | (config only) | | Array of allowed headers |
+| `cors.allowCredentials` | (config only) | | Allow credentials |
+| `securityHeadersEnabled` | `--no-security-headers-enabled` | `true` | Add security headers to responses |
+
+---
+
+## Endpoints
+
+### Health Check
+
+```
+GET /health
+```
+
+Always returns 200 with `{"ok": true}`.
+
+**Example:**
+
+```bash
+curl http://127.0.0.1:3000/health
+```
+
+**Response:**
+
+```json
+{"ok": true}
+```
+
+### Readiness Check
+
+```
+GET /ready
+```
+
+Returns 200 when ready, 503 when not ready.
+
+**Example:**
+
+```bash
+curl http://127.0.0.1:3000/ready
+```
+
+**Response (ready):**
+
+```json
+{"ok": true}
+```
+
+**Response (not ready):**
+
+```json
+{"ok": false}
+```
+
+### LLM Run (Non-Streaming)
+
+```
+POST /run
+Content-Type: application/json
+```
+
+Execute a non-streaming LLM call.
+
+**Request Body:** `LLMCallSpec` (see [Spec Reference](#llmcallspec))
+
+**Example:**
+
+```bash
+curl http://127.0.0.1:3000/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role":"user","content":[{"type":"text","text":"Hello"}]}],
+    "llmPriority": [{"provider":"anthropic","model":"claude-sonnet-4-20250514"}],
+    "settings": {}
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "type": "response",
+  "data": {
+    "content": [{"type": "text", "text": "Hello! How can I help you today?"}],
+    "stopReason": "end_turn",
+    "usage": {
+      "inputTokens": 10,
+      "outputTokens": 15
+    },
+    "model": "claude-sonnet-4-20250514",
+    "provider": "anthropic"
+  }
+}
+```
+
+### LLM Stream (Streaming)
+
+```
+POST /stream
+Content-Type: application/json
+```
+
+Execute a streaming LLM call. Returns Server-Sent Events.
+
+**Request Body:** `LLMCallSpec` (see [Spec Reference](#llmcallspec))
+
+**Example:**
+
+```bash
+curl http://127.0.0.1:3000/stream \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role":"user","content":[{"type":"text","text":"Write a haiku"}]}],
+    "llmPriority": [{"provider":"anthropic","model":"claude-sonnet-4-20250514"}],
+    "settings": {}
+  }'
+```
+
+**Response (SSE):**
+
+```
+data: {"type":"message_start","message":{"id":"msg_...","model":"claude-sonnet-4-20250514"}}
+
+data: {"type":"delta","text":"Silent"}
+
+data: {"type":"delta","text":" morning"}
+
+data: {"type":"delta","text":" dew"}
+
+data: {"type":"message_stop","stopReason":"end_turn","usage":{"inputTokens":10,"outputTokens":20}}
+```
+
+### Vector Run (Non-Streaming)
+
+```
+POST /vector/run
+Content-Type: application/json
+```
+
+Execute a non-streaming vector operation.
+
+**Request Body:** `VectorCallSpec` (see [Spec Reference](#vectorcallspec))
+
+**Example - Query:**
+
+```bash
+curl http://127.0.0.1:3000/vector/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "query",
+    "store": "qdrant-local",
+    "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+    "input": {"query": "machine learning", "topK": 5}
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "type": "response",
+  "data": {
+    "operation": "query",
+    "results": [
+      {"id": "doc1", "score": 0.95, "payload": {"text": "Machine learning is..."}},
+      {"id": "doc2", "score": 0.87, "payload": {"text": "Deep learning..."}}
+    ]
+  }
+}
+```
+
+**Example - Upsert:**
+
+```bash
+curl http://127.0.0.1:3000/vector/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "upsert",
+    "store": "qdrant-local",
+    "input": {
+      "points": [
+        {"id": "doc1", "vector": [0.1, 0.2, 0.3], "payload": {"text": "Hello"}}
+      ]
+    }
+  }'
+```
+
+**Example - Delete:**
+
+```bash
+curl http://127.0.0.1:3000/vector/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "delete",
+    "store": "qdrant-local",
+    "input": {"ids": ["doc1", "doc2"]}
+  }'
+```
+
+**Example - Collections:**
+
+```bash
+curl http://127.0.0.1:3000/vector/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "collections",
+    "store": "qdrant-local",
+    "input": {"collectionOp": "list"}
+  }'
+```
+
+### Vector Stream (Streaming)
+
+```
+POST /vector/stream
+Content-Type: application/json
+```
+
+Execute a streaming vector operation. Useful for batch operations.
+
+**Request Body:** `VectorCallSpec`
+
+**Response (SSE):**
+
+```
+data: {"type":"progress","processed":10,"total":100}
+
+data: {"type":"progress","processed":20,"total":100}
+
+data: {"type":"result","operation":"embed","vectors":[...]}
+```
+
+### Embeddings Run
+
+```
+POST /embeddings/run
+Content-Type: application/json
+```
+
+Execute an embedding operation.
+
+**Request Body:** `EmbeddingCallSpec` (see [Spec Reference](#embeddingcallspec))
+
+**Example:**
+
+```bash
+curl http://127.0.0.1:3000/embeddings/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "embed",
+    "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+    "input": {"texts": ["Hello world", "Machine learning"]}
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "type": "response",
+  "data": {
+    "operation": "embed",
+    "vectors": [[0.1, 0.2, ...], [0.3, 0.4, ...]],
+    "dimensions": 1536,
+    "model": "openai/text-embedding-3-small"
+  }
+}
+```
+
+---
+
+## Spec Reference
+
+### LLMCallSpec
+
+```typescript
+{
+  // System prompt (optional)
+  "systemPrompt": "You are a helpful assistant.",
+
+  // Messages (required)
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Hello"}
+      ]
+    }
+  ],
+
+  // Provider priority list (required)
+  "llmPriority": [
+    {
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-20250514",
+      "settings": {}  // Optional per-provider override
+    }
+  ],
+
+  // Settings (required, can be empty)
+  "settings": {
+    "temperature": 0.7,
+    "topP": 1.0,
+    "maxTokens": 4096,
+    "stop": ["END"],
+    "reasoning": {
+      "enabled": true,
+      "effort": "medium",
+      "budget": 10000
+    }
+  },
+
+  // Tools (optional)
+  "functionToolNames": ["test.echo"],
+  "tools": [...],
+  "mcpServers": ["testmcp"],
+  "toolChoice": "auto",
+
+  // Vector/RAG (optional)
+  "vectorContext": {
+    "stores": ["qdrant-local"],
+    "mode": "auto",
+    "topK": 5,
+    "embeddingPriority": [{"provider": "openrouter-embeddings"}]
+  },
+
+  // Metadata (optional)
+  "metadata": {
+    "correlationId": "request-123"
+  }
+}
+```
+
+### VectorCallSpec
+
+```typescript
+{
+  // Operation (required)
+  "operation": "embed" | "upsert" | "query" | "delete" | "collections",
+
+  // Store ID (required)
+  "store": "qdrant-local",
+
+  // Collection (optional)
+  "collection": "my-docs",
+
+  // Embedding priority (required for embed/query with text)
+  "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+
+  // Operation-specific input (required)
+  "input": {...},
+
+  // Settings (optional)
+  "settings": {
+    "batchSize": 10
+  },
+
+  // Metadata (optional)
+  "metadata": {
+    "correlationId": "request-123"
+  }
+}
+```
+
+### EmbeddingCallSpec
+
+```typescript
+{
+  // Operation (required)
+  "operation": "embed",
+
+  // Embedding priority (required)
+  "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+
+  // Input (required)
+  "input": {
+    "text": "Single text"
+  }
+  // OR
+  "input": {
+    "texts": ["Multiple", "texts"]
+  },
+
+  // Metadata (optional)
+  "metadata": {
+    "correlationId": "request-123"
+  }
+}
+```
+
+---
+
+## Security Configuration
+
+### Authentication
+
+Enable authentication to require API keys:
+
+```bash
+# Via CLI
+llm-adapter serve --auth-enabled --port 3000
+```
+
+```typescript
+// Programmatically
+const server = await createServer({
+  port: 3000,
+  auth: {
+    enabled: true,
+    allowBearer: true,
+    allowApiKeyHeader: true,
+    apiKeys: ['key1', 'key2']
+  }
+});
+```
+
+**Making authenticated requests:**
+
+```bash
+# Bearer token
+curl http://127.0.0.1:3000/run \
+  -H "Authorization: Bearer key1" \
+  -H "Content-Type: application/json" \
+  -d '...'
+
+# x-api-key header
+curl http://127.0.0.1:3000/run \
+  -H "x-api-key: key1" \
+  -H "Content-Type: application/json" \
+  -d '...'
+```
+
+**Using hashed keys:**
+
+Store SHA-256 hashes instead of plaintext keys:
+
+```typescript
+const server = await createServer({
+  port: 3000,
+  auth: {
+    enabled: true,
+    hashedKeys: [
+      '5e884898da28047d9...', // SHA-256 of actual key
+    ]
+  }
+});
+```
+
+### Rate Limiting
+
+Limit requests per client:
+
+```bash
+# Via CLI
+llm-adapter serve --rate-limit-enabled \
+  --rate-limit-requests-per-minute 60 \
+  --rate-limit-burst 10 \
+  --port 3000
+```
+
+```typescript
+// Programmatically
+const server = await createServer({
+  port: 3000,
+  rateLimit: {
+    enabled: true,
+    requestsPerMinute: 60,
+    burst: 10,
+    trustProxyHeaders: false
+  }
+});
+```
+
+When rate limited, the server returns:
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 60
+
+{"error": "Rate limit exceeded"}
+```
+
+### CORS
+
+Enable Cross-Origin Resource Sharing:
+
+```bash
+# Via CLI
+llm-adapter serve --cors-enabled --port 3000
+```
+
+```typescript
+// Programmatically
+const server = await createServer({
+  port: 3000,
+  cors: {
+    enabled: true,
+    allowedOrigins: ['https://example.com', 'https://app.example.com'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+    allowCredentials: true
+  }
+});
+
+// Or allow all origins
+const server = await createServer({
+  port: 3000,
+  cors: {
+    enabled: true,
+    allowedOrigins: '*'
+  }
+});
+```
+
+### Security Headers
+
+By default, the server adds security headers to all responses:
+
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `X-XSS-Protection: 1; mode=block`
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains`
+
+Disable with:
+
+```bash
+llm-adapter serve --no-security-headers-enabled --port 3000
+```
+
+---
+
+## Configuration via defaults.json
+
+Server defaults can be configured in `plugins/configs/defaults.json`:
+
+```json
+{
+  "server": {
+    "maxRequestBytes": 26214400,
+    "bodyReadTimeoutMs": 10000,
+    "requestTimeoutMs": 0,
+    "streamIdleTimeoutMs": 60000,
+    "maxConcurrentRequests": 128,
+    "maxConcurrentStreams": 32,
+    "maxQueueSize": 1000,
+    "queueTimeoutMs": 30000,
+    "auth": {
+      "enabled": false,
+      "allowBearer": true,
+      "allowApiKeyHeader": true
+    },
+    "rateLimit": {
+      "enabled": false,
+      "requestsPerMinute": 60,
+      "burst": 10
+    },
+    "cors": {
+      "enabled": false
+    },
+    "securityHeadersEnabled": true
+  }
+}
+```
+
+**Important:** API keys and sensitive data should be set via environment variables or programmatic configuration, not in defaults.json.
+
+---
+
+## Error Responses
+
+### 400 Bad Request
+
+Invalid request body or spec:
+
+```json
+{"error": "Invalid JSON", "details": "..."}
+```
+
+### 401 Unauthorized
+
+Authentication required but not provided:
+
+```json
+{"error": "Unauthorized"}
+```
+
+### 403 Forbidden
+
+Invalid API key:
+
+```json
+{"error": "Forbidden"}
+```
+
+### 429 Too Many Requests
+
+Rate limit exceeded:
+
+```json
+{"error": "Rate limit exceeded"}
+```
+
+Headers:
+```
+Retry-After: 60
+```
+
+### 500 Internal Server Error
+
+Server error:
+
+```json
+{"error": "Internal server error", "details": "..."}
+```
+
+### 503 Service Unavailable
+
+Server not ready or overloaded:
+
+```json
+{"error": "Service unavailable"}
+```
+
+---
+
+## Streaming Error Handling
+
+For streaming endpoints (`/stream`, `/vector/stream`), errors are sent as SSE events:
+
+```
+data: {"type":"error","error":"Provider error","details":"..."}
+```
+
+The connection then closes.
+
+---
+
+## Request Examples
+
+### Complete LLM Request
+
+```bash
+curl http://127.0.0.1:3000/run \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-api-key" \
+  -d '{
+    "systemPrompt": "You are a helpful coding assistant.",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {"type": "text", "text": "Write a function to calculate fibonacci numbers"}
+        ]
+      }
+    ],
+    "llmPriority": [
+      {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-20250514",
+        "settings": {"temperature": 0.3}
+      },
+      {
+        "provider": "openai",
+        "model": "gpt-4"
+      }
+    ],
+    "settings": {
+      "temperature": 0.7,
+      "maxTokens": 2048
+    },
+    "metadata": {
+      "correlationId": "req-12345"
+    }
+  }'
+```
+
+### Streaming with Tools
+
+```bash
+curl http://127.0.0.1:3000/stream \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      {"role": "user", "content": [{"type": "text", "text": "Echo hello world"}]}
+    ],
+    "llmPriority": [{"provider": "anthropic", "model": "claude-sonnet-4-20250514"}],
+    "settings": {},
+    "functionToolNames": ["test.echo"]
+  }'
+```
+
+### RAG Query
+
+```bash
+curl http://127.0.0.1:3000/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      {"role": "user", "content": [{"type": "text", "text": "What is machine learning?"}]}
+    ],
+    "llmPriority": [{"provider": "anthropic", "model": "claude-sonnet-4-20250514"}],
+    "settings": {},
+    "vectorContext": {
+      "stores": ["qdrant-local"],
+      "mode": "auto",
+      "topK": 5,
+      "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+      "injectAs": "system",
+      "injectTemplate": "Use this context:\n{{results}}"
+    }
+  }'
+```
+
+### Batch Embedding
+
+```bash
+curl http://127.0.0.1:3000/embeddings/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "embed",
+    "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+    "input": {
+      "texts": [
+        "First document text",
+        "Second document text",
+        "Third document text"
+      ]
+    }
+  }'
+```
+
+### Vector Upsert with Embeddings
+
+```bash
+curl http://127.0.0.1:3000/vector/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "embed",
+    "store": "qdrant-local",
+    "collection": "my-docs",
+    "embeddingPriority": [{"provider": "openrouter-embeddings"}],
+    "input": {
+      "texts": ["Document 1", "Document 2"],
+      "ids": ["doc1", "doc2"],
+      "payloads": [{"title": "First"}, {"title": "Second"}],
+      "upsert": true
+    }
+  }'
+```
+
+---
+
+## Client Libraries
+
+### Node.js/TypeScript
+
+```typescript
+// Non-streaming
+const response = await fetch('http://127.0.0.1:3000/run', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+    llmPriority: [{ provider: 'anthropic', model: 'claude-sonnet-4-20250514' }],
+    settings: {}
+  })
+});
+
+const result = await response.json();
+console.log(result.data.content[0].text);
+```
+
+```typescript
+// Streaming
+const response = await fetch('http://127.0.0.1:3000/stream', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+    llmPriority: [{ provider: 'anthropic', model: 'claude-sonnet-4-20250514' }],
+    settings: {}
+  })
+});
+
+const reader = response.body.getReader();
+const decoder = new TextDecoder();
+
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+
+  const chunk = decoder.decode(value);
+  const lines = chunk.split('\n');
+
+  for (const line of lines) {
+    if (line.startsWith('data: ')) {
+      const event = JSON.parse(line.slice(6));
+      if (event.type === 'delta') {
+        process.stdout.write(event.text);
+      }
+    }
+  }
+}
+```
+
+### Python
+
+```python
+import requests
+
+# Non-streaming
+response = requests.post('http://127.0.0.1:3000/run', json={
+    'messages': [{'role': 'user', 'content': [{'type': 'text', 'text': 'Hello'}]}],
+    'llmPriority': [{'provider': 'anthropic', 'model': 'claude-sonnet-4-20250514'}],
+    'settings': {}
+})
+
+result = response.json()
+print(result['data']['content'][0]['text'])
+```
+
+```python
+import requests
+import json
+
+# Streaming
+response = requests.post('http://127.0.0.1:3000/stream', json={
+    'messages': [{'role': 'user', 'content': [{'type': 'text', 'text': 'Hello'}]}],
+    'llmPriority': [{'provider': 'anthropic', 'model': 'claude-sonnet-4-20250514'}],
+    'settings': {}
+}, stream=True)
+
+for line in response.iter_lines():
+    if line:
+        line = line.decode('utf-8')
+        if line.startswith('data: '):
+            event = json.loads(line[6:])
+            if event.get('type') == 'delta':
+                print(event.get('text', ''), end='')
+```
+
+---
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `LLM_ADAPTER_BATCH_ID` | Default batch ID for logging |
+| `LLM_ADAPTER_BATCH_DIR` | Use batch-based directories ("1" or "0") |
+| `LLM_ADAPTER_DISABLE_FILE_LOGS` | Disable file logging ("1") |
+| `LLM_ADAPTER_DISABLE_CONSOLE_LOGS` | Disable console logging ("1") |
+| `ANTHROPIC_API_KEY` | Anthropic provider API key |
+| `OPENAI_API_KEY` | OpenAI provider API key |
+| `GOOGLE_API_KEY` | Google provider API key |
+| `OPENROUTER_API_KEY` | OpenRouter provider API key |
+| `EMBEDDING_API_KEY` | Embedding provider API key |
+| `VECTOR_STORE_API_KEY` | Vector store API key |
+
+---
+
+## Performance Tuning
+
+### High Throughput
+
+For high-throughput scenarios:
+
+```bash
+llm-adapter serve \
+  --port 3000 \
+  --max-concurrent-requests 256 \
+  --max-concurrent-streams 64 \
+  --max-queue-size 2000 \
+  --queue-timeout-ms 60000
+```
+
+### Memory Constrained
+
+For memory-constrained environments:
+
+```bash
+llm-adapter serve \
+  --port 3000 \
+  --max-concurrent-requests 32 \
+  --max-concurrent-streams 8 \
+  --max-queue-size 100 \
+  --max-request-bytes 5242880
+```
+
+### Long-Running Requests
+
+For requests that may take a long time:
+
+```bash
+llm-adapter serve \
+  --port 3000 \
+  --request-timeout-ms 300000 \
+  --stream-idle-timeout-ms 120000
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Provider-agnostic LLM adapter with a unified interface across multiple providers
 
 ## Features
 
-- **Plugin-Based Providers**: Add/remove providers via `plugins/**` manifests + compats
+- **Plugin-Based Providers**: Add/remove providers via `plugins/` manifests + compats
 - **Per-Provider Settings**: Configure different settings (temperature, maxTokens, etc.) for each provider in your priority list
 - **Document Processing**: Universal file support with automatic format detection and conversion
 - **Tool Calling**: Unified tool calling interface across providers
@@ -13,1126 +13,321 @@ Provider-agnostic LLM adapter with a unified interface across multiple providers
 - **Streaming**: Real-time streaming responses with tool support
 - **100% Test Coverage**: Comprehensive test suite with full coverage
 
-## Server Mode
-
-The adapter can run as a thin HTTP/SSE server, exposing the same spec‑driven behavior as the CLI.
-All LLM logic remains in the coordinator; the server is transport‑only.
-
-### Start via CLI
+## Quick Start
 
 ```bash
-llm-adapter serve [options]
+# CLI usage
+llm-adapter run --spec '{"messages":[...],"llmPriority":[...],"settings":{}}'
+
+# Server usage
+llm-adapter serve --port 3000
 ```
 
-Common options:
-- `--host <host>` (default `127.0.0.1`)
-- `--port <port>` (default `0` for ephemeral)
-- `--plugins <path>` (default `./plugins`)
-- `--batch-id <id>` (optional)
+See [README-CLI.md](README-CLI.md) for complete CLI documentation and [README-SERVER.md](README-SERVER.md) for server documentation.
 
-Operational knobs (all optional; override `server.*` defaults):
-- `--max-request-bytes <n>`
-- `--body-read-timeout-ms <n>`
-- `--request-timeout-ms <n>`
-- `--stream-idle-timeout-ms <n>`
-- `--max-concurrent-requests <n>`
-- `--max-concurrent-streams <n>`
-- `--max-queue-size <n>`
-- `--queue-timeout-ms <n>`
-- `--max-concurrent-vector-requests <n>`
-- `--max-concurrent-vector-streams <n>`
-- `--vector-max-queue-size <n>`
-- `--vector-queue-timeout-ms <n>`
-- `--max-concurrent-embedding-requests <n>`
-- `--embedding-max-queue-size <n>`
-- `--embedding-queue-timeout-ms <n>`
-- `--auth-enabled`, `--no-auth-allow-bearer`, `--no-auth-allow-api-key-header`, `--auth-header-name <name>`, `--auth-realm <realm>`
-- `--rate-limit-enabled`, `--rate-limit-requests-per-minute <n>`, `--rate-limit-burst <n>`, `--rate-limit-trust-proxy-headers`
-- `--cors-enabled`
-- `--no-security-headers-enabled`
+## Architecture
 
-**Secrets and allowlists are config/env only.** Do not pass API keys or CORS origin lists via CLI; set them under `server.auth.*` and `server.cors.*` in `plugins/configs/defaults.json` or via `${ENV}` substitution.
-
-### Start programmatically
-
-```ts
-import { createServer } from 'llm-adapter/server';
-
-const server = await createServer({ port: 3000 });
-console.log(server.url);
-
-// later
-await server.close();
+```
+universal_llm_adapter/
+├── bin/
+│   └── cli.ts                    # CLI entry point (thin shell, lazy-loads modules)
+├── modules/                      # Provider-agnostic core logic
+│   ├── kernel/                   # Core primitives: types, defaults, registry, config
+│   ├── cli/                      # Unified CLI program and handlers
+│   ├── llm/                      # LLM coordinator and manager
+│   ├── server/                   # HTTP/SSE server
+│   ├── vector/                   # Vector store coordinator and manager
+│   ├── embeddings/               # Embedding coordinator and manager
+│   ├── tools/                    # Tool discovery and execution loop
+│   ├── mcp/                      # MCP client and server management
+│   ├── messages/                 # Message preparation and mutation
+│   ├── context/                  # Conversation pruning and token estimation
+│   ├── documents/                # Document loading and preprocessing
+│   ├── logging/                  # Logger factories (LLM, Embedding, Vector)
+│   ├── security/                 # Security utilities, header redaction
+│   ├── settings/                 # Settings splitting and merging
+│   ├── retry/                    # Retry policies and sequencing
+│   ├── usage/                    # Usage/cost metadata normalization
+│   ├── lifecycle/                # Coordinator lifecycle wrappers
+│   └── string/                   # String utilities
+├── plugins/                      # Provider-specific implementations
+│   ├── providers/                # LLM provider configs (.json)
+│   ├── embeddings/               # Embedding provider configs (.json)
+│   ├── vector/                   # Vector store configs (.json)
+│   ├── compat/                   # LLM provider compat implementations
+│   ├── embedding-compat/         # Embedding provider compat implementations
+│   ├── vector-compat/            # Vector store compat implementations
+│   ├── tools/                    # Tool definitions (.json)
+│   ├── processes/                # Process routing configs (.json)
+│   ├── mcp/                      # MCP server configs (.json)
+│   ├── mcp-servers/              # MCP server implementations (.mjs)
+│   ├── modules/                  # Plugin modules for tools
+│   └── configs/
+│       └── defaults.json         # Centralized defaults
+├── tests/
+│   ├── live/                     # Live integration tests
+│   └── sandbox/                  # Ad-hoc CLI runner
+└── package.json
 ```
 
-This is only for embedding server startup in a Node process; consumers still call the HTTP endpoints.
+### Key Principles
 
-### Endpoints
+1. **Plugin-First Design**: All provider-specific logic lives in `plugins/`. Core modules remain provider-agnostic.
 
-- `GET /health`
-  - Response: `{ "ok": true }`.
-- `GET /ready`
-  - Response: `{ "ok": true }` when ready, `{ "ok": false }` with `503` when not ready.
-- `POST /run`
-  - Body: `LLMCallSpec` JSON.
-  - Response: `{ "type": "response", "data": <LLMResponse> }`.
-- `POST /stream`
-  - Body: `LLMCallSpec` JSON.
-  - Response: SSE `text/event-stream` where each event is a raw `LLMStreamEvent` framed as `data: <json>\n\n`.
-- `POST /vector/run`
-  - Body: `VectorCallSpec` JSON.
-  - Response: `{ "type": "response", "data": <VectorOperationResult> }`.
-- `POST /vector/stream`
-  - Body: `VectorCallSpec` JSON.
-  - Response: SSE `text/event-stream` where each event is a raw `VectorStreamEvent` framed as `data: <json>\n\n`.
-- `POST /embeddings/run`
-  - Body: `EmbeddingCallSpec` JSON.
-  - Response: `{ "type": "response", "data": <EmbeddingOperationResult> }`.
+2. **Lazy Loading**: CLI/server only load modules when needed (e.g., `--help` loads only commander, not providers).
 
-Minimal curl example:
+3. **Strict Module Boundaries**: Each module has clear exports via `index.ts`. Internals are private.
 
-```bash
-curl -sS http://127.0.0.1:3000/run \\
-  -H "content-type: application/json" \\
-  -d '{
-    "messages": [{"role":"user","content":[{"type":"text","text":"Hello"}]}],
-    "llmPriority": [{"provider":"<provider-id>","model":"<model-id>"}],
-    "settings": {}
-  }'
-```
+4. **Index-Only Imports**: Production code imports from `module/index.ts`, never from `internal/`.
 
-## Per-Provider Settings
+## Plugin System
 
-### Overview
+### LLM Providers
 
-When specifying multiple providers in `llmPriority`, you can configure different settings for each provider. This is useful when:
-- Different providers perform better with different temperature values
-- You want to use extended thinking (reasoning) only with providers that support it
-- You need different token limits for different models
+Provider configurations live in `plugins/providers/*.json`:
 
-### Usage
-
-#### Global Settings Only (Default)
-
-Settings apply to all providers in the priority list:
-
-```typescript
-const response = await coordinator.run({
-  messages: [...],
-  llmPriority: [
-    { provider: '<provider-a>', model: '<model-a>' },
-    { provider: '<provider-b>', model: '<model-b>' }
-  ],
-  settings: {
-    temperature: 0.7,
-    maxTokens: 1000
-  }
-});
-// Both providers use temperature: 0.7, maxTokens: 1000
-```
-
-#### Per-Provider Settings
-
-Add a `settings` field to individual priority items:
-
-```typescript
-const response = await coordinator.run({
-  messages: [...],
-  llmPriority: [
-    {
-      provider: '<provider-a>',
-      model: '<model-a>',
-      settings: { temperature: 0.3 }  // Override for first provider
-    },
-    {
-      provider: '<provider-b>',
-      model: '<model-b>'
-      // No override - uses global settings
+```json
+{
+  "id": "anthropic",
+  "compat": "anthropic",
+  "endpoint": {
+    "urlTemplate": "https://api.anthropic.com/v1/messages",
+    "method": "POST",
+    "headers": {
+      "x-api-key": "${ANTHROPIC_API_KEY}",
+      "anthropic-version": "2023-06-01"
     }
-  ],
-  settings: {
-    temperature: 0.7,
-    maxTokens: 1000
-  }
-});
-// Provider A gets: { temperature: 0.3, maxTokens: 1000 }
-// Provider B gets: { temperature: 0.7, maxTokens: 1000 }
-```
-
-### Merge Behavior
-
-Per-provider settings use **deep merge** with global settings:
-
-- **Primitives**: Per-provider value overrides global
-- **Nested objects**: Deep merged (e.g., `reasoning` object)
-- **Arrays**: Replaced entirely (e.g., `stop` sequences)
-- **Undefined values**: Ignored (falls back to global)
-
-#### Deep Merge Example
-
-```typescript
-{
-  llmPriority: [
-    {
-      provider: '<provider-a>',
-      model: '<model-a>',
-      settings: {
-        reasoning: { budget: 2000 }  // Override only budget
-      }
-    }
-  ],
-  settings: {
-    temperature: 0.7,
-    reasoning: { enabled: true, budget: 1000 }
-  }
-}
-// Provider A gets: {
-//   temperature: 0.7,
-//   reasoning: { enabled: true, budget: 2000 }  // enabled preserved, budget overridden
-// }
-```
-
-### Tool Loop Propagation
-
-Per-provider settings automatically propagate to tool loop follow-up calls. If a provider makes multiple LLM calls during tool execution, all calls use the same merged settings.
-
-## File Support
-
-### Overview
-
-The LLM coordinator supports sending files (PDFs, CSVs, text files, images, etc.) to any compatible provider. Files are automatically preprocessed and converted to the appropriate format for each provider.
-
-### Supported File Types
-
-- **Documents**: PDF, CSV, TXT, JSON, HTML, Markdown
-- **Microsoft Office**: DOCX, XLSX
-- **Images**: JPEG, PNG, GIF, WebP (as ImageContent, not DocumentContent)
-- **Custom**: Any file type with MIME type specification
-
-### Usage
-
-#### Filepath Sources (Recommended)
-
-Provide a file path and the coordinator will automatically load, encode, and detect the MIME type:
-
-```typescript
-	import { LLMCoordinator } from 'llm-adapter/llm';
-	import { Role } from 'llm-adapter';
-
-const coordinator = new LLMCoordinator();
-
-const response = await coordinator.run({
-  messages: [
-    {
-      role: Role.USER,
-      content: [
-        { type: 'text', text: 'Analyze this document' },
-        {
-          type: 'document',
-          source: { type: 'filepath', path: '/path/to/document.pdf' }
-          // mimeType and filename are auto-detected
-        }
-      ]
-    }
-  ],
-  llmPriority: [
-    { provider: '<provider-id>', model: '<model-id>' }
-  ]
-});
-```
-
-#### Base64 Sources
-
-For pre-encoded data:
-
-```typescript
-{
-  type: 'document',
-  source: { type: 'base64', data: 'dGVzdCBkYXRh...' },
-  mimeType: 'application/pdf',  // Required for base64
-  filename: 'report.pdf'         // Optional
-}
-```
-
-#### URL Sources
-
-For publicly accessible files:
-
-```typescript
-{
-  type: 'document',
-  source: { type: 'url', url: 'https://example.com/doc.pdf' },
-  mimeType: 'application/pdf',  // Required
-  filename: 'doc.pdf'            // Optional
-}
-```
-
-**Note**: Source-type support varies by provider plugin. If you use `url` or `file_id`, ensure the active provider plugin supports that source type.
-
-#### File ID Sources
-
-For provider-uploaded files:
-
-```typescript
-{
-  type: 'document',
-  source: { type: 'file_id', fileId: 'file-abc123' },
-  mimeType: 'application/pdf',  // Required
-  filename: 'doc.pdf'            // Optional
-}
-```
-
-### Plugin-Specific Options
-
-Some provider plugins accept additional document options. Pass them through via `providerOptions`; the structure is defined by the provider plugin.
-
-```typescript
-{
-  type: 'document',
-  source: { type: 'filepath', path: '/path/to/document.pdf' },
-  providerOptions: {
-    '<provider-id>': {
-      '<optionName>': '<optionValue>'
-    }
+  },
+  "retryWords": ["rate", "limit", "overloaded"],
+  "defaults": {
+    "maxTokens": 8192,
+    "reasoningBudget": 51200
   }
 }
 ```
 
-See the relevant docs under `plugins/**` for supported options.
-
-### Implementation Details
-
-#### Automatic Preprocessing
-
-The coordinator automatically:
-1. Loads files from filesystem paths
-2. Detects MIME types from file extensions
-3. Encodes binary data to base64
-4. Extracts filenames from paths
-5. Converts to provider-specific formats
-
-#### Compat Transformations
-
-After preprocessing, the active provider compat/plugin converts `DocumentContent` into the request format required by the provider API.
-
-#### MIME Type Detection
-
-Built-in support for common file types:
-
-| Extension | MIME Type |
-|-----------|-----------|
-| .pdf | application/pdf |
-| .csv | text/csv |
-| .txt | text/plain |
-| .json | application/json |
-| .html, .htm | text/html |
-| .md, .markdown | text/markdown |
-| .docx | application/vnd.openxmlformats-officedocument.wordprocessingml.document |
-| .xlsx | application/vnd.openxmlformats-officedocument.spreadsheetml.sheet |
-| .jpg, .jpeg | image/jpeg |
-| .png | image/png |
-| .gif | image/gif |
-| .webp | image/webp |
-
-Unknown extensions default to `application/octet-stream`.
-
-### Architecture
-
-```
-User Input (filepath)
-       ↓
-coordinator.prepareMessages()
-       ↓
-processDocumentContent()
-  - Load file
-  - Detect MIME
-  - Encode base64
-       ↓
-Provider Compat Module
-  - Transform to provider format
-       ↓
-LLM API
-```
-
-**Key Files**:
-- `modules/kernel/index.ts` - DocumentContent type definitions
-- `modules/documents/index.ts` - File loading and preprocessing
-- `modules/documents/index.ts` - MIME type detection
-- `modules/llm/index.ts` - Message preprocessing integration
-- `plugins/compat/<compat-id>/index.ts` - Provider-specific transformations
-- `bin/cli.ts` - Unified CLI entry point (llm-adapter command)
-- `modules/vector/index.ts` - VectorStoreCoordinator class
-- `modules/kernel/index.ts` - VectorCallSpec and related types
-- `modules/vector/index.ts` - Text chunking utility
-- `modules/vector/index.ts` - RAG context injection
-
-## Vector Stores & Embeddings
-
-### Overview
-
-The coordinator provides unified vector store and embedding support for RAG (Retrieval Augmented Generation) applications. Like LLM providers, vector stores and embedding providers use a plugin architecture with priority-based fallback.
-
-**Key Principle**: Provider-specific code lives ONLY in `plugins/`. Main codebase stays agnostic.
-
-### Two Ways to Use Vector Stores
-
-1. **Unified CLI** (`llm-adapter vector ...`): Batch operations for managing vector data (embed, upsert, query, delete, collections)
-2. **VectorContextConfig** in `LLMCallSpec`: RAG context injection during LLM calls (auto-inject, tool mode, or both)
-
-### Architecture
-
-```
-User Query → EmbeddingManager (agnostic) → embedding-compat (provider-specific) → provider API
-                    ↓
-              Vector (numbers)
-                    ↓
-         VectorStoreManager (agnostic) → vector-compat (provider-specific) → store backend
-```
+Provider compat implementations live in `plugins/compat/<provider>/index.ts` and implement `ICompatModule`:
+- `buildPayload()` - Transform unified spec to provider format
+- `parseResponse()` - Transform provider response to unified format
+- `parseStream()` - Parse streaming chunks
+- `validate()` - Validate configuration
 
 ### Embedding Providers
 
-#### Configuration
-
-Create JSON configs in `plugins/embeddings/`:
+Embedding configurations live in `plugins/embeddings/*.json`:
 
 ```json
-// plugins/embeddings/<embedding-provider-id>.json
 {
-  "id": "<embedding-provider-id>",
-  "kind": "<embedding-compat-id>",
+  "id": "openrouter-embeddings",
+  "kind": "openrouter",
   "endpoint": {
-    "urlTemplate": "<url-template>",
+    "urlTemplate": "https://openrouter.ai/api/v1/embeddings",
     "headers": {
-      "Authorization": "Bearer ${EMBEDDING_API_KEY}",
-      "Content-Type": "application/json"
+      "Authorization": "Bearer ${OPENROUTER_API_KEY}"
     }
   },
-  "model": "<embedding-model-id>",
+  "model": "openai/text-embedding-3-small",
   "dimensions": 1536
 }
 ```
 
-#### Usage
-
-```typescript
-import { EmbeddingManager } from 'llm-adapter/embeddings';
-import { PluginRegistry } from 'llm-adapter';
-
-const registry = new PluginRegistry('./plugins');
-const embeddingManager = new EmbeddingManager(registry);
-
-// Embed text with priority fallback
-const result = await embeddingManager.embed('Hello world', [
-  { provider: '<embedding-provider-id>' },
-  { provider: '<embedding-provider-id-2>' }  // Falls back if first fails
-]);
-
-console.log(result.vectors);    // [[0.1, 0.2, ...]]
-console.log(result.dimensions); // 1536
-console.log(result.model);      // '<embedding-model-id>'
-
-// Get dimensions for a provider
-const dims = await embeddingManager.getDimensions('<embedding-provider-id>');
-
-// Create embedder function for VectorStoreManager
-const embedFn = embeddingManager.createEmbedderFn([
-  { provider: '<embedding-provider-id>' }
-]);
-```
+Embedding compat implementations live in `plugins/embedding-compat/<kind>/index.ts`.
 
 ### Vector Stores
 
-#### Supported Stores
-
-Supported vector stores depend on the installed `plugins/vector-compat/**` implementations.
-
-#### Configuration
-
-Create JSON configs in `plugins/vector/`:
+Vector store configurations live in `plugins/vector/*.json`:
 
 ```json
-// plugins/vector/<vector-store-id-local>.json
 {
-  "id": "<vector-store-id-local>",
-  "kind": "<vector-compat-id>",
+  "id": "qdrant-local",
+  "kind": "qdrant",
   "connection": {
     "host": "localhost",
-    "port": 1234
+    "port": 6333
   },
+  "defaultEmbeddingPriority": [{ "provider": "openrouter-embeddings" }],
   "defaultCollection": "documents"
 }
+```
 
-// plugins/vector/<vector-store-id-remote>.json
+Vector compat implementations live in `plugins/vector-compat/<kind>/index.ts`.
+
+### Tools
+
+Tool definitions live in `plugins/tools/*.json`:
+
+```json
 {
-  "id": "<vector-store-id-remote>",
-  "kind": "<vector-compat-id>",
-  "connection": {
-    "url": "<url>",
-    "apiKey": "${VECTOR_STORE_API_KEY}"
-  },
-  "defaultCollection": "documents"
-}
-```
-
-#### Usage
-
-```typescript
-import { VectorStoreManager } from 'llm-adapter/vector';
-import { EmbeddingManager } from 'llm-adapter/embeddings';
-import { PluginRegistry } from 'llm-adapter';
-
-const registry = new PluginRegistry('./plugins');
-const embeddingManager = new EmbeddingManager(registry);
-const vectorStore = new VectorStoreManager(
-  new Map(),  // configs
-  new Map(),  // adapters
-  embeddingManager.createEmbedderFn([{ provider: '<embedding-provider-id>' }]),
-  registry
-);
-
-// Query with priority fallback
-const { store, results } = await vectorStore.queryWithPriority(
-  ['<vector-store-id-local>', '<vector-store-id-remote>'],  // Priority list
-  'What is machine learning?',        // Query text (auto-embedded)
-  5,                                   // Top K
-  { category: 'tech' }                 // Optional filter
-);
-
-// Upsert points
-await vectorStore.upsert('<vector-store-id-local>', [
-  { id: 'doc1', vector: [0.1, 0.2, ...], payload: { text: 'Hello' } },
-  { id: 'doc2', vector: [0.3, 0.4, ...], payload: { text: 'World' } }
-]);
-
-// Delete points
-await vectorStore.deleteByIds('<vector-store-id-local>', ['doc1', 'doc2']);
-
-// Access underlying compat for advanced operations
-const compat = await vectorStore.getCompat('<vector-store-id-local>');
-if (compat) {
-  const exists = await compat.collectionExists('documents');
-  if (!exists) {
-    await compat.createCollection('documents', 1536, { distance: 'Cosine' });
-  }
-}
-
-// Close all connections
-await vectorStore.closeAll();
-```
-
-### Unified CLI
-
-The unified CLI (`llm-adapter`) provides a single command-line interface for all LLM, vector, and embedding operations.
-
-#### LLM Commands
-
-```bash
-# Non-streaming LLM call
-llm-adapter run --spec '{...}'
-
-# Streaming LLM call
-llm-adapter stream --spec '{...}'
-```
-
-#### Vector Commands
-
-| Command | Description |
-|---------|-------------|
-| `vector run` | Execute any vector operation from a `VectorCallSpec` |
-| `vector stream` | Stream `VectorStreamEvent` for an operation (batch embed yields progress) |
-| `vector embed` | Embed texts and optionally upsert to a vector store |
-| `vector upsert` | Upsert pre-computed vectors to a store |
-| `vector query` | Query a vector store |
-| `vector delete` | Delete vectors by ID |
-| `vector collections` | Manage collections (list, create, delete, exists) |
-
-```bash
-# Run any vector operation (preferred for CLI/server parity)
-llm-adapter vector run --spec '{...}'
-
-# Stream any operation (preferred for CLI/server parity)
-llm-adapter vector stream --spec '{...}'
-
-# Embed texts and upsert
-llm-adapter vector embed --spec '{
-  "operation": "embed",
-  "store": "<vector-store-id>",
-  "embeddingPriority": [{ "provider": "<embedding-provider-id>" }],
-  "input": { "texts": ["Hello world", "Machine learning is..."] }
-}'
-
-# Embed with custom batch size (default: 10)
-# The batchSize setting controls how many texts are embedded per API call.
-# This applies to both streaming and non-streaming embed operations.
-llm-adapter vector embed --spec '{
-  "operation": "embed",
-  "store": "<vector-store-id>",
-  "embeddingPriority": [{ "provider": "<embedding-provider-id>" }],
-  "input": { "texts": ["Text 1", "Text 2", "Text 3", "Text 4", "Text 5"] },
-  "settings": { "batchSize": 2 }
-}'
-
-# Query with a text query (auto-embedded)
-llm-adapter vector query --spec '{
-  "operation": "query",
-  "store": "<vector-store-id>",
-  "embeddingPriority": [{ "provider": "<embedding-provider-id>" }],
-  "input": { "query": "What is ML?", "topK": 5 }
-}'
-
-# Query with pre-computed vector
-llm-adapter vector query --spec '{
-  "operation": "query",
-  "store": "<vector-store-id>",
-  "input": { "vector": [0.1, 0.2, ...], "topK": 5 }
-}'
-
-# Delete vectors
-llm-adapter vector delete --spec '{
-  "operation": "delete",
-  "store": "<vector-store-id>",
-  "input": { "ids": ["doc1", "doc2"] }
-}'
-
-# List collections
-llm-adapter vector collections --spec '{
-  "operation": "collections",
-  "store": "<vector-store-id>",
-  "input": { "collectionOp": "list" }
-}'
-
-# Stream progress for batch operations
-llm-adapter vector embed --stream --spec '{...}'
-```
-
-#### Embedding Commands
-
-```bash
-# Execute an embedding operation
-llm-adapter embeddings run --spec '{
-  "operation": "embed",
-  "embeddingPriority": [{ "provider": "<embedding-provider-id>" }],
-  "input": { "texts": ["Hello world"] }
-}'
-```
-
-#### Server Command
-
-```bash
-# Start the HTTP/SSE server
-llm-adapter serve --port 3000
-```
-
-#### CLI Options
-
-- `--spec <json>`: Spec as JSON string
-- `--file <path>`: Path to spec JSON file
-- `--plugins <path>`: Path to plugins directory (default: `./plugins`)
-- `--pretty`: Pretty print output
-- `--stream`: Stream progress events (for `embed` command)
-- `--batch-id <id>`: Optional batch identifier for grouped logging
-
-### VectorContextConfig (RAG Integration)
-
-The `VectorContextConfig` field in `LLMCallSpec` enables automatic RAG (Retrieval Augmented Generation) during LLM calls.
-
-#### Modes
-
-| Mode | Behavior |
-|------|----------|
-| `auto` | Query vectors with user message, inject results before LLM call |
-| `tool` | Create a `vector_search` tool the LLM can call on-demand |
-| `both` | Auto-inject initial context + provide tool for follow-up queries |
-
-#### Auto-Inject Mode
-
-Context is automatically retrieved and injected into messages before the LLM call:
-
-```typescript
-const response = await coordinator.run({
-  messages: [
-    { role: 'user', content: [{ type: 'text', text: 'What is machine learning?' }] }
-  ],
-  llmPriority: [{ provider: '<provider-id>', model: '<model-id>' }],
-  vectorContext: {
-    stores: ['<vector-store-id>'],
-    mode: 'auto',
-    topK: 5,
-    scoreThreshold: 0.7,
-    embeddingPriority: [{ provider: '<embedding-provider-id>' }],
-    injectAs: 'system',  // or 'user_context'
-    injectTemplate: 'Relevant context:\n\n{{results}}'
-  }
-});
-```
-
-#### Tool Mode
-
-Creates a tool the LLM can call to search when needed:
-
-```typescript
-const response = await coordinator.run({
-  messages: [...],
-  llmPriority: [...],
-  vectorContext: {
-    stores: ['<vector-store-id>'],
-    mode: 'tool',
-    toolName: 'search_knowledge_base',  // default: 'vector_search'
-    toolDescription: 'Search the knowledge base for relevant information',
-    embeddingPriority: [{ provider: '<embedding-provider-id>' }],
-    // Optional: allow the LLM to pass a metadata filter when not locked
-    // The tool schema will include `filter` when `locks.filter` is not set
-    locks: {
-      // filter: { doc_type: 'faq' } // uncomment to lock a filter
-    }
-  }
-});
-```
-
-When `locks.filter` is **not** set, the generated tool schema includes an optional `filter` (JSON object) so the LLM can constrain results (e.g., `{ "category": "tech", "year": 2024 }`). Filter precedence is:
-
-1. `locks.filter` (highest, always enforced)
-2. LLM-provided `filter` argument
-3. `vectorContext.filter` fallback
-
-Only `query` is required; `topK`, `store`, and `filter` are exposed only when their respective locks are unset.
-
-#### Both Mode (Hybrid)
-
-Auto-injects initial context AND provides a tool for follow-up queries:
-
-```typescript
-const response = await coordinator.run({
-  messages: [...],
-  llmPriority: [...],
-  vectorContext: {
-    stores: ['<vector-store-id>'],
-    mode: 'both',
-    topK: 3,
-    injectAs: 'system',
-    injectTemplate: 'Initial context:\n{{results}}\n\nYou can search for more using the search tool.',
-    toolName: 'search_more',
-    toolDescription: 'Search for additional information'
-  }
-});
-```
-
-#### VectorContextConfig Options
-
-```typescript
-interface VectorContextConfig {
-  stores: string[];                       // Which stores to query
-  mode: 'tool' | 'auto' | 'both';         // How to use results
-
-  // Query config
-  topK?: number;                          // Default: 5
-  scoreThreshold?: number;                // Minimum score (0-1)
-  filter?: JsonObject;                    // Metadata filter
-  collection?: string;                    // Collection to query
-  embeddingPriority?: EmbeddingPriorityItem[];
-
-  // Query construction (auto/both modes)
-  overrideEmbeddingQuery?: string;        // Use this exact query instead of extracting from messages
-  queryConstruction?: QueryConstructionSettings;  // Control how query is built from messages
-
-  // Auto-inject config
-  injectAs?: 'system' | 'user_context';   // Default: 'system'
-  injectTemplate?: string;                // Default: "Relevant context:\n{{results}}"
-  resultFormat?: string;                  // Default: "- {{payload.text}} (score: {{score}})"
-
-  // Tool mode config
-  toolName?: string;                      // Default: 'vector_search'
-  toolDescription?: string;
-
-  // Parameter locking (tool mode only)
-  locks?: VectorSearchLocks;              // Lock parameters from LLM override
-}
-
-interface QueryConstructionSettings {
-  includeSystemPrompt?: 'always' | 'never' | 'if-in-range';  // Default: 'if-in-range'
-  includeAssistantMessages?: boolean;     // Default: true
-  messagesToInclude?: number;             // Default: 1 (0 = all messages)
-}
-
-interface VectorSearchLocks {
-  store?: string;                         // Lock which store to use
-  topK?: number;                          // Lock result count
-  filter?: JsonObject;                    // Lock metadata filter
-  scoreThreshold?: number;                // Lock minimum score
-  collection?: string;                    // Lock collection name
-}
-```
-
-#### Query Construction (Auto/Both Modes)
-
-In `auto` and `both` modes, the adapter extracts a query from the conversation to embed and search the vector store. By default, it uses only the most recent user message. The `queryConstruction` settings give you control over this behavior.
-
-**Query Construction Settings**
-
-| Setting | Values | Default | Description |
-|---------|--------|---------|-------------|
-| `messagesToInclude` | number | `1` | How many recent messages to include. `0` = all messages |
-| `includeAssistantMessages` | boolean | `true` | Whether assistant responses are included in query extraction |
-| `includeSystemPrompt` | `'always'` \| `'never'` \| `'if-in-range'` | `'if-in-range'` | When to include system prompt in query |
-
-**System Prompt Inclusion Logic**
-
-- `'never'`: System prompt is never included in the query
-- `'always'`: System prompt is always included
-- `'if-in-range'`: Include if total messages (including system) ≤ `messagesToInclude`, or if `messagesToInclude` is 0 (all)
-
-**Examples**
-
-```typescript
-// Default behavior: Last user message only
-const response = await coordinator.run({
-  systemPrompt: 'You are a coding assistant.',
-  messages: [
-    { role: 'user', content: [{ type: 'text', text: 'How do promises work?' }] },
-    { role: 'assistant', content: [{ type: 'text', text: 'Promises are...' }] },
-    { role: 'user', content: [{ type: 'text', text: 'Can you show an example?' }] }
-  ],
-  vectorContext: {
-    stores: ['docs'],
-    mode: 'auto'
-    // Query will be: "Can you show an example?"
-  }
-});
-
-// Include conversation context
-const response = await coordinator.run({
-  messages: [...],
-  vectorContext: {
-    stores: ['docs'],
-    mode: 'auto',
-    queryConstruction: {
-      messagesToInclude: 3,              // Last 3 messages
-      includeAssistantMessages: true,    // Include assistant responses
-      includeSystemPrompt: 'never'       // Don't include system prompt
-    }
-    // Query will combine last 3 messages for richer context
-  }
-});
-
-// Override query extraction entirely
-const response = await coordinator.run({
-  messages: [...],
-  vectorContext: {
-    stores: ['docs'],
-    mode: 'auto',
-    overrideEmbeddingQuery: 'JavaScript async/await patterns'
-    // Ignores all messages, uses this exact query
-  }
-});
-```
-
-#### Parameter Locking (Tool Mode)
-
-When using `tool` or `both` mode, the LLM can typically control parameters like `topK` and `store` through the tool schema. The `locks` feature allows you to enforce server-side parameter values that the LLM cannot override.
-
-**Why Lock Parameters?**
-
-- **Security**: Prevent LLM from accessing unauthorized stores or collections
-- **Cost Control**: Limit result count to avoid excessive token usage
-- **Quality**: Enforce minimum score thresholds for relevant results
-- **Data Isolation**: Lock to specific collections per user/tenant
-
-**How Locking Works**
-
-1. Locked parameters are **hidden from the tool schema** - the LLM doesn't know they exist
-2. Values are **enforced server-side** regardless of what the LLM attempts to pass
-3. Non-locked parameters remain available for LLM control
-
-```typescript
-// Without locks - LLM can set all parameters
-const response = await coordinator.run({
-  messages: [...],
-  vectorContext: {
-    stores: ['docs', 'faq', 'internal'],
-    mode: 'tool',
-    topK: 10
-  }
-});
-// Tool schema exposes: query, topK, store
-// LLM could request topK: 100, store: 'internal'
-
-// With locks - enforce restrictions
-const response = await coordinator.run({
-  messages: [...],
-  vectorContext: {
-    stores: ['docs', 'faq', 'internal'],
-    mode: 'tool',
-    topK: 10,
-    locks: {
-      store: 'docs',        // Only 'docs' store, hidden from LLM
-      topK: 5,              // Max 5 results, hidden from LLM
-      scoreThreshold: 0.7   // Minimum relevance, enforced server-side
-    }
-  }
-});
-// Tool schema exposes: query (only)
-// LLM can only provide the search query
-// store='docs', topK=5, scoreThreshold=0.7 are enforced
-```
-
-**Example: Multi-Tenant Data Isolation**
-
-```typescript
-// Lock collection per tenant to prevent cross-tenant access
-const response = await coordinator.run({
-  messages: [...],
-  vectorContext: {
-    stores: ['<vector-store-id>'],
-    mode: 'tool',
-    locks: {
-      collection: `tenant-${tenantId}`,  // Tenant-specific collection
-      filter: { tenantId: tenantId }     // Additional filter as backup
-    }
-  }
-});
-```
-
-**Example: Cost Control**
-
-```typescript
-// Limit results to control token usage
-const response = await coordinator.run({
-  messages: [...],
-  vectorContext: {
-    stores: ['knowledge-base'],
-    mode: 'tool',
-    topK: 20,           // Default for non-locked use
-    locks: {
-      topK: 3,          // But lock to max 3 for this call
-      scoreThreshold: 0.8  // Only highly relevant results
-    }
-  }
-});
-```
-
-#### Tool Schema Overrides (Tool Mode)
-
-When using `tool` or `both` mode, you can customize how parameters are exposed to the LLM using `toolSchemaOverrides`. This allows you to:
-
-- **Rename parameters** for domain-specific or user-friendly labels
-- **Override descriptions** to provide clearer guidance
-- **Expose normally-hidden parameters** like `collection` and `scoreThreshold`
-- **Hide normally-exposed parameters** without locking them
-
-```typescript
-interface ToolSchemaParamOverride {
-  name?: string;        // Exposed name (LLM sees this)
-  description?: string; // Custom description
-  expose?: boolean;     // Whether to show in schema
-}
-
-interface ToolSchemaOverrides {
-  toolDescription?: string;  // Override tool description
-  params?: {
-    query?: ToolSchemaParamOverride;
-    topK?: ToolSchemaParamOverride;
-    store?: ToolSchemaParamOverride;
-    filter?: ToolSchemaParamOverride;
-    collection?: ToolSchemaParamOverride;     // Hidden by default
-    scoreThreshold?: ToolSchemaParamOverride; // Hidden by default
-  };
-}
-```
-
-**Example: Domain-Specific Parameter Names**
-
-```typescript
-const response = await coordinator.run({
-  messages: [...],
-  vectorContext: {
-    stores: ['product-docs'],
-    mode: 'tool',
-    toolSchemaOverrides: {
-      toolDescription: 'Search our product documentation',
-      params: {
-        query: {
-          name: 'search_query',
-          description: 'Your search terms'
-        },
-        topK: {
-          name: 'max_results',
-          description: 'Maximum number of results (1-20)'
-        },
-        store: { expose: false },  // Hide store selection
-        collection: {
-          expose: true,
-          name: 'category',
-          description: 'Product category to search'
-        }
-      }
-    }
-  }
-});
-// Tool schema shows: search_query (required), max_results, category
-// LLM calls with: { search_query: "...", max_results: 5, category: "widgets" }
-// Adapter translates to: { query: "...", topK: 5, collection: "widgets" }
-```
-
-**Key Behaviors:**
-
-1. **Alias Translation**: The adapter automatically translates aliased parameter names back to canonical names when invoking the tool
-2. **Lock Precedence**: Locked parameters remain hidden even if `expose: true` is set in overrides
-3. **Required Fields**: The `query` parameter (or its alias) is always required
-4. **Default Exposure**: `query`, `topK`, `store`, `filter` are exposed by default; `collection` and `scoreThreshold` are hidden
-5. **Duplicate Detection**: Throws an error if two parameters would have the same exposed name
-
-**Combining with Locks:**
-
-You can use both locks and schema overrides together. Locks take precedence for visibility:
-
-```typescript
-const response = await coordinator.run({
-  messages: [...],
-  vectorContext: {
-    stores: ['docs'],
-    mode: 'tool',
-    locks: {
-      store: 'docs'  // Hidden from schema and enforced
+  "name": "test.echo",
+  "description": "Echo back a message exactly as provided",
+  "parametersJsonSchema": {
+    "type": "object",
+    "properties": {
+      "message": { "type": "string", "description": "The message to echo" }
     },
-    toolSchemaOverrides: {
-      params: {
-        topK: { name: 'limit' },      // Renamed but not locked
-        store: { expose: true }        // Ignored - lock takes precedence
-      }
+    "required": ["message"]
+  }
+}
+```
+
+Process routing (how tools are invoked) lives in `plugins/processes/*.json`:
+
+```json
+{
+  "id": "test-echo",
+  "match": { "type": "exact", "pattern": "test.echo" },
+  "invoke": {
+    "kind": "module",
+    "module": "./dist/plugins/modules/test-echo/index.js",
+    "function": "handle"
+  },
+  "timeoutMs": 5000
+}
+```
+
+### MCP Servers
+
+MCP server configurations live in `plugins/mcp/*.json`:
+
+```json
+{
+  "mcpServers": {
+    "testmcp": {
+      "command": "node",
+      "args": ["./plugins/mcp-servers/test-server.mjs"],
+      "description": "Test MCP server",
+      "autoStart": false
     }
   }
-});
-// Tool schema shows: query (required), limit
-// store is hidden because it's locked, not because of expose setting
+}
 ```
 
-#### VectorContext vs VectorPriority
+## Core Types
 
-These serve different purposes and can coexist:
+### LLMCallSpec
 
-- **`vectorPriority`**: Semantic tool selection - retrieves *tools* from vector stores based on relevance
-- **`vectorContext`**: RAG context injection - retrieves *context* for the LLM to use
+The unified specification for LLM calls:
 
 ```typescript
-{
-  // vectorPriority for tool selection
-  vectorPriority: ['tool-store'],
+interface LLMCallSpec {
+  systemPrompt?: string;
+  messages: Message[];
+  llmPriority: LLMPriorityItem[];
+  settings: LLMCallSettings;
 
-  // vectorContext for RAG
-  vectorContext: {
-    stores: ['doc-store'],
-    mode: 'auto',
-    topK: 5
-  }
+  // Tools
+  functionToolNames?: string[];
+  tools?: UnifiedTool[];
+  mcpServers?: string[];
+  toolChoice?: ToolChoice;
+
+  // Vector/RAG
+  vectorContext?: VectorContextConfig;
+  vectorPriority?: string[];
+
+  // Retry
+  rateLimitRetryDelays?: number[];
+
+  // Metadata
+  metadata?: JsonObject;
 }
 ```
 
-### Adding New Providers
-
-#### Embedding Compat
-
-Create `plugins/embedding-compat/<kind>/index.ts`:
+### Message Structure
 
 ```typescript
-	import { IEmbeddingCompat, EmbeddingProviderConfig, EmbeddingResult } from '../../../modules/kernel/index.js';
+interface Message {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: ContentPart[];
+  toolCalls?: ToolCall[];
+  toolCallId?: string;
+  name?: string;
+  reasoning?: ReasoningData;
+}
 
-export default class YourProviderEmbeddingCompat implements IEmbeddingCompat {
-  async embed(
-    input: string | string[],
-    config: EmbeddingProviderConfig,
-    modelOverride?: string
-  ): Promise<EmbeddingResult> {
-    // Provider-specific API call
-    return { vectors: [...], model: '...', dimensions: ... };
-  }
+type ContentPart = TextContent | ImageContent | DocumentContent | ToolResultContent;
 
-  getDimensions(config: EmbeddingProviderConfig, model?: string): number {
-    return config.dimensions || 0;
-  }
-
-  async validate(config: EmbeddingProviderConfig): Promise<boolean> {
-    // Test API connectivity
-  }
+interface DocumentContent {
+  type: 'document';
+  source:
+    | { type: 'filepath'; path: string }
+    | { type: 'base64'; data: string }
+    | { type: 'url'; url: string }
+    | { type: 'file_id'; fileId: string };
+  mimeType?: string;
+  filename?: string;
+  providerOptions?: Record<string, any>;
 }
 ```
 
-#### Vector Store Compat
-
-Create `plugins/vector-compat/<kind>/index.ts`:
+### LLMCallSettings
 
 ```typescript
-	import { IVectorStoreCompat, VectorStoreConfig, VectorPoint, VectorQueryResult } from '../../../modules/kernel/index.js';
+interface LLMCallSettings {
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+  stop?: string[];
+  responseFormat?: string;
+  seed?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
 
-export default class YourProviderCompat implements IVectorStoreCompat {
-  async connect(config: VectorStoreConfig): Promise<void> { /* ... */ }
-  async close(): Promise<void> { /* ... */ }
-  async query(collection: string, vector: number[], topK: number, options?: VectorQueryOptions): Promise<VectorQueryResult[]> { /* ... */ }
-  async upsert(collection: string, points: VectorPoint[]): Promise<void> { /* ... */ }
-  async deleteByIds(collection: string, ids: string[]): Promise<void> { /* ... */ }
-  async collectionExists(collection: string): Promise<boolean> { /* ... */ }
-  async createCollection(collection: string, dimensions: number, options?: JsonObject): Promise<void> { /* ... */ }
+  // Extended thinking/reasoning
+  reasoning?: {
+    enabled?: boolean;
+    effort?: 'high' | 'medium' | 'low' | 'minimal' | 'none' | 'xhigh';
+    budget?: number;
+    exclude?: boolean;
+  };
+  reasoningBudget?: number;
+
+  // Tool configuration
+  toolCountdownEnabled?: boolean;
+  toolFinalPromptEnabled?: boolean;
+  maxToolIterations?: number;
+  preserveToolResults?: number | 'all' | 'none';
+  preserveReasoning?: number | 'all' | 'none';
+  parallelToolExecution?: boolean;
+  toolResultMaxChars?: number;
+
+  // Provider-specific
+  provider?: Record<string, any>;
 }
 ```
 
-### Types
+### VectorCallSpec
 
 ```typescript
-interface EmbeddingProviderConfig {
-  id: string;
-  kind: string;  // '<embedding-compat-id>'
-  endpoint: { urlTemplate: string; headers: Record<string, string> };
-  model: string;
-  dimensions?: number;
-}
-
-interface VectorStoreConfig {
-  id: string;
-  kind: string;  // '<vector-compat-id>'
-  connection: JsonObject;
-  defaultCollection?: string;
-}
-
-interface VectorPoint {
-  id: string;
-  vector: number[];
-  payload?: JsonObject;
-}
-
-interface VectorQueryResult {
-  id: string;
-  score: number;
-  payload?: JsonObject;
-  vector?: number[];
-}
-
-interface EmbeddingResult {
-  vectors: number[][];
-  model: string;
-  dimensions: number;
-  tokenCount?: number;
+interface VectorCallSpec {
+  operation: 'embed' | 'upsert' | 'query' | 'delete' | 'collections';
+  store: string;
+  collection?: string;
+  embeddingPriority?: EmbeddingPriorityItem[];
+  input?: VectorOperationInput;
+  settings?: VectorOperationSettings;
+  metadata?: JsonObject;
 }
 ```
 
-## Usage Accounting
-
-Some provider plugins return extended usage metrics (token counts, cache hits, cost, audio tokens, etc.). When available, these appear in `response.usage`.
+### EmbeddingCallSpec
 
 ```typescript
-const response = await coordinator.run({
-  messages: [...],
-  llmPriority: [{ provider: '<provider-id>', model: '<model-id>' }]
-});
-
-console.log(response.usage);
+interface EmbeddingCallSpec {
+  operation: string;
+  provider?: string;
+  model?: string;
+  embeddingPriority?: EmbeddingPriorityItem[];
+  input?: { text?: string; texts?: string[] };
+  metadata?: JsonObject;
+}
 ```
-
-If supported by the provider plugin, you can pass through provider-specific request fields via the call spec (e.g., `extra`) or plugin defaults; see the relevant docs under `plugins/**`.
 
 ## Configuration
 
 ### Centralized Defaults
 
-All non-provider-specific defaults are centralized in `/plugins/configs/defaults.json`. This provides a single source of truth for configuration values and makes the codebase easier to maintain.
+All non-provider-specific defaults are in `plugins/configs/defaults.json`:
 
 ```json
 {
@@ -1153,11 +348,9 @@ All non-provider-specific defaults are centralized in `/plugins/configs/defaults
   },
   "vector": {
     "topK": 5,
+    "batchSize": 10,
     "injectTemplate": "Relevant context:\n{{results}}",
     "resultFormat": "- {{payload.text}} (score: {{score}})",
-    "batchSize": 10,
-    "includePayload": true,
-    "includeVector": false,
     "defaultCollection": "default"
   },
   "chunking": {
@@ -1175,212 +368,173 @@ All non-provider-specific defaults are centralized in `/plugins/configs/defaults
     "embeddingHttp": 60000,
     "loggerFlush": 2000
   },
-  "paths": {
-    "plugins": "./plugins"
+  "server": {
+    "maxRequestBytes": 26214400,
+    "bodyReadTimeoutMs": 10000,
+    "requestTimeoutMs": 0,
+    "streamIdleTimeoutMs": 60000,
+    "maxConcurrentRequests": 128,
+    "maxConcurrentStreams": 32,
+    "maxQueueSize": 1000,
+    "queueTimeoutMs": 30000
   }
 }
 ```
 
-#### Accessing Defaults in Code
+### Accessing Defaults in Code
 
 ```typescript
 import { getDefaults } from 'llm-adapter';
 
 const defaults = getDefaults();
-console.log(defaults.retry.maxAttempts);  // 3
+console.log(defaults.retry.maxAttempts);   // 3
 console.log(defaults.tools.maxIterations); // 10
 ```
 
-#### Provider-Specific Defaults
+### Environment Variables
 
-Provider-specific defaults live in their respective JSON manifests under the `defaults` field:
+| Variable | Purpose |
+|----------|---------|
+| `LLM_ADAPTER_BATCH_ID` | Batch identifier for logs |
+| `LLM_ADAPTER_BATCH_DIR` | Use batch-based directories for logs ("1" or "0") |
+| `LLM_ADAPTER_DISABLE_FILE_LOGS` | Disable file logging ("1" or unset) |
+| `LLM_ADAPTER_DISABLE_CONSOLE_LOGS` | Disable console logging ("1" or unset) |
 
-```json
-// plugins/providers/<provider-id>.json
-{
-  "id": "<provider-id>",
-  "defaults": {
-    "maxTokens": 8192,
-    "reasoningBudget": 51200
-  }
-}
-```
+Provider-specific environment variables are defined in provider manifests with `${ENV_VAR}` syntax:
+- `${ANTHROPIC_API_KEY}`
+- `${OPENAI_API_KEY}`
+- `${GOOGLE_API_KEY}`
+- `${OPENROUTER_API_KEY}`
+- `${EMBEDDING_API_KEY}`
+- `${VECTOR_STORE_API_KEY}`
 
-#### Runtime Overrides
+## Programmatic Usage
 
-All defaults can be overridden at runtime via the call spec:
+### LLM Coordinator
 
 ```typescript
-await coordinator.run({
-  messages: [...],
-  settings: {
-    maxTokens: 4096  // Overrides provider default
-  },
-  maxToolIterations: 5  // Overrides tools.maxIterations
+import { LLMCoordinator } from 'llm-adapter/llm';
+import { PluginRegistry } from 'llm-adapter';
+
+const registry = new PluginRegistry('./plugins');
+const coordinator = new LLMCoordinator(registry);
+
+const response = await coordinator.run({
+  messages: [
+    { role: 'user', content: [{ type: 'text', text: 'Hello' }] }
+  ],
+  llmPriority: [
+    { provider: 'anthropic', model: 'claude-sonnet-4-20250514' }
+  ],
+  settings: { temperature: 0.7 }
 });
+```
+
+### Embedding Manager
+
+```typescript
+import { EmbeddingManager } from 'llm-adapter/embeddings';
+import { PluginRegistry } from 'llm-adapter';
+
+const registry = new PluginRegistry('./plugins');
+const embeddingManager = new EmbeddingManager(registry);
+
+const result = await embeddingManager.embed('Hello world', [
+  { provider: 'openrouter-embeddings' }
+]);
+
+console.log(result.vectors);    // [[0.1, 0.2, ...]]
+console.log(result.dimensions); // 1536
+```
+
+### Vector Store Manager
+
+```typescript
+import { VectorStoreManager } from 'llm-adapter/vector';
+import { EmbeddingManager } from 'llm-adapter/embeddings';
+import { PluginRegistry } from 'llm-adapter';
+
+const registry = new PluginRegistry('./plugins');
+const embeddingManager = new EmbeddingManager(registry);
+const vectorStore = new VectorStoreManager(
+  new Map(),
+  new Map(),
+  embeddingManager.createEmbedderFn([{ provider: 'openrouter-embeddings' }]),
+  registry
+);
+
+const { results } = await vectorStore.queryWithPriority(
+  ['qdrant-local'],
+  'What is machine learning?',
+  5
+);
+```
+
+### Server
+
+```typescript
+import { createServer } from 'llm-adapter/server';
+
+const server = await createServer({ port: 3000 });
+console.log(server.url);  // http://127.0.0.1:3000
+
+// later
+await server.close();
+```
+
+## Logging
+
+```typescript
+import { getLLMLogger, getEmbeddingLogger, getVectorLogger, closeLogger } from 'llm-adapter/logging';
+
+// Get loggers
+const llmLogger = getLLMLogger();
+const embeddingLogger = getEmbeddingLogger();
+const vectorLogger = getVectorLogger();
+
+// With correlation ID
+const logger = getLLMLogger().withCorrelation('request-123');
+logger.info('Processing request');
+
+// Close all loggers (call on shutdown)
+await closeLogger();
 ```
 
 ## Testing
 
-The library maintains 100% test coverage. Run tests with:
-
 ```bash
+# Run all tests
 npm test
-```
 
-Document-specific tests:
-```bash
-npm test -- --testPathPattern="document"
-```
-
-Coverage report:
-```bash
+# Run with coverage
 npm test -- --coverage
-```
 
-### Sandbox scenarios (manual)
-
-Ad-hoc CLI runner for scripted or interactive conversations that write transcripts + copied logs under `tests/sandbox/logs/`.
-
-- Scripted scenario: `npm run sandbox:cli -- --scenario tests/sandbox/scenarios/example.yml`
-- Interactive-only (no preset turns): `npm run sandbox:cli -- --scenario tests/sandbox/scenarios/interactive-empty.yml`
-
-## Logging
-
-- Use factory helpers from `llm-adapter/logging`:
-  - `getLLMLogger()` (also available via `getLogger()`) for LLM HTTP + console logs
-  - `getEmbeddingLogger()` for embedding requests/responses
-  - `getVectorLogger()` for vector store operations
-- Each logger lazily creates its own log directory (`logs/llm`, `logs/embedding`, `logs/vector`) the first time you write a log entry, reducing startup I/O for workers that only use one call type.
-- `closeLogger()` now shuts down all logger singletons and waits up to 2s to flush transports; call this when switching batch IDs or shutting down long-running workers.
-- Batch env vars (`LLM_ADAPTER_BATCH_ID`, `LLM_ADAPTER_BATCH_DIR`) continue to apply per logger and are enforced during the first write via retention policies.
-- Retention runs safely even before the first log file is created, so batch pruning can be triggered up front without creating placeholder files.
-
-### CorrelationId
-
-The `correlationId` field allows you to tag log entries with one or more identifiers to track requests across your system. Unlike batch IDs which control log file naming, correlation IDs appear inside individual log entries.
-
-#### Usage
-
-Pass `correlationId` via the `metadata` field in your `LLMCallSpec`:
-
-```typescript
-// Single correlationId
-const response = await coordinator.run({
-  messages: [...],
-  llmPriority: [...],
-  metadata: {
-    correlationId: 'request-123'
-  }
-});
-
-// Multiple correlationIds (e.g., request + user + session)
-const response = await coordinator.run({
-  messages: [...],
-  llmPriority: [...],
-  metadata: {
-    correlationId: ['req-123', 'user-456', 'session-789']
-  }
-});
-```
-
-#### Where CorrelationId Appears
-
-1. **Console/File Logs**: JSON output includes `correlationId` field
-   ```json
-   {"type":"log","timestamp":"...","level":"info","message":"Calling provider","correlationId":["req-123","user-456"]}
-   ```
-
-2. **Detail Logs**: LLM, Embedding, and Vector detail logs include `CorrelationId:` line
-   ```
-	   >>> OUTGOING REQUEST >>>
-	   Timestamp: 2025-12-06T07:30:00.000Z
-	   CorrelationId: req-123, user-456
-	   Provider: <provider-id>
-	   ...
-	   ```
-
-#### Direct Logger Usage
-
-You can also use correlationId directly with loggers:
-
-```typescript
-import { getLLMLogger } from 'llm-adapter/logging';
-
-// Create logger with correlationId
-const logger = getLLMLogger().withCorrelation('request-123');
-
-// Or with multiple IDs
-const logger = getLLMLogger().withCorrelation(['req-123', 'user-456']);
-
-logger.info('Processing request');
-```
-
-### Live Tests
-
-Live tests make real API calls to test actual integrations. They require API keys and external services.
-
-#### Prerequisites
-
-Set required environment variables:
-```bash
-export PROVIDER_API_KEY=your-key
-export EMBEDDING_API_KEY=your-key
-export VECTOR_STORE_URL=<url>
-export VECTOR_STORE_API_KEY=your-key
-```
-
-The exact variables you need depend on the plugin manifests you’re using (via `${ENV}` placeholders in `plugins/**`).
-Backend-specific requirements vary by plugin; see the relevant docs under `plugins/**`.
-
-#### Running Live Tests
-
-```bash
-# Run ALL tests (unit + integration + live) - for CI
-npm run test:all
-
-# Run only live tests
+# Run live tests (require API keys)
 npm run test:live
 
-# Run provider-scoped live tests (see package.json scripts)
-npm run test:live:<provider-id>
-
-# Run embedding live tests only
+# Run provider-specific live tests
+npm run test:live:anthropic
+npm run test:live:openai
 npm run test:live:embeddings
-
-# Run vector store live tests only
 npm run test:live:vector
+
+# Filter live tests by provider
+LLM_TEST_PROVIDERS=anthropic,openai npm run test:live
 ```
 
-#### Provider Filtering
-
-You can run live tests for specific providers using the `LLM_TEST_PROVIDERS` environment variable:
+### Sandbox (Manual Testing)
 
 ```bash
-# Single provider
-LLM_TEST_PROVIDERS=<provider-id> npm run test:live
+# Scripted scenario
+npm run sandbox:cli -- --scenario tests/sandbox/scenarios/example.yml
 
-# Multiple providers (comma-separated)
-LLM_TEST_PROVIDERS=<provider-a>,<provider-b> npm run test:live
-
-# Case-insensitive
-LLM_TEST_PROVIDERS=<PROVIDER-ID> npm run test:live
+# Interactive mode
+npm run sandbox:cli -- --scenario tests/sandbox/scenarios/interactive-empty.yml
 ```
 
-Provider IDs are defined by the live test runner; see `tests/live/README.md` and `package.json` scripts.
+## Documentation
 
-This is useful for:
-- Faster iteration when debugging a specific provider
-- Running tests when you only have API keys for certain providers
-- Reducing API costs during development
-
-#### Available Live Test Suites
-
-| Test File | Description |
-|-----------|-------------|
-| `15-embeddings.live.test.ts` | Embedding integration tests |
-| `16-vector-store.live.test.ts` | Vector store integration tests |
-| `17-vector-cli.live.test.ts` | Vector Store CLI operations |
-| `18-vector-auto-inject.live.test.ts` | VectorContext RAG integration |
-| `19-vector-search-locks.live.test.ts` | Vector search parameter locking |
-| `00-14-*.live.test.ts` | LLM provider integration tests |
+- [README-CLI.md](README-CLI.md) - Complete CLI manual with all commands and options
+- [README-SERVER.md](README-SERVER.md) - Complete server manual with all endpoints and configuration
+- `modules/*/README.md` - Module-specific documentation
+- `plugins/*/README.md` - Plugin-specific documentation


### PR DESCRIPTION
Split documentation into three focused README files:
- README.md: Architecture overview, plugin system, core types, configuration
- README-CLI.md: Complete CLI manual with all commands, options, and specs
- README-SERVER.md: Complete server manual with endpoints, security, and examples

This makes it easier for users to find the documentation relevant to their use case (CLI vs server) while keeping the main README focused on architecture.

@codex to review