### PR TITLE
Issue #319: bound tool call tracking

### DIFF
--- a/modules/kernel/index.ts
+++ b/modules/kernel/index.ts
@@ -12,4 +12,6 @@ export * from './internal/vector-spec-types.js';
 export * from './internal/tool-names.js';
 export * from './internal/safe-data.js';
 export * from './internal/realtime-types.js';
+export * from './internal/realtime-tool-call-tracking.js';
 export * from './internal/async-queue.js';
+export * from './internal/lru-map.js';

--- a/modules/kernel/internal/lru-map.ts
+++ b/modules/kernel/internal/lru-map.ts
@@ -1,0 +1,85 @@
+export interface LruMapOptions<K, V> {
+  /**
+   * Optional label included in eviction warnings.
+   */
+  label?: string;
+
+  /**
+   * When enabled, logs a warn-level message via `console.warn` on eviction.
+   */
+  warnOnEvict?: boolean;
+
+  onEvict?: (options: { key: K; value: V }) => void;
+}
+
+function normalizeMaxEntries(value: number): number {
+  if (!Number.isFinite(value) || value < 1) return 1;
+  return Math.floor(value);
+}
+
+/**
+ * A tiny LRU map implemented by re-inserting on `get()` and evicting the oldest
+ * entry when `maxEntries` is exceeded.
+ *
+ * Notes:
+ * - Uses Map insertion order: "oldest" is the first key in iteration order.
+ * - `get()` refreshes recency (moves the key to the end).
+ */
+export class LruMap<K, V> extends Map<K, V> {
+  private maxEntries: number;
+  private readonly label?: string;
+  private readonly warnOnEvict: boolean;
+  private readonly onEvict?: LruMapOptions<K, V>['onEvict'];
+
+  constructor(maxEntries: number, options: LruMapOptions<K, V> = {}) {
+    super();
+    this.maxEntries = normalizeMaxEntries(maxEntries);
+    this.label = options.label;
+    this.warnOnEvict = options.warnOnEvict ?? false;
+    this.onEvict = options.onEvict;
+  }
+
+  getMaxEntries(): number {
+    return this.maxEntries;
+  }
+
+  setMaxEntries(next: number): void {
+    this.maxEntries = normalizeMaxEntries(next);
+    this.evictIfNeeded();
+  }
+
+  override get(key: K): V | undefined {
+    if (!super.has(key)) return undefined;
+    const value = super.get(key) as V;
+    // Refresh recency.
+    super.delete(key);
+    super.set(key, value);
+    return value;
+  }
+
+  override set(key: K, value: V): this {
+    // Refresh recency on update.
+    if (super.has(key)) {
+      super.delete(key);
+    }
+    super.set(key, value);
+    this.evictIfNeeded();
+    return this;
+  }
+
+  private evictIfNeeded(): void {
+    while (this.size > this.maxEntries) {
+      const oldestKey = this.keys().next().value as K;
+      const oldestValue = super.get(oldestKey) as V;
+      super.delete(oldestKey);
+      this.onEvict?.({ key: oldestKey, value: oldestValue });
+      if (this.warnOnEvict && typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('LRU map eviction', {
+          ...(this.label ? { label: this.label } : {}),
+          key: oldestKey,
+          maxEntries: this.maxEntries
+        });
+      }
+    }
+  }
+}

--- a/modules/kernel/internal/realtime-tool-call-tracking.ts
+++ b/modules/kernel/internal/realtime-tool-call-tracking.ts
@@ -1,0 +1,13 @@
+import type { RealtimeSessionSpec } from './realtime-types.js';
+
+export const DEFAULT_REALTIME_TOOL_CALL_TRACKING_MAX_ENTRIES = 1000;
+
+export function resolveRealtimeToolCallTrackingMaxEntries(
+  spec: Pick<RealtimeSessionSpec, 'toolCallTracking'> | undefined
+): number {
+  const raw = (spec as any)?.toolCallTracking?.maxEntries;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_REALTIME_TOOL_CALL_TRACKING_MAX_ENTRIES;
+  return Math.floor(n);
+}
+

--- a/modules/kernel/internal/realtime-types.ts
+++ b/modules/kernel/internal/realtime-types.ts
@@ -113,6 +113,17 @@ export interface RealtimeHistoryItem {
   text: string;
 }
 
+export interface RealtimeToolCallTrackingConfig {
+  /**
+   * Max entries tracked for mapping provider tool call ids to tool names during a session.
+   *
+   * This is a per-session memory safety guard for long-lived sessions with heavy tool usage.
+   *
+   * Defaults to 1000.
+   */
+  maxEntries?: number;
+}
+
 export interface RealtimeSessionSpec {
   /** Provider id from plugins/realtime-providers/*.json */
   provider: string;
@@ -128,6 +139,7 @@ export interface RealtimeSessionSpec {
   // tools
   functionToolNames?: string[];
   toolChoice?: ToolChoice;
+  toolCallTracking?: RealtimeToolCallTrackingConfig;
 
   // audio + transcription
   audio?: RealtimeSessionAudioConfig;

--- a/modules/realtime/README.md
+++ b/modules/realtime/README.md
@@ -73,6 +73,7 @@ Key fields:
   - Each item is `{ role: 'system' | 'user' | 'assistant', text: string }`.
   - Use `session.injectContext(items)` for mid-session injection (does not auto-trigger a response).
 - `functionToolNames` / `toolChoice`: enable tool calling within the session.
+- `toolCallTracking`: bounds internal tool-call id → name tracking (default `maxEntries: 1000`).
 - `audio`: negotiated session audio input/output formats.
 - `transcription`: enable user transcription (and optionally language hints).
 - `turnDetection`: `manual_commit` vs `server_vad`.

--- a/plugins/realtime-compat/gemini/internal/session.ts
+++ b/plugins/realtime-compat/gemini/internal/session.ts
@@ -7,7 +7,7 @@ import type {
   RealtimeEvent,
   RealtimeSessionSpec
 } from '../../../../modules/kernel/index.js';
-import { AsyncQueue, sanitizeToolName } from '../../../../modules/kernel/index.js';
+import { AsyncQueue, LruMap, resolveRealtimeToolCallTrackingMaxEntries, sanitizeToolName } from '../../../../modules/kernel/index.js';
 import { buildGeminiActivityEndMessage, buildGeminiActivityStartMessage, buildGeminiCommitTextTurnMessage, buildGeminiInterruptMessage, buildGeminiRealtimeAudioMessage, buildGeminiRealtimeTextMessage, buildGeminiSendTextMessage, buildGeminiSetupMessage, buildGeminiToolResponseMessage } from './commands.js';
 import { convertSessionAudioToProviderPcm16_16k } from './audio.js';
 import { mapGeminiLiveServerMessage, type GeminiRealtimeMapperState } from './event-mapper.js';
@@ -76,6 +76,8 @@ export function createGeminiRealtimeCompatSession(options: Parameters<IRealtimeC
   const queue = new AsyncQueue<RealtimeEvent>();
   const sessionId = generateSessionId();
 
+  const toolCallTrackingMaxEntries = resolveRealtimeToolCallTrackingMaxEntries(spec);
+
   const { message: setupMessage, audio } = buildGeminiSetupMessage({
     model,
     spec,
@@ -87,7 +89,10 @@ export function createGeminiRealtimeCompatSession(options: Parameters<IRealtimeC
     unifiedToolNameByProviderName: new Map(
       (options.tools ?? []).map(t => [sanitizeToolName(t.name), t.name] as const)
     ),
-    toolNameByCallId: new Map<string, string>(),
+    toolNameByCallId: new LruMap<string, string>(toolCallTrackingMaxEntries, {
+      label: 'realtime-tool-call-tracking(gemini)',
+      warnOnEvict: true
+    }),
     toolCallSeq: 0,
     sawUsageThisTurn: false,
     userTranscriptRaw: '',

--- a/plugins/realtime-compat/openai/internal/event-mapper.ts
+++ b/plugins/realtime-compat/openai/internal/event-mapper.ts
@@ -98,6 +98,8 @@ export function mapOpenAIRealtimeServerEvent(
       const argsText = String(evt?.arguments ?? '');
       if (!callId || !argsText) return [];
       const name = state.functionNameByCallId.get(callId) ?? 'unknown';
+      // Prevent unbounded per-session growth for long-running sessions.
+      state.functionNameByCallId.delete(callId);
       const argumentsObj = parseJsonObject(argsText);
       return [{ type: 'tool_call.end', toolCallId: callId, name, arguments: argumentsObj }];
     }

--- a/plugins/realtime-compat/openai/internal/session-core.ts
+++ b/plugins/realtime-compat/openai/internal/session-core.ts
@@ -5,7 +5,7 @@ import type {
   RealtimeEvent,
   RealtimeSessionSpec
 } from '../../../../modules/kernel/index.js';
-import { AsyncQueue } from '../../../../modules/kernel/index.js';
+import { AsyncQueue, LruMap, resolveRealtimeToolCallTrackingMaxEntries } from '../../../../modules/kernel/index.js';
 
 import {
   buildConversationItemCreateEvent,
@@ -52,6 +52,8 @@ export function createOpenAIRealtimeCompatSessionWithTransport(
   const queue = new AsyncQueue<RealtimeEvent>();
   const sessionId = generateSessionId();
 
+  const toolCallTrackingMaxEntries = resolveRealtimeToolCallTrackingMaxEntries(spec);
+
   const { event: sessionUpdateEvent, audio, toolNameByProviderName } = buildSessionUpdateEvent({
     spec,
     tools: options.tools
@@ -59,7 +61,10 @@ export function createOpenAIRealtimeCompatSessionWithTransport(
 
   const state = {
     audio,
-    functionNameByCallId: new Map<string, string>(),
+    functionNameByCallId: new LruMap<string, string>(toolCallTrackingMaxEntries, {
+      label: 'realtime-tool-call-tracking(openai)',
+      warnOnEvict: true
+    }),
     toolNameByProviderName
   };
 

--- a/tests/unit/kernel/lru-map.test.ts
+++ b/tests/unit/kernel/lru-map.test.ts
@@ -1,0 +1,96 @@
+import { jest } from '@jest/globals';
+import { LruMap } from '@/modules/kernel/index.ts';
+
+describe('kernel/lru-map', () => {
+  test('evicts the oldest entry when over maxEntries', () => {
+    const map = new LruMap<string, number>(2);
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
+
+    expect(map.has('a')).toBe(false);
+    expect(map.has('b')).toBe(true);
+    expect(map.has('c')).toBe(true);
+  });
+
+  test('treats get() as a recency refresh (LRU)', () => {
+    const map = new LruMap<string, number>(2);
+    map.set('a', 1);
+    map.set('b', 2);
+
+    // Touch 'a' so 'b' becomes oldest.
+    expect(map.get('a')).toBe(1);
+    expect(map.get('missing')).toBeUndefined();
+
+    map.set('c', 3);
+
+    expect(map.has('a')).toBe(true);
+    expect(map.has('b')).toBe(false);
+    expect(map.has('c')).toBe(true);
+  });
+
+  test('set() updates existing keys without growing size', () => {
+    const map = new LruMap<string, number>(10);
+    map.set('a', 1);
+    map.set('a', 2);
+    expect(map.size).toBe(1);
+    expect(map.get('a')).toBe(2);
+  });
+
+  test('invokes onEvict with key/value for each evicted entry', () => {
+    const evicted: Array<{ key: string; value: number }> = [];
+    const map = new LruMap<string, number>(1, {
+      onEvict: (entry) => evicted.push(entry)
+    });
+
+    map.set('a', 1);
+    map.set('b', 2);
+
+    expect(evicted).toEqual([{ key: 'a', value: 1 }]);
+  });
+
+  test('optionally logs a warning on eviction', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const withLabel = new LruMap<string, number>(1, { warnOnEvict: true, label: 'test' });
+    withLabel.set('a', 1);
+    withLabel.set('b', 2);
+
+    const withoutLabel = new LruMap<string, number>(1, { warnOnEvict: true });
+    withoutLabel.set('a', 1);
+    withoutLabel.set('b', 2);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenNthCalledWith(
+      1,
+      'LRU map eviction',
+      expect.objectContaining({ label: 'test', key: 'a', maxEntries: 1 })
+    );
+    expect(warn).toHaveBeenNthCalledWith(
+      2,
+      'LRU map eviction',
+      expect.objectContaining({ key: 'a', maxEntries: 1 })
+    );
+    expect((warn.mock.calls[1]?.[1] as any)?.label).toBeUndefined();
+
+    warn.mockRestore();
+  });
+
+  test('setMaxEntries() can trigger eviction', () => {
+    const map = new LruMap<string, number>(3);
+    map.set('a', 1);
+    map.set('b', 2);
+    map.set('c', 3);
+
+    map.setMaxEntries(2);
+    expect(map.has('a')).toBe(false);
+    expect(map.has('b')).toBe(true);
+    expect(map.has('c')).toBe(true);
+    expect(map.getMaxEntries()).toBe(2);
+  });
+
+  test('normalizes invalid maxEntries to >= 1', () => {
+    const map = new LruMap<string, number>(0);
+    expect(map.getMaxEntries()).toBe(1);
+  });
+});

--- a/tests/unit/kernel/realtime-tool-call-tracking.test.ts
+++ b/tests/unit/kernel/realtime-tool-call-tracking.test.ts
@@ -1,0 +1,17 @@
+import { DEFAULT_REALTIME_TOOL_CALL_TRACKING_MAX_ENTRIES, resolveRealtimeToolCallTrackingMaxEntries } from '@/modules/kernel/index.ts';
+
+describe('kernel/realtime-tool-call-tracking', () => {
+  test('defaults when unset or invalid', () => {
+    expect(resolveRealtimeToolCallTrackingMaxEntries(undefined)).toBe(DEFAULT_REALTIME_TOOL_CALL_TRACKING_MAX_ENTRIES);
+    expect(resolveRealtimeToolCallTrackingMaxEntries({ toolCallTracking: {} } as any)).toBe(DEFAULT_REALTIME_TOOL_CALL_TRACKING_MAX_ENTRIES);
+    expect(resolveRealtimeToolCallTrackingMaxEntries({ toolCallTracking: { maxEntries: 0 } } as any)).toBe(DEFAULT_REALTIME_TOOL_CALL_TRACKING_MAX_ENTRIES);
+    expect(resolveRealtimeToolCallTrackingMaxEntries({ toolCallTracking: { maxEntries: -1 } } as any)).toBe(DEFAULT_REALTIME_TOOL_CALL_TRACKING_MAX_ENTRIES);
+    expect(resolveRealtimeToolCallTrackingMaxEntries({ toolCallTracking: { maxEntries: 'nope' } } as any)).toBe(DEFAULT_REALTIME_TOOL_CALL_TRACKING_MAX_ENTRIES);
+  });
+
+  test('normalizes to an integer >= 1', () => {
+    expect(resolveRealtimeToolCallTrackingMaxEntries({ toolCallTracking: { maxEntries: 42.9 } } as any)).toBe(42);
+    expect(resolveRealtimeToolCallTrackingMaxEntries({ toolCallTracking: { maxEntries: '5' } } as any)).toBe(5);
+  });
+});
+

--- a/tests/unit/realtime-compat/openai-realtime-event-mapper.test.ts
+++ b/tests/unit/realtime-compat/openai-realtime-event-mapper.test.ts
@@ -149,6 +149,7 @@ describe('realtime-compat/openai — event mapper', () => {
     expect(end.toolCallId).toBe('c1');
     expect(end.name).toBe('test.echo');
     expect(end.arguments).toEqual({ message: 'Tokyo' });
+    expect(state.functionNameByCallId.has('c1')).toBe(false);
 
     const unknownNameEnd = mapOpenAIRealtimeServerEvent(
       { type: 'response.function_call_arguments.done', call_id: 'unknown', arguments: '{"ok":true}' },


### PR DESCRIPTION
Fixes #319.

- Add `LruMap` + `resolveRealtimeToolCallTrackingMaxEntries` (default `1000`) and wire into OpenAI/Gemini realtime compat sessions.
- OpenAI: delete per-call id mapping after emitting `tool_call.end` to avoid growth.
- Docs: document `RealtimeSessionSpec.toolCallTracking`.

Validation:
- `npm test`
- `npm run test:live:realtime -- --transport=both`