### PR TITLE
Issue #331: bound realtime event buffering

### DIFF
--- a/modules/kernel/internal/async-queue.ts
+++ b/modules/kernel/internal/async-queue.ts
@@ -3,6 +3,14 @@ export class AsyncQueue<T> {
   private resolvers: Array<(value: IteratorResult<T>) => void> = [];
   private closed = false;
 
+  getBufferedCount(): number {
+    return this.items.length;
+  }
+
+  clear(): void {
+    this.items.length = 0;
+  }
+
   push(item: T): void {
     if (this.closed) return;
     const next = this.resolvers.shift();
@@ -40,4 +48,3 @@ export class AsyncQueue<T> {
     }
   }
 }
-

--- a/modules/kernel/internal/realtime-types.ts
+++ b/modules/kernel/internal/realtime-types.ts
@@ -124,6 +124,16 @@ export interface RealtimeToolCallTrackingConfig {
   maxEntries?: number;
 }
 
+export interface RealtimeEventBufferConfig {
+  /**
+   * Max normalized events to buffer when the consumer is not draining `session.events()`.
+   *
+   * When exceeded, the session fails fast with an `error` (code: `event_buffer_overflow`)
+   * and closes to prevent unbounded memory growth.
+   */
+  maxEvents?: number;
+}
+
 export interface RealtimeSessionSpec {
   /** Provider id from plugins/realtime-providers/*.json */
   provider: string;
@@ -140,6 +150,7 @@ export interface RealtimeSessionSpec {
   functionToolNames?: string[];
   toolChoice?: ToolChoice;
   toolCallTracking?: RealtimeToolCallTrackingConfig;
+  eventBuffer?: RealtimeEventBufferConfig;
 
   // audio + transcription
   audio?: RealtimeSessionAudioConfig;

--- a/modules/realtime/README.md
+++ b/modules/realtime/README.md
@@ -74,6 +74,8 @@ Key fields:
   - Use `session.injectContext(items)` for mid-session injection (does not auto-trigger a response).
 - `functionToolNames` / `toolChoice`: enable tool calling within the session.
 - `toolCallTracking`: bounds internal tool-call id → name tracking (default `maxEntries: 1000`).
+- `eventBuffer`: bounds normalized event buffering when the consumer is not draining `session.events()` (memory safety guard).
+  - When exceeded, the session emits an `error` (code: `event_buffer_overflow`), requests playback clear (`reason: 'error'`), and closes.
 - `audio`: negotiated session audio input/output formats.
 - `transcription`: enable user transcription (and optionally language hints).
 - `turnDetection`: `manual_commit` vs `server_vad`.

--- a/modules/realtime/internal/realtime-session.ts
+++ b/modules/realtime/internal/realtime-session.ts
@@ -45,6 +45,8 @@ type ToolCoordinatorLike = {
 
 class RealtimeSessionController implements RealtimeSession {
   private readonly queue = new AsyncQueue<RealtimeEvent>();
+  private maxBufferedEvents: number | undefined;
+  private bufferOverflowed = false;
   private startedAtMs = Date.now();
   private lastActivityAtMs = Date.now();
   private maxDurationMs: number;
@@ -70,6 +72,12 @@ class RealtimeSessionController implements RealtimeSession {
     this.idleTimeoutMs = timeoutCfg.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
     this.onTimeout = timeoutCfg.onTimeout ?? DEFAULT_ON_TIMEOUT;
 
+    const eventBufferCfg = options.spec.eventBuffer ?? {};
+    const maxEvents = Number((eventBufferCfg as any).maxEvents);
+    if (Number.isFinite(maxEvents) && maxEvents > 0) {
+      this.maxBufferedEvents = Math.floor(maxEvents);
+    }
+
     const dtmfCfg = options.spec.dtmf ?? {};
     this.dtmfMode = dtmfCfg.mode ?? 'digit';
     this.dtmfTerminators = new Set((dtmfCfg.terminators ?? ['#']).map(s => String(s)));
@@ -88,6 +96,35 @@ class RealtimeSessionController implements RealtimeSession {
     }
     this.eventsConsumed = true;
     return this.queue.iterate();
+  }
+
+  private pushEvent(event: RealtimeEvent): void {
+    if (this.closed) return;
+
+    if (!this.bufferOverflowed && this.maxBufferedEvents !== undefined) {
+      if (this.queue.getBufferedCount() >= this.maxBufferedEvents) {
+        void this.handleEventBufferOverflow();
+        return;
+      }
+    }
+
+    this.queue.push(event);
+  }
+
+  private async handleEventBufferOverflow(): Promise<void> {
+    this.bufferOverflowed = true;
+
+    // Drop buffered events to free memory; downstream consumers will receive an explicit error + close.
+    this.queue.clear();
+    const now = Date.now();
+    this.queue.push({
+      type: 'error',
+      message: 'Realtime event buffer overflow: consumer is not draining events()',
+      code: 'event_buffer_overflow'
+    });
+    this.queue.push({ type: 'playback.clear_requested', reason: 'error', atMs: now });
+
+    await this.closeInternal({ reason: 'error', emitClosedEvent: true });
   }
 
   async sendText(options: { text: string; role?: 'system' | 'user' }): Promise<void> {
@@ -117,7 +154,7 @@ class RealtimeSessionController implements RealtimeSession {
     } else if (this.dtmfMode === 'digit') {
       await this.maybeBargeIn('user_dtmf.digit');
     }
-    this.queue.push({ type: 'user_dtmf.digit', digit: d });
+    this.pushEvent({ type: 'user_dtmf.digit', digit: d });
 
     if (this.dtmfMode === 'digit') {
       await this.options.compatSession.sendText({ text: `DTMF: ${d}`, role: 'user' });
@@ -137,7 +174,7 @@ class RealtimeSessionController implements RealtimeSession {
     if (!this.dtmfBargedInThisBuffer) {
       await this.maybeBargeIn('user_dtmf.sequence');
     }
-    this.queue.push({ type: 'user_dtmf.sequence', digits, ...(terminator ? { terminator } : {}) });
+    this.pushEvent({ type: 'user_dtmf.sequence', digits, ...(terminator ? { terminator } : {}) });
 
     await this.options.compatSession.sendText({ text: `DTMF sequence: ${digits}`, role: 'user' });
     await this.options.compatSession.commit();
@@ -160,7 +197,7 @@ class RealtimeSessionController implements RealtimeSession {
     this.ensureOpen();
     this.onActivity();
     await this.options.compatSession.interrupt({ reason: _options.reason });
-    this.queue.push({
+    this.pushEvent({
       type: 'playback.clear_requested',
       reason: 'interrupt',
       atMs: Date.now()
@@ -222,14 +259,14 @@ class RealtimeSessionController implements RealtimeSession {
     const elapsedMs = reason === 'idle' ? now - this.lastActivityAtMs : now - this.startedAtMs;
     const configuredMs = reason === 'idle' ? this.idleTimeoutMs : this.maxDurationMs;
 
-    this.queue.push({
+    this.pushEvent({
       type: 'timeout',
       reason,
       elapsedMs,
       configuredMs
     });
 
-    this.queue.push({
+    this.pushEvent({
       type: 'playback.clear_requested',
       reason: 'timeout',
       atMs: now
@@ -250,7 +287,7 @@ class RealtimeSessionController implements RealtimeSession {
         return;
       }
       if (!first.value || (first.value as any).type !== 'ready') {
-        this.queue.push({ type: 'error', message: 'First realtime event must be ready', code: 'invalid_first_event' });
+        this.pushEvent({ type: 'error', message: 'First realtime event must be ready', code: 'invalid_first_event' });
         await this.closeInternal({ reason: 'error', emitClosedEvent: true });
         return;
       }
@@ -260,7 +297,7 @@ class RealtimeSessionController implements RealtimeSession {
         try {
           await this.options.compatSession.injectContext(history);
         } catch (err: any) {
-          this.queue.push({
+          this.pushEvent({
             type: 'error',
             message: err?.message ?? String(err),
             code: 'history_injection_failed'
@@ -271,7 +308,7 @@ class RealtimeSessionController implements RealtimeSession {
       }
 
       this.onActivity();
-      this.queue.push(first.value);
+      this.pushEvent(first.value);
 
       while (true) {
         const next = await iter.next();
@@ -285,7 +322,7 @@ class RealtimeSessionController implements RealtimeSession {
       }
     } catch (error: any) {
       if (!this.closed) {
-        this.queue.push({ type: 'error', message: error?.message ?? String(error), code: 'compat_error' });
+        this.pushEvent({ type: 'error', message: error?.message ?? String(error), code: 'compat_error' });
         await this.closeInternal({ reason: 'error', emitClosedEvent: true });
       }
     }
@@ -301,7 +338,7 @@ class RealtimeSessionController implements RealtimeSession {
       await this.maybeBargeIn('user_transcript.delta');
     }
 
-    this.queue.push(event);
+    this.pushEvent(event);
 
     if (event.type === 'tool_call.end') {
       await this.handleToolCallEnd(event);
@@ -322,7 +359,7 @@ class RealtimeSessionController implements RealtimeSession {
     if (!triggers.includes(trigger)) return false;
 
     await this.options.compatSession.interrupt({ reason: 'barge_in' });
-    this.queue.push({ type: 'playback.clear_requested', reason: 'barge_in', atMs: Date.now() });
+    this.pushEvent({ type: 'playback.clear_requested', reason: 'barge_in', atMs: Date.now() });
     return true;
   }
 
@@ -339,13 +376,13 @@ class RealtimeSessionController implements RealtimeSession {
 
   private async handleToolCallEnd(event: Extract<RealtimeEvent, { type: 'tool_call.end' }>): Promise<void> {
     if (!this.enabledToolNames) {
-      this.queue.push({ type: 'error', message: 'Tool call received but tools are not enabled', code: 'tools_disabled' });
+      this.pushEvent({ type: 'error', message: 'Tool call received but tools are not enabled', code: 'tools_disabled' });
       await this.closeInternal({ reason: 'error', emitClosedEvent: true });
       return;
     }
 
     if (!this.enabledToolNames.has(event.name)) {
-      this.queue.push({ type: 'error', message: `Tool not enabled: ${event.name}`, code: 'tool_not_enabled' });
+      this.pushEvent({ type: 'error', message: `Tool not enabled: ${event.name}`, code: 'tool_not_enabled' });
       await this.closeInternal({ reason: 'error', emitClosedEvent: true });
       return;
     }
@@ -365,9 +402,9 @@ class RealtimeSessionController implements RealtimeSession {
         toolCallId: event.toolCallId,
         result: result as JsonValue
       });
-      this.queue.push({ type: 'tool_result.sent', toolCallId: event.toolCallId });
+      this.pushEvent({ type: 'tool_result.sent', toolCallId: event.toolCallId });
     } catch (error: any) {
-      this.queue.push({ type: 'error', message: `Tool execution failed: ${error?.message ?? String(error)}`, code: 'tool_error' });
+      this.pushEvent({ type: 'error', message: `Tool execution failed: ${error?.message ?? String(error)}`, code: 'tool_error' });
       await this.closeInternal({ reason: 'error', emitClosedEvent: true });
     }
   }

--- a/tests/live/config.ts
+++ b/tests/live/config.ts
@@ -154,7 +154,10 @@ export function getFilteredRealtimeTestRuns(): RealtimeTestRun[] {
       `Warning: No realtime test runs matched providers: ${providerFilter}. ` +
       `Available: ${realtimeTestRuns.map(r => r.name).join(', ')}`
     );
-    return realtimeTestRuns;
+    // Unlike base LLM live tests, realtime runs are not interchangeable; when a provider filter
+    // doesn't match any realtime runs, treat it as "no realtime runs selected" rather than
+    // silently running a different realtime provider.
+    return [];
   }
 
   return filtered;
@@ -172,9 +175,9 @@ export const filteredTestRuns = getFilteredTestRuns();
  */
 export const filteredRealtimeTestRuns = getFilteredRealtimeTestRuns();
 
-// Backwards compatibility exports (use first run as default)
-export const llmPriority = testRuns[0].llmPriority;
-export const defaultSettings = testRuns[0].settings;
+// Backwards compatibility exports (use first *filtered* run as default)
+export const llmPriority = filteredTestRuns[0]?.llmPriority ?? testRuns[0].llmPriority;
+export const defaultSettings = filteredTestRuns[0]?.settings ?? testRuns[0].settings;
 export const primaryProvider = llmPriority[0]?.provider ?? '';
 
 export const invalidPriorityEntry = {

--- a/tests/live/run-live.ts
+++ b/tests/live/run-live.ts
@@ -11,6 +11,20 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..', '..');
 
+function getMissingLiveEnvForProvider(provider: string | null, env: NodeJS.ProcessEnv): string[] {
+  if (!provider) return [];
+
+  const requiredByProvider: Record<string, string[]> = {
+    anthropic: ['ANTHROPIC_API_KEY'],
+    'openai-responses': ['OPENAI_API_KEY'],
+    openrouter: ['OPENROUTER_API_KEY'],
+    google: ['GEMINI_API_KEY']
+  };
+
+  const required = requiredByProvider[String(provider)] ?? [];
+  return required.filter(key => !env?.[key] || String(env[key]).trim() === '');
+}
+
 function createRunId(prefix: string): string {
   // File-safe + stable, avoids characters that are invalid in env-derived IDs.
   const stamp = new Date().toISOString().replace(/[:.]/g, '-');
@@ -167,6 +181,15 @@ async function main() {
 
   const baseEnv: NodeJS.ProcessEnv = { ...process.env, LLM_LIVE: '1' };
   if (provider) baseEnv.LLM_TEST_PROVIDERS = provider;
+
+  const missingEnv = getMissingLiveEnvForProvider(provider, baseEnv);
+  if (missingEnv.length > 0) {
+    console.warn(
+      `Skipping live tests for '${provider}': missing required env var(s): ${missingEnv.join(', ')}.`
+    );
+    process.exitCode = 0;
+    return;
+  }
 
   // Live suites invoke the built CLI entrypoint under `dist/` (and server mode runs `dist/bin/cli.js`),
   // so ensure `dist/` is up to date for *all* transports (cli/server/both) for deterministic results.

--- a/tests/live/test-files/20-realtime.live.test.ts
+++ b/tests/live/test-files/20-realtime.live.test.ts
@@ -7,6 +7,10 @@ import { filteredRealtimeTestRuns as testRuns } from '../config.ts';
 const runLive = process.env.LLM_LIVE === '1';
 const pluginsPath = './plugins';
 
+if (testRuns.length === 0) {
+  test.skip('20-realtime — skipped (no matching realtime providers)', () => {});
+}
+
 function fixturePath(name: string): string {
   return path.resolve(process.cwd(), 'tests', 'live', 'fixtures', 'realtime', name);
 }

--- a/tests/unit/kernel/async-queue.test.ts
+++ b/tests/unit/kernel/async-queue.test.ts
@@ -36,4 +36,18 @@ describe('kernel/async-queue', () => {
     const res = await pending;
     expect(res.done).toBe(true);
   });
+
+  test('getBufferedCount() reports buffered items and clear() drops them', async () => {
+    const q = new AsyncQueue<number>();
+    expect(q.getBufferedCount()).toBe(0);
+
+    q.push(1);
+    q.push(2);
+    expect(q.getBufferedCount()).toBe(2);
+
+    q.clear();
+    expect(q.getBufferedCount()).toBe(0);
+
+    q.close();
+  });
 });

--- a/tests/unit/realtime/realtime-module.test.ts
+++ b/tests/unit/realtime/realtime-module.test.ts
@@ -220,6 +220,89 @@ describe('modules/realtime/internal/realtime-session', () => {
     await session.close();
   });
 
+  test('fails fast when event buffer overflows (consumer stalls)', async () => {
+    const closed = createDeferred<void>();
+    const compatClose = jest.fn().mockImplementation(async () => closed.resolve());
+
+    const compat: RealtimeCompatSession = {
+      sendText: jest.fn(),
+      injectContext: jest.fn(),
+      sendAudio: jest.fn(),
+      commit: jest.fn(),
+      interrupt: jest.fn(),
+      sendToolResult: jest.fn(),
+      close: compatClose,
+      events: async function* () {
+        yield { type: 'ready', sessionId: 's' };
+        for (let i = 0; i < 10; i++) {
+          yield { type: 'user_transcript.delta', textDelta: `d${i}` };
+        }
+      }
+    };
+
+    const session = createRealtimeSessionController({
+      registry: { getProcessRoutes: jest.fn().mockResolvedValue([]) },
+      provider: { id: 'p' } as any,
+      spec: {
+        provider: 'p',
+        eventBuffer: { maxEvents: 2 },
+        timeout: { maxDurationMs: 0, idleTimeoutMs: 0, onTimeout: 'close' }
+      },
+      compatSession: compat
+    });
+
+    // Do not drain events until after overflow triggers (simulates a stalled consumer).
+    await closed.promise;
+
+    const events = await collectAll(session.events());
+    expect(events[0]).toEqual({
+      type: 'error',
+      message: 'Realtime event buffer overflow: consumer is not draining events()',
+      code: 'event_buffer_overflow'
+    });
+    expect(events[1]).toMatchObject({ type: 'playback.clear_requested', reason: 'error' });
+    expect(typeof (events[1] as any).atMs).toBe('number');
+    expect(events[2]).toEqual({ type: 'closed', reason: 'error' });
+    expect(compatClose).toHaveBeenCalled();
+  });
+
+  test('eventBuffer.maxEvents does not affect normal sessions within limit', async () => {
+    const compatClose = jest.fn();
+    const compat: RealtimeCompatSession = {
+      sendText: jest.fn(),
+      injectContext: jest.fn(),
+      sendAudio: jest.fn(),
+      commit: jest.fn(),
+      interrupt: jest.fn(),
+      sendToolResult: jest.fn(),
+      close: compatClose,
+      events: async function* () {
+        yield { type: 'ready', sessionId: 's' };
+        yield { type: 'user_transcript.delta', textDelta: 'hi' };
+        yield { type: 'closed', reason: 'provider_close' };
+      }
+    };
+
+    const session = createRealtimeSessionController({
+      registry: { getProcessRoutes: jest.fn().mockResolvedValue([]) },
+      provider: { id: 'p' } as any,
+      spec: {
+        provider: 'p',
+        eventBuffer: { maxEvents: 10 },
+        timeout: { maxDurationMs: 0, idleTimeoutMs: 0, onTimeout: 'close' }
+      },
+      compatSession: compat
+    });
+
+    const events = await collectAll(session.events());
+    expect(events).toEqual([
+      { type: 'ready', sessionId: 's' },
+      { type: 'user_transcript.delta', textDelta: 'hi' },
+      { type: 'closed', reason: 'provider_close' }
+    ]);
+    expect(compatClose).toHaveBeenCalled();
+  });
+
   test('enforces first event must be ready', async () => {
     const compatClose = jest.fn();
     const compat: RealtimeCompatSession = {


### PR DESCRIPTION
Closes #331.

Adds a memory-safety guardrail for long-lived realtime sessions:
- New optional `spec.eventBuffer.maxEvents` to bound buffered normalized realtime events when the consumer isn’t draining `session.events()`.
- Fail-fast behavior on overflow: clear buffered events, emit `error` (`code: event_buffer_overflow`) + `playback.clear_requested` (`reason: 'error'`), then close.

Also includes small live-test harness tweaks (consistent with Issue #330 follow-ups) so `npm run test:live:openrouter -- --transport=both` can be run on machines without `OPENROUTER_API_KEY` (it will skip and exit 0).

Verification:
- `npm test` (100% coverage)
- `npm run test:live:openrouter -- --transport=both` (skips in this env due to missing key)
