### PR TITLE
Issue #318: Add query string credential redaction for URLs

### DIFF
--- a/modules/logging/internal/base-logger.ts
+++ b/modules/logging/internal/base-logger.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import DailyRotateFile from 'winston-daily-rotate-file';
 import TransportStream from 'winston-transport';
 import type { TransformableInfo } from 'logform';
-import { genericRedactHeaders } from '../../security/index.js';
+import { genericRedactHeaders, redactUrl } from '../../security/index.js';
 import { readEnvFloat, readEnvInt } from './retention.js';
 import { applyRetentionOnce } from './retention-manager.js';
 import { getDefaults } from '../../kernel/index.js';
@@ -277,6 +277,10 @@ export class BaseAdapterLogger {
   protected jsonReplacer(_key: string, value: any): any {
     if (value instanceof Buffer || value instanceof Uint8Array) {
       return Buffer.from(value).toString('base64');
+    }
+    // Redact sensitive query parameters in URL-like strings
+    if (typeof value === 'string' && /^(https?|wss?):\/\//.test(value)) {
+      return redactUrl(value);
     }
     return value;
   }

--- a/modules/security/README.md
+++ b/modules/security/README.md
@@ -7,5 +7,36 @@ Small, dependency-free security helpers used across the library.
 - Production code imports only `modules/security/index.ts` (tests may import internals).
 
 ## Exports
-- `genericRedactHeaders(headers)` – masks sensitive values in commonly used headers.
-- `redactUrlCredentials(url)` – redacts basic-auth credentials in URLs (e.g. `https://user:pass@host`).
+
+### Header Redaction
+- `genericRedactHeaders(headers)` – masks sensitive values in commonly used headers (`Authorization`, `x-api-key`). Shows only the last 4 characters (e.g., `Bearer ***7890`).
+
+### URL Redaction
+- `redactUrlCredentials(url)` – redacts basic-auth credentials in URLs (e.g., `https://user:pass@host` → `https://***:***@host`).
+- `redactUrlQueryParams(url, sensitiveParams?)` – redacts sensitive query parameters in URLs. Shows only the last 4 characters of sensitive values (e.g., `?key=AIzaSy1234` → `?key=***1234`). Default sensitive params: `key`, `api_key`, `apikey`, `token`, `secret`, `password`, `auth`, `credential`. Case-insensitive matching. Pass custom `sensitiveParams` array to override defaults.
+- `redactUrl(url)` – combines `redactUrlCredentials` and `redactUrlQueryParams` for full URL redaction.
+
+### Signed WebSocket Tokens
+- `signWsToken(payload, secret, options?)` – creates a signed token for WebSocket authentication.
+- `verifyWsToken(token, secret, options?)` – verifies and decodes a signed WebSocket token.
+
+## Usage Examples
+
+```typescript
+import { redactUrl, redactUrlQueryParams } from '@/modules/security';
+
+// Redact Gemini-style API key in query string
+const geminiUrl = 'wss://generativelanguage.googleapis.com/ws/live?key=AIzaSyABCD1234';
+console.log(redactUrl(geminiUrl));
+// Output: wss://generativelanguage.googleapis.com/ws/live?key=***1234
+
+// Redact multiple sensitive params
+const url = 'https://api.example.com?token=secret123&model=gpt-4';
+console.log(redactUrlQueryParams(url));
+// Output: https://api.example.com/?token=***t123&model=gpt-4
+
+// Custom sensitive params
+const customUrl = 'https://api.example.com?mySecret=abc123&key=keep-this';
+console.log(redactUrlQueryParams(customUrl, ['mySecret']));
+// Output: https://api.example.com/?mySecret=***c123&key=keep-this
+```

--- a/modules/security/internal/redaction.ts
+++ b/modules/security/internal/redaction.ts
@@ -21,3 +21,71 @@ export function genericRedactHeaders(headers: Record<string, any>): Record<strin
 export function redactUrlCredentials(url: string): string {
   return url.replace(/\/\/[^:]+:[^@]+@/, '//***:***@');
 }
+
+/**
+ * Default query parameter names that are considered sensitive and should be redacted.
+ * Matching is case-insensitive.
+ */
+const DEFAULT_SENSITIVE_PARAMS = [
+  'key',
+  'api_key',
+  'apikey',
+  'token',
+  'secret',
+  'password',
+  'auth',
+  'credential'
+];
+
+/**
+ * Redacts sensitive query parameters in a URL string.
+ * Shows only the last 4 characters of sensitive values (e.g., `key=***1234`).
+ *
+ * @param url - The URL string to redact
+ * @param sensitiveParams - Optional list of parameter names to redact (case-insensitive).
+ *                         Defaults to common credential parameter names.
+ * @returns The URL with sensitive query parameters redacted, or the original string if parsing fails.
+ */
+export function redactUrlQueryParams(url: string, sensitiveParams?: string[]): string {
+  const paramsToRedact = sensitiveParams ?? DEFAULT_SENSITIVE_PARAMS;
+  const paramsLower = new Set(paramsToRedact.map(p => p.toLowerCase()));
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // Not a valid URL, return as-is
+    return url;
+  }
+
+  // If no query params, return URL as-is (preserves original format)
+  if (parsed.searchParams.size === 0) {
+    return url;
+  }
+
+  // Redact sensitive params
+  for (const [key] of parsed.searchParams) {
+    if (paramsLower.has(key.toLowerCase())) {
+      const value = parsed.searchParams.get(key) ?? '';
+      if (value.length === 0) {
+        // Empty value stays empty
+        continue;
+      }
+      const redacted = value.length <= 4 ? '***' : `***${value.slice(-4)}`;
+      parsed.searchParams.set(key, redacted);
+    }
+  }
+
+  return parsed.toString();
+}
+
+/**
+ * Redacts both basic-auth credentials and sensitive query parameters in a URL.
+ * Combines `redactUrlCredentials` and `redactUrlQueryParams`.
+ *
+ * @param url - The URL string to redact
+ * @returns The URL with both basic-auth and query parameter credentials redacted.
+ */
+export function redactUrl(url: string): string {
+  return redactUrlQueryParams(redactUrlCredentials(url));
+}

--- a/tests/unit/core/logging.test.ts
+++ b/tests/unit/core/logging.test.ts
@@ -1683,4 +1683,101 @@ describe('core/logging', () => {
       }
     });
   });
+
+  // ============================================================================
+  // URL redaction in jsonReplacer tests (Issue #318)
+  // ============================================================================
+
+  test('debugRaw redacts sensitive query params in URL strings', async () => {
+    const { module, mocks } = await setupLoggingTestHarness({ disableFileLogs: true });
+    const { AdapterLogger } = module;
+
+    const logger = new AdapterLogger();
+
+    mocks.logger.debug.mockClear();
+    logger.debugRaw({ endpoint: 'wss://api.example.com/realtime?key=AIzaSyABCD1234' });
+
+    expect(mocks.logger.debug).toHaveBeenCalledWith('Raw payload', {
+      raw: expect.stringContaining('key=***1234')
+    });
+    expect(mocks.logger.debug).toHaveBeenCalledWith('Raw payload', {
+      raw: expect.not.stringContaining('AIzaSyABCD1234')
+    });
+  });
+
+  test('debugRaw redacts multiple sensitive query params in nested object', async () => {
+    const { module, mocks } = await setupLoggingTestHarness({ disableFileLogs: true });
+    const { AdapterLogger } = module;
+
+    const logger = new AdapterLogger();
+
+    mocks.logger.debug.mockClear();
+    logger.debugRaw({
+      gemini: 'wss://generativelanguage.googleapis.com/ws/live?key=AIzaSySecret123',
+      openai: 'https://api.openai.com/v1/realtime?token=sk-proj-abc123xyz'
+    });
+
+    const call = mocks.logger.debug.mock.calls[0];
+    const rawPayload = call[1].raw;
+
+    expect(rawPayload).toContain('key=***t123');
+    expect(rawPayload).toContain('token=***3xyz');
+    expect(rawPayload).not.toContain('AIzaSySecret123');
+    expect(rawPayload).not.toContain('sk-proj-abc123xyz');
+  });
+
+  test('debugRaw redacts basic-auth and query params together in URLs', async () => {
+    const { module, mocks } = await setupLoggingTestHarness({ disableFileLogs: true });
+    const { AdapterLogger } = module;
+
+    const logger = new AdapterLogger();
+
+    mocks.logger.debug.mockClear();
+    logger.debugRaw({ url: 'https://user:password@api.example.com?api_key=secret1234' });
+
+    const call = mocks.logger.debug.mock.calls[0];
+    const rawPayload = call[1].raw;
+
+    expect(rawPayload).toContain('***:***@');
+    expect(rawPayload).toContain('api_key=***1234');
+    expect(rawPayload).not.toContain('password');
+    expect(rawPayload).not.toContain('secret1234');
+  });
+
+  test('debugRaw preserves non-sensitive URLs unchanged', async () => {
+    const { module, mocks } = await setupLoggingTestHarness({ disableFileLogs: true });
+    const { AdapterLogger } = module;
+
+    const logger = new AdapterLogger();
+
+    mocks.logger.debug.mockClear();
+    logger.debugRaw({ url: 'https://api.example.com/v1/chat?model=gpt-4&version=v1' });
+
+    const call = mocks.logger.debug.mock.calls[0];
+    const rawPayload = call[1].raw;
+
+    expect(rawPayload).toContain('model=gpt-4');
+    expect(rawPayload).toContain('version=v1');
+  });
+
+  test('debugRaw handles WebSocket URLs (ws:// and wss://)', async () => {
+    const { module, mocks } = await setupLoggingTestHarness({ disableFileLogs: true });
+    const { AdapterLogger } = module;
+
+    const logger = new AdapterLogger();
+
+    mocks.logger.debug.mockClear();
+    logger.debugRaw({
+      ws: 'ws://localhost:8080?token=localtoken123',
+      wss: 'wss://secure.example.com?secret=mysecret456'
+    });
+
+    const call = mocks.logger.debug.mock.calls[0];
+    const rawPayload = call[1].raw;
+
+    expect(rawPayload).toContain('token=***n123');
+    expect(rawPayload).toContain('secret=***t456');
+    expect(rawPayload).not.toContain('localtoken123');
+    expect(rawPayload).not.toContain('mysecret456');
+  });
 });

--- a/tests/unit/utils/security/redaction.test.ts
+++ b/tests/unit/utils/security/redaction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { genericRedactHeaders, redactUrlCredentials } from '@/modules/security/index.ts';
+import { genericRedactHeaders, redactUrlCredentials, redactUrlQueryParams, redactUrl } from '@/modules/security/index.ts';
 
 describe('utils/security/redaction', () => {
   test('genericRedactHeaders masks authorization and api keys', () => {
@@ -25,5 +25,172 @@ describe('utils/security/redaction', () => {
 
   test('redactUrlCredentials leaves URLs without credentials unchanged', () => {
     expect(redactUrlCredentials('https://cloud.example.com')).toBe('https://cloud.example.com');
+  });
+
+  describe('redactUrlQueryParams', () => {
+    test('redacts single sensitive query param (key)', () => {
+      expect(redactUrlQueryParams('https://api.example.com?key=AIzaSyABCDEF1234')).toBe(
+        'https://api.example.com/?key=***1234'
+      );
+    });
+
+    test('redacts single sensitive query param (api_key)', () => {
+      expect(redactUrlQueryParams('https://api.example.com?api_key=sk-abcdef7890')).toBe(
+        'https://api.example.com/?api_key=***7890'
+      );
+    });
+
+    test('redacts single sensitive query param (apiKey camelCase)', () => {
+      expect(redactUrlQueryParams('https://api.example.com?apiKey=secret1234')).toBe(
+        'https://api.example.com/?apiKey=***1234'
+      );
+    });
+
+    test('redacts token query param', () => {
+      expect(redactUrlQueryParams('https://api.example.com?token=eyJhbGciOiJIUzI1NiJ9')).toBe(
+        'https://api.example.com/?token=***NiJ9'
+      );
+    });
+
+    test('redacts secret query param', () => {
+      expect(redactUrlQueryParams('https://api.example.com?secret=mysecretvalue')).toBe(
+        'https://api.example.com/?secret=***alue'
+      );
+    });
+
+    test('redacts password query param', () => {
+      expect(redactUrlQueryParams('https://api.example.com?password=hunter2abc')).toBe(
+        'https://api.example.com/?password=***2abc'
+      );
+    });
+
+    test('redacts multiple sensitive params', () => {
+      const result = redactUrlQueryParams('https://api.example.com?key=abc123&token=xyz789&foo=bar');
+      expect(result).toContain('key=***c123');
+      expect(result).toContain('token=***z789');
+      expect(result).toContain('foo=bar');
+    });
+
+    test('preserves non-sensitive params', () => {
+      expect(redactUrlQueryParams('https://api.example.com?model=gpt-4&version=v1')).toBe(
+        'https://api.example.com/?model=gpt-4&version=v1'
+      );
+    });
+
+    test('handles mixed sensitive and non-sensitive params', () => {
+      const result = redactUrlQueryParams('https://api.example.com?model=gpt-4&key=secret123&version=v1');
+      expect(result).toContain('model=gpt-4');
+      expect(result).toContain('key=***t123');
+      expect(result).toContain('version=v1');
+    });
+
+    test('handles WebSocket URLs (wss://)', () => {
+      expect(redactUrlQueryParams('wss://api.example.com/realtime?key=AIzaSy1234')).toBe(
+        'wss://api.example.com/realtime?key=***1234'
+      );
+    });
+
+    test('handles ws:// URLs', () => {
+      expect(redactUrlQueryParams('ws://localhost:8080?token=localtoken')).toBe(
+        'ws://localhost:8080/?token=***oken'
+      );
+    });
+
+    test('handles URL without query params (pass-through)', () => {
+      expect(redactUrlQueryParams('https://api.example.com/path')).toBe('https://api.example.com/path');
+    });
+
+    test('handles empty query string', () => {
+      // With no query params, returns the original URL unchanged
+      expect(redactUrlQueryParams('https://api.example.com?')).toBe('https://api.example.com?');
+    });
+
+    test('handles short values (less than 4 chars) by fully redacting', () => {
+      expect(redactUrlQueryParams('https://api.example.com?key=abc')).toBe(
+        'https://api.example.com/?key=***'
+      );
+    });
+
+    test('handles empty values', () => {
+      expect(redactUrlQueryParams('https://api.example.com?key=')).toBe(
+        'https://api.example.com/?key='
+      );
+    });
+
+    test('handles case-insensitive matching for param names', () => {
+      expect(redactUrlQueryParams('https://api.example.com?KEY=secret1234')).toBe(
+        'https://api.example.com/?KEY=***1234'
+      );
+      expect(redactUrlQueryParams('https://api.example.com?API_KEY=secret1234')).toBe(
+        'https://api.example.com/?API_KEY=***1234'
+      );
+    });
+
+    test('handles custom sensitive params list', () => {
+      expect(redactUrlQueryParams('https://api.example.com?custom=value123&key=noredact', ['custom'])).toBe(
+        'https://api.example.com/?custom=***e123&key=noredact'
+      );
+    });
+
+    test('handles malformed URLs gracefully (returns original)', () => {
+      const malformed = 'not-a-valid-url';
+      expect(redactUrlQueryParams(malformed)).toBe(malformed);
+    });
+
+    test('handles URL with auth and query params', () => {
+      // Note: redactUrlQueryParams only handles query params, not basic-auth
+      expect(redactUrlQueryParams('https://user:pass@api.example.com?key=secret12')).toBe(
+        'https://user:pass@api.example.com/?key=***et12'
+      );
+    });
+
+    test('preserves URL fragments', () => {
+      expect(redactUrlQueryParams('https://api.example.com?key=secret12#section')).toBe(
+        'https://api.example.com/?key=***et12#section'
+      );
+    });
+
+    test('handles credential param', () => {
+      expect(redactUrlQueryParams('https://api.example.com?credential=mycred123')).toBe(
+        'https://api.example.com/?credential=***d123'
+      );
+    });
+
+    test('handles auth param', () => {
+      expect(redactUrlQueryParams('https://api.example.com?auth=authvalue1')).toBe(
+        'https://api.example.com/?auth=***lue1'
+      );
+    });
+  });
+
+  describe('redactUrl', () => {
+    test('redacts both basic-auth and query params', () => {
+      const result = redactUrl('https://user:password@api.example.com?key=secret1234');
+      expect(result).toContain('***:***@');
+      expect(result).toContain('key=***1234');
+    });
+
+    test('redacts only query params when no basic-auth', () => {
+      expect(redactUrl('https://api.example.com?key=secret1234')).toBe(
+        'https://api.example.com/?key=***1234'
+      );
+    });
+
+    test('redacts only basic-auth when no sensitive query params', () => {
+      expect(redactUrl('https://user:password@api.example.com?model=gpt-4')).toBe(
+        'https://***:***@api.example.com/?model=gpt-4'
+      );
+    });
+
+    test('passes through clean URLs unchanged', () => {
+      expect(redactUrl('https://api.example.com/path')).toBe('https://api.example.com/path');
+    });
+
+    test('handles Gemini-style WebSocket URL', () => {
+      const geminiUrl = 'wss://generativelanguage.googleapis.com/ws/google.ai?key=AIzaSyABCD1234';
+      const result = redactUrl(geminiUrl);
+      expect(result).toContain('key=***1234');
+      expect(result).not.toContain('AIzaSyABCD1234');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `redactUrlQueryParams()` function to redact sensitive query parameters in URLs
- Adds `redactUrl()` convenience function combining basic-auth and query param redaction
- Updates `jsonReplacer` in base-logger to automatically redact URL-like strings
- Protects Gemini API keys and other credentials from appearing in logs

## Changes

**`modules/security/internal/redaction.ts`:**
- `redactUrlQueryParams(url, sensitiveParams?)` - redacts sensitive query params, shows last 4 chars
- `redactUrl(url)` - combines basic-auth and query param redaction
- Default sensitive params: `key`, `api_key`, `apikey`, `token`, `secret`, `password`, `auth`, `credential`

**`modules/logging/internal/base-logger.ts`:**
- `jsonReplacer()` now applies URL redaction to `http://`, `https://`, `ws://`, `wss://` strings

**Tests:**
- 26 new tests for query param redaction (edge cases, WebSocket URLs, custom params)
- 5 new tests for logging URL redaction

**Documentation:**
- Updated `modules/security/README.md` with examples

## Test plan

- [x] All 1610 unit tests pass
- [x] All redaction tests pass
- [x] All logging tests pass

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)