### PR TITLE
Issue #321: extract audio rate limiter (DRY)

### DIFF
--- a/modules/server/index.ts
+++ b/modules/server/index.ts
@@ -302,4 +302,6 @@ export async function createServer(options: ServerOptions = {}): Promise<Running
   };
 }
 
+export { createAudioRateLimiter } from './internal/transport/audio-rate-limiter.js';
+
 export type { LLMCallSpec, LLMStreamEvent };

--- a/modules/server/internal/realtime/ws.ts
+++ b/modules/server/internal/realtime/ws.ts
@@ -2,6 +2,7 @@ import type http from 'http';
 import type net from 'net';
 import { createRequire } from 'module';
 
+import { createAudioRateLimiter } from '../transport/audio-rate-limiter.js';
 import { createLimiter } from '../transport/limiter.js';
 
 export interface RealtimeWsConfig {
@@ -138,10 +139,9 @@ export async function attachRealtimeWsServer(options: {
     let openSeen = false;
     let closed = false;
 
-    let idleTimer: NodeJS.Timeout | undefined;
-    let durationTimer: NodeJS.Timeout | undefined;
-    let audioTokens = options.config.maxAudioBytesPerSecond;
-    let audioLastRefillMs = Date.now();
+	    let idleTimer: NodeJS.Timeout | undefined;
+	    let durationTimer: NodeJS.Timeout | undefined;
+	    const audioRateLimiter = createAudioRateLimiter(options.config.maxAudioBytesPerSecond);
 
     const touch = () => {
       // also drives idle timeout resets
@@ -158,23 +158,10 @@ export async function attachRealtimeWsServer(options: {
       }, options.config.idleTimeoutMs);
     };
 
-    const chargeAudioBytes = (bytes: number) => {
-      const now = Date.now();
-      const elapsedMs = Math.max(0, now - audioLastRefillMs);
-      const refill = (elapsedMs * options.config.maxAudioBytesPerSecond) / 1000;
-      audioTokens = Math.min(options.config.maxAudioBytesPerSecond, audioTokens + refill);
-      audioLastRefillMs = now;
-
-      if (audioTokens < bytes) {
-        throw Object.assign(new Error('Audio rate limit exceeded'), { code: 'audio_rate_limited' });
-      }
-      audioTokens -= bytes;
-    };
-
-    const send = (env: RealtimeServerEnvelope) => {
-      if (ws.readyState !== ws.OPEN) return;
-      touch();
-      scheduleIdleCheck();
+	    const send = (env: RealtimeServerEnvelope) => {
+	      if (ws.readyState !== ws.OPEN) return;
+	      touch();
+	      scheduleIdleCheck();
       ws.send(JSON.stringify(env));
     };
 
@@ -280,13 +267,13 @@ export async function attachRealtimeWsServer(options: {
             await session.sendText({ text: msg.text, role: msg.role });
             return;
           }
-          case 'send_audio': {
-            ensureOpen();
-            const approxBytes = Math.floor((msg.frame.dataBase64.length * 3) / 4);
-            chargeAudioBytes(approxBytes);
-            await session.sendAudio(msg.frame);
-            return;
-          }
+	          case 'send_audio': {
+	            ensureOpen();
+	            const approxBytes = Math.floor((msg.frame.dataBase64.length * 3) / 4);
+	            audioRateLimiter.charge(approxBytes);
+	            await session.sendAudio(msg.frame);
+	            return;
+	          }
           case 'inject_context': {
             ensureOpen();
             await session.injectContext(msg.items);

--- a/modules/server/internal/transport/audio-rate-limiter.ts
+++ b/modules/server/internal/transport/audio-rate-limiter.ts
@@ -1,0 +1,28 @@
+export function createAudioRateLimiter(maxBytesPerSecond: number): {
+  charge: (bytes: number) => void;
+  reset: () => void;
+} {
+  let tokens = maxBytesPerSecond;
+  let lastRefillMs = Date.now();
+
+  const reset = () => {
+    tokens = maxBytesPerSecond;
+    lastRefillMs = Date.now();
+  };
+
+  const charge = (bytes: number) => {
+    const now = Date.now();
+    const elapsedMs = Math.max(0, now - lastRefillMs);
+    const refill = (elapsedMs * maxBytesPerSecond) / 1000;
+    tokens = Math.min(maxBytesPerSecond, tokens + refill);
+    lastRefillMs = now;
+
+    if (tokens < bytes) {
+      throw Object.assign(new Error('Audio rate limit exceeded'), { code: 'audio_rate_limited' });
+    }
+    tokens -= bytes;
+  };
+
+  return { charge, reset };
+}
+

--- a/plugins/modules/twilio-media-streams/internal/bridge.ts
+++ b/plugins/modules/twilio-media-streams/internal/bridge.ts
@@ -2,6 +2,7 @@ import type { RealtimeAudioFrame, RealtimeEvent } from '../../../../modules/kern
 import type { RealtimeSession } from '../../../../modules/realtime/index.js';
 import { AudioPacer, base64ToBytes, bytesToBase64, durationMsForBytes } from '../../../../modules/audio/index.js';
 import { verifySignedWsToken } from '../../../../modules/security/index.js';
+import { createAudioRateLimiter } from '../../../../modules/server/index.js';
 
 import { convertAudioBytes, frameAudioBytes, type AudioSpec } from './audio.js';
 import {
@@ -166,26 +167,6 @@ function safeClose(ws: TwilioMediaStreamsWsLike, code: number, reason: string): 
   try {
     ws.close(code, reason);
   } catch {}
-}
-
-function createAudioRateLimiter(maxBytesPerSecond: number): { charge: (bytes: number) => void } {
-  let tokens = maxBytesPerSecond;
-  let lastRefillMs = Date.now();
-
-  return {
-    charge(bytes: number) {
-      const now = Date.now();
-      const elapsedMs = Math.max(0, now - lastRefillMs);
-      const refill = (elapsedMs * maxBytesPerSecond) / 1000;
-      tokens = Math.min(maxBytesPerSecond, tokens + refill);
-      lastRefillMs = now;
-
-      if (tokens < bytes) {
-        throw Object.assign(new Error('Audio rate limit exceeded'), { code: 'audio_rate_limited' });
-      }
-      tokens -= bytes;
-    }
-  };
 }
 
 class ResettableQueue<T> {

--- a/tests/live/test-files/20-realtime.live.test.ts
+++ b/tests/live/test-files/20-realtime.live.test.ts
@@ -244,9 +244,10 @@ for (let i = 0; i < testRuns.length; i++) {
           },
           { type: 'commit' },
           { type: 'wait_for_event', eventType: 'user_transcript.final', timeoutMs: 30000 },
-          // Some providers emit an assistant confirmation for the audio turn; drain turn completion
-          // markers so the follow-up assertion targets the *second* (text) turn deterministically.
-          { type: 'wait_for_event', eventType: 'usage', timeoutMs: 30000 },
+          // Some providers emit an assistant confirmation for the audio turn; wait for the first
+          // turn's final assistant transcript so the follow-up assertion targets the *second* (text)
+          // turn deterministically.
+          { type: 'wait_for_event', eventType: 'assistant_transcript.final', timeoutMs: 30000 },
           { type: 'send_text', text: 'What number did I ask you to remember? Answer digits only.', role: 'user' },
           { type: 'commit' },
           { type: 'wait_for_event', eventType: 'assistant_transcript.final', timeoutMs: 30000 },

--- a/tests/unit/utils/server/audio-rate-limiter.test.ts
+++ b/tests/unit/utils/server/audio-rate-limiter.test.ts
@@ -1,0 +1,40 @@
+import { jest } from '@jest/globals';
+import { createAudioRateLimiter } from '@/modules/server/internal/transport/audio-rate-limiter.ts';
+
+describe('utils/server createAudioRateLimiter', () => {
+  test('charges tokens and refills over time', () => {
+    let now = 0;
+    const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+    const limiter = createAudioRateLimiter(10);
+
+    limiter.charge(5);
+    expect(() => limiter.charge(6)).toThrow('Audio rate limit exceeded');
+
+    try {
+      limiter.charge(6);
+    } catch (err: any) {
+      expect(err.code).toBe('audio_rate_limited');
+    }
+
+    now += 1000;
+    expect(() => limiter.charge(6)).not.toThrow();
+
+    nowSpy.mockRestore();
+  });
+
+  test('reset restores the full bucket', () => {
+    let now = 0;
+    const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+    const limiter = createAudioRateLimiter(10);
+    limiter.charge(10);
+    expect(() => limiter.charge(1)).toThrow('Audio rate limit exceeded');
+
+    limiter.reset();
+    expect(() => limiter.charge(1)).not.toThrow();
+
+    nowSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
Fixes #321.

- Added shared `createAudioRateLimiter()` in `modules/server/internal/transport/audio-rate-limiter.ts` (exported via `modules/server/index.ts`).
- Reused it in server realtime WS (`modules/server/internal/realtime/ws.ts`) and Twilio bridge.
- Added unit tests for the rate limiter.
- Live test tweak: realtime memory scenario now drains the first turn via `assistant_transcript.final` (more reliable than `usage` across providers).

Validation:
- `npm test`
- `npm run test:live:realtime -- --transport=both`