### PR TITLE
Issue #330: CLI realtime client-secret parity

### DIFF
--- a/README-CLI.md
+++ b/README-CLI.md
@@ -30,6 +30,7 @@ llm-adapter <command> [options]
 | `embeddings run` | Execute embedding operation |
 | `serve` | Start HTTP/SSE server |
 | `realtime` | Realtime session over stdin/stdout JSON protocol |
+| `realtime client-secret` | Mint a short-lived realtime WebRTC client secret |
 
 ---
 
@@ -422,6 +423,47 @@ llm-adapter realtime [options]
 
 - The first emitted event must be `{ "type": "ready", ... }`.
 - The `spec` field is passed through to the realtime session factory and is treated as an opaque object by the CLI.
+
+### `llm-adapter realtime client-secret`
+
+Mint a short-lived realtime **WebRTC client secret** (for browser/mobile WebRTC session establishment).
+
+```bash
+llm-adapter realtime client-secret [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-f, --file <path>` | Path to request JSON file | |
+| `-s, --spec <json>` | Request as JSON string | |
+| `-p, --plugins <path>` | Path to plugins directory | `./plugins` |
+| `--pretty` | Pretty print output | |
+
+**Request JSON (file/spec/stdin):**
+
+```json
+{
+  "provider": "…",
+  "model": "…",
+  "systemPrompt": "…",
+  "expiresAfterSeconds": 60
+}
+```
+
+Notes:
+- `provider` must be a realtime provider id from `plugins/realtime-providers/*.json`.
+- `expiresAfterSeconds` (when provided) must be an integer between `30` and `600` (inclusive), matching the server endpoint validation.
+
+**Response (stdout):**
+
+```json
+{
+  "clientSecret": "…",
+  "expiresAt": 1730000000
+}
+```
 
 ---
 

--- a/modules/cli/internal/unified-cli.ts
+++ b/modules/cli/internal/unified-cli.ts
@@ -503,10 +503,120 @@ export function createUnifiedProgram(
     stdout.write(`${JSON.stringify(env)}\n`);
   };
 
-  program
+  type RealtimeClientSecretRequest = {
+    provider: string;
+    model?: unknown;
+    systemPrompt?: unknown;
+    expiresAfterSeconds?: unknown;
+  };
+
+  const realtime = program
     .command('realtime')
     .description('Realtime session over stdin/stdout JSON protocol')
     .option('-p, --plugins <path>', 'Path to plugins directory', './plugins')
+    ;
+
+  realtime
+    .command('client-secret')
+    .description('Mint a short-lived realtime WebRTC client secret')
+    .option('-f, --file <path>', 'Path to request JSON file')
+    .option('-s, --spec <json>', 'Request as JSON string')
+    .option('-p, --plugins <path>', 'Path to plugins directory', './plugins')
+    .option('--pretty', 'Pretty print output')
+    .action(async (options) => {
+      try {
+        const { loadSpec } = await import('./spec-loader.js');
+        const { writeJsonToStdout } = await import('./stdout-writer.js');
+
+        const body = await loadSpec<RealtimeClientSecretRequest>(options);
+        const providerId = String((body as any)?.provider ?? '').trim();
+        const model = (body as any)?.model !== undefined ? String((body as any).model) : undefined;
+        const systemPrompt =
+          (body as any)?.systemPrompt !== undefined ? String((body as any).systemPrompt) : undefined;
+
+        const expiresAfterSecondsRaw = (body as any)?.expiresAfterSeconds;
+        const expiresAfterSeconds =
+          expiresAfterSecondsRaw === undefined || expiresAfterSecondsRaw === null
+            ? undefined
+            : Number(expiresAfterSecondsRaw);
+
+        const MIN_CLIENT_SECRET_EXPIRES_AFTER_SECONDS = 30;
+        const MAX_CLIENT_SECRET_EXPIRES_AFTER_SECONDS = 600;
+
+        if (!providerId) {
+          throw new Error('Missing provider');
+        }
+
+        if (expiresAfterSeconds !== undefined) {
+          if (!Number.isFinite(expiresAfterSeconds)) {
+            throw new Error('Invalid expiresAfterSeconds');
+          }
+          if (!Number.isInteger(expiresAfterSeconds)) {
+            throw new Error('expiresAfterSeconds must be an integer');
+          }
+          if (
+            expiresAfterSeconds < MIN_CLIENT_SECRET_EXPIRES_AFTER_SECONDS ||
+            expiresAfterSeconds > MAX_CLIENT_SECRET_EXPIRES_AFTER_SECONDS
+          ) {
+            throw new Error(
+              `expiresAfterSeconds must be between ${MIN_CLIENT_SECRET_EXPIRES_AFTER_SECONDS} and ${MAX_CLIENT_SECRET_EXPIRES_AFTER_SECONDS}`
+            );
+          }
+        }
+
+        const registry = await deps.createRegistry(options.plugins);
+        if (typeof (registry as any).loadAll === 'function') {
+          await (registry as any).loadAll();
+        }
+
+        const reg = registry as any;
+        if (typeof reg.getRealtimeProvider !== 'function' || typeof reg.getRealtimeCompat !== 'function') {
+          throw new Error('Registry does not support realtime client-secret minting');
+        }
+
+        const provider = await reg.getRealtimeProvider(providerId);
+        const compatKind = provider?.compat;
+        if (!compatKind) {
+          throw new Error(`Realtime client-secret minting not supported for provider '${providerId}'`);
+        }
+
+        const compat = await reg.getRealtimeCompat(compatKind);
+        if (!compat || typeof compat.mintClientSecret !== 'function') {
+          throw new Error(`Realtime client-secret minting not supported for provider '${providerId}'`);
+        }
+
+        const result = await compat.mintClientSecret({
+          provider,
+          spec: {
+            provider: providerId,
+            ...(model ? { model } : {}),
+            ...(systemPrompt ? { systemPrompt } : {}),
+            transport: { type: 'webrtc' }
+          },
+          ...(expiresAfterSeconds !== undefined ? { expiresAfterSeconds } : {})
+        });
+
+        const clientSecret = String(result?.clientSecret ?? '');
+        if (!clientSecret) {
+          throw new Error('Realtime client secret response missing client secret value');
+        }
+
+        await writeJsonToStdout(
+          {
+            clientSecret,
+            ...(result?.expiresAt !== undefined ? { expiresAt: result.expiresAt } : {})
+          },
+          { pretty: options.pretty }
+        );
+
+        deps.exit(0);
+      } catch (error: any) {
+        deps.error(JSON.stringify({ error: error?.message ?? String(error) }));
+        deps.exit(1);
+      }
+    });
+
+  realtime
     .action(async (options) => {
       const { stdin, stdout, stderr } = deps.getRealtimeStdio();
 

--- a/tests/live/config.ts
+++ b/tests/live/config.ts
@@ -154,7 +154,10 @@ export function getFilteredRealtimeTestRuns(): RealtimeTestRun[] {
       `Warning: No realtime test runs matched providers: ${providerFilter}. ` +
       `Available: ${realtimeTestRuns.map(r => r.name).join(', ')}`
     );
-    return realtimeTestRuns;
+    // Unlike base LLM live tests, realtime runs are not interchangeable; when a provider filter
+    // doesn't match any realtime runs, treat it as "no realtime runs selected" rather than
+    // silently running a different realtime provider.
+    return [];
   }
 
   return filtered;
@@ -172,9 +175,9 @@ export const filteredTestRuns = getFilteredTestRuns();
  */
 export const filteredRealtimeTestRuns = getFilteredRealtimeTestRuns();
 
-// Backwards compatibility exports (use first run as default)
-export const llmPriority = testRuns[0].llmPriority;
-export const defaultSettings = testRuns[0].settings;
+// Backwards compatibility exports (use first *filtered* run as default)
+export const llmPriority = filteredTestRuns[0]?.llmPriority ?? testRuns[0].llmPriority;
+export const defaultSettings = filteredTestRuns[0]?.settings ?? testRuns[0].settings;
 export const primaryProvider = llmPriority[0]?.provider ?? '';
 
 export const invalidPriorityEntry = {

--- a/tests/live/run-live.ts
+++ b/tests/live/run-live.ts
@@ -11,6 +11,20 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..', '..');
 
+function getMissingLiveEnvForProvider(provider: string | null, env: NodeJS.ProcessEnv): string[] {
+  if (!provider) return [];
+
+  const requiredByProvider: Record<string, string[]> = {
+    anthropic: ['ANTHROPIC_API_KEY'],
+    'openai-responses': ['OPENAI_API_KEY'],
+    openrouter: ['OPENROUTER_API_KEY'],
+    google: ['GEMINI_API_KEY']
+  };
+
+  const required = requiredByProvider[String(provider)] ?? [];
+  return required.filter(key => !env?.[key] || String(env[key]).trim() === '');
+}
+
 function createRunId(prefix: string): string {
   // File-safe + stable, avoids characters that are invalid in env-derived IDs.
   const stamp = new Date().toISOString().replace(/[:.]/g, '-');
@@ -167,6 +181,15 @@ async function main() {
 
   const baseEnv: NodeJS.ProcessEnv = { ...process.env, LLM_LIVE: '1' };
   if (provider) baseEnv.LLM_TEST_PROVIDERS = provider;
+
+  const missingEnv = getMissingLiveEnvForProvider(provider, baseEnv);
+  if (missingEnv.length > 0) {
+    console.warn(
+      `Skipping live tests for '${provider}': missing required env var(s): ${missingEnv.join(', ')}.`
+    );
+    process.exitCode = 0;
+    return;
+  }
 
   // Live suites invoke the built CLI entrypoint under `dist/` (and server mode runs `dist/bin/cli.js`),
   // so ensure `dist/` is up to date for *all* transports (cli/server/both) for deterministic results.

--- a/tests/live/test-files/20-realtime.live.test.ts
+++ b/tests/live/test-files/20-realtime.live.test.ts
@@ -7,6 +7,10 @@ import { filteredRealtimeTestRuns as testRuns } from '../config.ts';
 const runLive = process.env.LLM_LIVE === '1';
 const pluginsPath = './plugins';
 
+if (testRuns.length === 0) {
+  test.skip('20-realtime — skipped (no matching realtime providers)', () => {});
+}
+
 function fixturePath(name: string): string {
   return path.resolve(process.cwd(), 'tests', 'live', 'fixtures', 'realtime', name);
 }

--- a/tests/unit/cli/unified-cli.test.ts
+++ b/tests/unit/cli/unified-cli.test.ts
@@ -124,6 +124,13 @@ describe('cli/internal/unified-cli', () => {
       expect(realtimeCmd).toBeDefined();
     });
 
+    test('realtime has client-secret subcommand', () => {
+      const program = createUnifiedProgram(mockDeps);
+      const realtimeCmd = program.commands.find(c => c.name() === 'realtime');
+      const csCmd = realtimeCmd?.commands.find((c: Command) => c.name() === 'client-secret');
+      expect(csCmd).toBeDefined();
+    });
+
     test('vector has run subcommand', () => {
       const program = createUnifiedProgram(mockDeps);
       const vectorCmd = program.commands.find(c => c.name() === 'vector');
@@ -677,6 +684,329 @@ describe('cli/internal/unified-cli', () => {
       const envelopes = lines.map(l => JSON.parse(l));
       expect(envelopes.some(e => e.type === 'error' && e.error.code === 'already_open')).toBe(true);
       expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(1);
+    });
+  });
+
+  describe('realtime client-secret command', () => {
+    test('mints a client secret via realtime compat and writes JSON response', async () => {
+      const providerId = 'test-realtime-provider';
+      const compatKind = 'test-realtime-compat';
+
+      const providerManifest = { id: providerId, compat: compatKind };
+      const mintClientSecret = jest.fn().mockResolvedValue({ clientSecret: 'client_secret_value', expiresAt: 123 });
+      const registry = {
+        loadAll: jest.fn().mockResolvedValue(undefined),
+        getRealtimeProvider: jest.fn().mockResolvedValue(providerManifest),
+        getRealtimeCompat: jest.fn().mockResolvedValue({ mintClientSecret })
+      };
+
+      const written: string[] = [];
+      jest.spyOn(process.stdout, 'write').mockImplementation((chunk: any, encodingOrCb?: any, cb?: any) => {
+        written.push(chunk.toString());
+        const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb;
+        if (callback) setImmediate(callback);
+        return true;
+      });
+
+      const program = createUnifiedProgram({
+        ...mockDeps,
+        createRegistry: jest.fn().mockResolvedValue(registry)
+      });
+
+      const req = {
+        provider: providerId,
+        model: 'test-model',
+        systemPrompt: 'hello',
+        expiresAfterSeconds: 60
+      };
+
+      await program.parseAsync([
+        'node',
+        'llm-adapter',
+        'realtime',
+        'client-secret',
+        '--plugins',
+        './test-plugins',
+        '--spec',
+        JSON.stringify(req)
+      ]);
+
+      expect(registry.getRealtimeProvider).toHaveBeenCalledWith(providerId);
+      expect(registry.getRealtimeCompat).toHaveBeenCalledWith(compatKind);
+      expect(mintClientSecret).toHaveBeenCalledWith({
+        provider: providerManifest,
+        spec: {
+          provider: providerId,
+          model: 'test-model',
+          systemPrompt: 'hello',
+          transport: { type: 'webrtc' }
+        },
+        expiresAfterSeconds: 60
+      });
+
+      const output = written.join('');
+      expect(output).toContain('"clientSecret"');
+      expect(output).toContain('client_secret_value');
+      expect(output).toContain('"expiresAt"');
+      expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(0);
+
+      jest.spyOn(process.stdout, 'write').mockRestore();
+    });
+
+    test('supports minimal request (no model/systemPrompt/expiresAfterSeconds) and omits expiresAt in response', async () => {
+      const providerId = 'test-realtime-provider';
+      const compatKind = 'test-realtime-compat';
+
+      const providerManifest = { id: providerId, compat: compatKind };
+      const mintClientSecret = jest.fn().mockResolvedValue({ clientSecret: 'client_secret_value' });
+      const registry = {
+        loadAll: jest.fn().mockResolvedValue(undefined),
+        getRealtimeProvider: jest.fn().mockResolvedValue(providerManifest),
+        getRealtimeCompat: jest.fn().mockResolvedValue({ mintClientSecret })
+      };
+
+      const written: string[] = [];
+      jest.spyOn(process.stdout, 'write').mockImplementation((chunk: any, encodingOrCb?: any, cb?: any) => {
+        written.push(chunk.toString());
+        const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb;
+        if (callback) setImmediate(callback);
+        return true;
+      });
+
+      const program = createUnifiedProgram({
+        ...mockDeps,
+        createRegistry: jest.fn().mockResolvedValue(registry)
+      });
+
+      await program.parseAsync([
+        'node',
+        'llm-adapter',
+        'realtime',
+        'client-secret',
+        '--plugins',
+        './test-plugins',
+        '--spec',
+        JSON.stringify({ provider: providerId })
+      ]);
+
+      expect(mintClientSecret).toHaveBeenCalledWith({
+        provider: providerManifest,
+        spec: {
+          provider: providerId,
+          transport: { type: 'webrtc' }
+        }
+      });
+
+      const output = written.join('');
+      expect(output).toContain('"clientSecret"');
+      expect(output).toContain('client_secret_value');
+      expect(output).not.toContain('"expiresAt"');
+      expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(0);
+
+      jest.spyOn(process.stdout, 'write').mockRestore();
+    });
+
+    test('fails validation on missing provider', async () => {
+      const registry = { loadAll: jest.fn().mockResolvedValue(undefined) };
+      const program = createUnifiedProgram({
+        ...mockDeps,
+        createRegistry: jest.fn().mockResolvedValue(registry)
+      });
+
+      await program.parseAsync(['node', 'llm-adapter', 'realtime', 'client-secret', '--spec', '{}']);
+
+      expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(1);
+      expect(capturedErrors[capturedErrors.length - 1]).toContain('Missing provider');
+    });
+
+    test('fails validation on invalid expiresAfterSeconds (non-finite)', async () => {
+      const program = createUnifiedProgram(mockDeps);
+
+      await program.parseAsync([
+        'node',
+        'llm-adapter',
+        'realtime',
+        'client-secret',
+        '--spec',
+        JSON.stringify({ provider: 'p', expiresAfterSeconds: 'Infinity' })
+      ]);
+
+      expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(1);
+      expect(capturedErrors[capturedErrors.length - 1]).toContain('Invalid expiresAfterSeconds');
+    });
+
+    test('fails validation on non-integer expiresAfterSeconds', async () => {
+      const program = createUnifiedProgram(mockDeps);
+
+      await program.parseAsync([
+        'node',
+        'llm-adapter',
+        'realtime',
+        'client-secret',
+        '--spec',
+        JSON.stringify({ provider: 'p', expiresAfterSeconds: 1.5 })
+      ]);
+
+      expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(1);
+      expect(capturedErrors[capturedErrors.length - 1]).toContain('must be an integer');
+    });
+
+    test('fails validation on out-of-range expiresAfterSeconds', async () => {
+      const registry = { loadAll: jest.fn().mockResolvedValue(undefined) };
+      const program = createUnifiedProgram({
+        ...mockDeps,
+        createRegistry: jest.fn().mockResolvedValue(registry)
+      });
+
+      await program.parseAsync([
+        'node',
+        'llm-adapter',
+        'realtime',
+        'client-secret',
+        '--spec',
+        JSON.stringify({ provider: 'p', expiresAfterSeconds: 999999 })
+      ]);
+
+      expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(1);
+      expect(capturedErrors[capturedErrors.length - 1]).toContain('expiresAfterSeconds must be between');
+    });
+
+    test('fails when registry does not support realtime client-secret minting', async () => {
+      const registry = { loadAll: jest.fn().mockResolvedValue(undefined) };
+      const program = createUnifiedProgram({
+        ...mockDeps,
+        createRegistry: jest.fn().mockResolvedValue(registry)
+      });
+
+      await program.parseAsync([
+        'node',
+        'llm-adapter',
+        'realtime',
+        'client-secret',
+        '--spec',
+        JSON.stringify({ provider: 'test-realtime-provider' })
+      ]);
+
+      expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(1);
+      expect(capturedErrors[capturedErrors.length - 1]).toContain(
+        'Registry does not support realtime client-secret minting'
+      );
+    });
+
+    test('fails when provider is missing compat mapping', async () => {
+      const providerId = 'test-realtime-provider';
+      const registry = {
+        loadAll: jest.fn().mockResolvedValue(undefined),
+        getRealtimeProvider: jest.fn().mockResolvedValue({ id: providerId }),
+        getRealtimeCompat: jest.fn()
+      };
+
+      const program = createUnifiedProgram({
+        ...mockDeps,
+        createRegistry: jest.fn().mockResolvedValue(registry)
+      });
+
+      await program.parseAsync([
+        'node',
+        'llm-adapter',
+        'realtime',
+        'client-secret',
+        '--spec',
+        JSON.stringify({ provider: providerId })
+      ]);
+
+      expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(1);
+      expect(capturedErrors[capturedErrors.length - 1]).toContain('not supported for provider');
+    });
+
+    test('fails when compat does not support client-secret minting', async () => {
+      const providerId = 'test-realtime-provider';
+      const compatKind = 'test-realtime-compat';
+
+      const registry = {
+        loadAll: jest.fn().mockResolvedValue(undefined),
+        getRealtimeProvider: jest.fn().mockResolvedValue({ id: providerId, compat: compatKind }),
+        getRealtimeCompat: jest.fn().mockResolvedValue({})
+      };
+
+      const program = createUnifiedProgram({
+        ...mockDeps,
+        createRegistry: jest.fn().mockResolvedValue(registry)
+      });
+
+      await program.parseAsync([
+        'node',
+        'llm-adapter',
+        'realtime',
+        'client-secret',
+        '--spec',
+        JSON.stringify({ provider: providerId })
+      ]);
+
+      expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(1);
+      expect(capturedErrors[capturedErrors.length - 1]).toContain('client-secret minting not supported');
+    });
+
+    test('fails when compat response is missing clientSecret', async () => {
+      const providerId = 'test-realtime-provider';
+      const compatKind = 'test-realtime-compat';
+
+      const registry = {
+        loadAll: jest.fn().mockResolvedValue(undefined),
+        getRealtimeProvider: jest.fn().mockResolvedValue({ id: providerId, compat: compatKind }),
+        getRealtimeCompat: jest.fn().mockResolvedValue({
+          mintClientSecret: jest.fn().mockResolvedValue({ expiresAt: 123 })
+        })
+      };
+
+      const program = createUnifiedProgram({
+        ...mockDeps,
+        createRegistry: jest.fn().mockResolvedValue(registry)
+      });
+
+      await program.parseAsync([
+        'node',
+        'llm-adapter',
+        'realtime',
+        'client-secret',
+        '--spec',
+        JSON.stringify({ provider: providerId })
+      ]);
+
+      expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(1);
+      expect(capturedErrors[capturedErrors.length - 1]).toContain('missing client secret');
+    });
+
+    test('handles non-Error failures from compat mintClientSecret', async () => {
+      const providerId = 'test-realtime-provider';
+      const compatKind = 'test-realtime-compat';
+
+      const registry = {
+        loadAll: jest.fn().mockResolvedValue(undefined),
+        getRealtimeProvider: jest.fn().mockResolvedValue({ id: providerId, compat: compatKind }),
+        getRealtimeCompat: jest.fn().mockResolvedValue({
+          mintClientSecret: jest.fn().mockImplementation(() => {
+            throw 'boom';
+          })
+        })
+      };
+
+      const program = createUnifiedProgram({
+        ...mockDeps,
+        createRegistry: jest.fn().mockResolvedValue(registry)
+      });
+
+      await program.parseAsync([
+        'node',
+        'llm-adapter',
+        'realtime',
+        'client-secret',
+        '--spec',
+        JSON.stringify({ provider: providerId })
+      ]);
+
+      expect(capturedExitCodes[capturedExitCodes.length - 1]).toBe(1);
+      expect(capturedErrors[capturedErrors.length - 1]).toContain('boom');
     });
   });
 


### PR DESCRIPTION
Closes #330.

Adds CLI/server parity for realtime WebRTC client-secret minting:
- New command: `llm-adapter realtime client-secret`
- TTL validation matches server (integer 30–600)
- Unit tests updated to keep `npm test` at 100% coverage
- CLI docs updated (`README-CLI.md`)

Also includes small live-test harness tweaks so `test:live:<provider>` respects provider filtering and realtime runs don’t fall back to a different provider when filtered.
