### PR TITLE
Issue #338: live runner hard-fails missing env (no skip)

### DIFF
--- a/tests/live/required-env.ts
+++ b/tests/live/required-env.ts
@@ -1,0 +1,58 @@
+export function getTestPathPatternsFromJestArgs(jestArgs: string[]): string[] {
+  const patterns: string[] = [];
+
+  for (let i = 0; i < jestArgs.length; i++) {
+    const arg = jestArgs[i];
+    if (arg.startsWith('--testPathPattern=')) {
+      patterns.push(arg.slice('--testPathPattern='.length));
+      continue;
+    }
+
+    if (arg === '--testPathPattern') {
+      const next = jestArgs[i + 1];
+      if (next) patterns.push(String(next));
+      i++;
+    }
+  }
+
+  return patterns.map(p => String(p || '').trim()).filter(Boolean);
+}
+
+export function getMissingRequiredEnv(options: {
+  selectedProviders: string[];
+  testPathPatterns: string[];
+  env: NodeJS.ProcessEnv;
+}): string[] {
+  const required = new Set<string>();
+
+  const requiredByProvider: Record<string, string[]> = {
+    anthropic: ['ANTHROPIC_API_KEY'],
+    'openai-responses': ['OPENAI_API_KEY'],
+    openrouter: ['OPENROUTER_API_KEY'],
+    google: ['GEMINI_API_KEY']
+  };
+
+  for (const provider of options.selectedProviders) {
+    for (const key of requiredByProvider[String(provider)] ?? []) {
+      required.add(key);
+    }
+  }
+
+  const patterns = options.testPathPatterns.join(' ');
+  const wantsAllLive = /\blive\b/i.test(patterns);
+  const wantsEmbeddings = /\bembeddings\b|15-embeddings/i.test(patterns);
+  const wantsVector =
+    /\bvector\b|16-vector-store|17-vector-cli|18-vector-auto-inject|19-vector-search-locks/i.test(patterns);
+
+  // Live suite includes embeddings/vector coverage; these are required for a full pass.
+  if (wantsAllLive || wantsEmbeddings || wantsVector) {
+    required.add('OPENROUTER_API_KEY');
+  }
+  if (wantsAllLive || wantsVector) {
+    required.add('QDRANT_CLOUD_URL');
+    required.add('QDRANT_API_KEY');
+  }
+
+  return [...required].filter(key => !options.env?.[key] || String(options.env[key]).trim() === '');
+}
+

--- a/tests/live/run-live.ts
+++ b/tests/live/run-live.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 import { parseLaunchConfig, buildJestArgs } from './launcher/index.js';
 import { maxWorkersDefault } from './config.ts';
+import { getTestPathPatternsFromJestArgs, getMissingRequiredEnv } from './required-env.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -157,8 +158,43 @@ async function main() {
 
   const { nodeArgs, jestArgs } = buildJestArgs({ maxWorkers, passthrough });
 
+  dotenv.config({ path: path.join(rootDir, '.env') });
+
   const baseEnv: NodeJS.ProcessEnv = { ...process.env, LLM_LIVE: '1' };
   if (provider) baseEnv.LLM_TEST_PROVIDERS = provider;
+
+  const testPathPatterns = getTestPathPatternsFromJestArgs(jestArgs);
+
+  const selectedProviders =
+    provider && String(provider).trim() !== ''
+      ? [String(provider).trim()]
+      : (baseEnv.LLM_TEST_PROVIDERS || '')
+          .split(',')
+          .map(p => p.trim())
+          .filter(Boolean);
+
+  const patterns = testPathPatterns.join(' ');
+  const wantsAllLive = /\blive\b/i.test(patterns);
+  const wantsEmbeddings = /\bembeddings\b|15-embeddings/i.test(patterns);
+  const wantsVector = /\bvector\b|16-vector-store|17-vector-cli|18-vector-auto-inject|19-vector-search-locks/i.test(patterns);
+
+  // LLM provider API keys are only required if this run is expected to execute the LLM live suites.
+  const expectsLlmSuites = selectedProviders.length > 0 || wantsAllLive || (!wantsEmbeddings && !wantsVector);
+  const effectiveProviders = expectsLlmSuites
+    ? selectedProviders.length > 0
+      ? selectedProviders
+      : ['anthropic', 'openai-responses', 'openrouter', 'google']
+    : [];
+
+  const missingEnv = getMissingRequiredEnv({ selectedProviders: effectiveProviders, testPathPatterns, env: baseEnv });
+  if (missingEnv.length > 0) {
+    console.error(
+      `Live tests require env var(s) that are missing/empty: ${missingEnv.join(', ')}. ` +
+        `Refusing to run.`
+    );
+    process.exitCode = 1;
+    return;
+  }
 
   const runJest = async (extraEnv: NodeJS.ProcessEnv): Promise<number> => {
     return spawnAndWait(process.execPath, [...nodeArgs, ...jestArgs], {
@@ -168,17 +204,14 @@ async function main() {
     });
   };
 
-  // Default behavior remains CLI-driven live tests
-  if (transport === 'cli') {
-    process.exitCode = await runJest({ LLM_LIVE_TRANSPORT: 'cli' });
-    return;
-  }
-
-  // Server-based transports require dist/ for running the server outside Jest.
-  dotenv.config({ path: path.join(rootDir, '.env') });
+  const commonJestEnv = { LLM_SKIP_TS_BUILD: '1' };
   await buildDistOnce();
 
-  const commonJestEnv = { LLM_SKIP_TS_BUILD: '1' };
+  // Default behavior remains CLI-driven live tests
+  if (transport === 'cli') {
+    process.exitCode = await runJest({ ...commonJestEnv, LLM_LIVE_TRANSPORT: 'cli' });
+    return;
+  }
 
   if (transport === 'both') {
     const cliCode = await runJest({ ...commonJestEnv, LLM_LIVE_TRANSPORT: 'cli' });

--- a/tests/unit/live/required-env.test.ts
+++ b/tests/unit/live/required-env.test.ts
@@ -1,0 +1,58 @@
+import { getMissingRequiredEnv, getTestPathPatternsFromJestArgs } from '../../live/required-env.ts';
+
+describe('live/required-env', () => {
+  test('getTestPathPatternsFromJestArgs parses --testPathPattern= form', () => {
+    const patterns = getTestPathPatternsFromJestArgs([
+      'jest.js',
+      '--testPathPattern=live',
+      '--maxWorkers=2'
+    ]);
+    expect(patterns).toEqual(['live']);
+  });
+
+  test('getTestPathPatternsFromJestArgs parses --testPathPattern <value> form', () => {
+    const patterns = getTestPathPatternsFromJestArgs([
+      'jest.js',
+      '--testPathPattern',
+      '15-embeddings'
+    ]);
+    expect(patterns).toEqual(['15-embeddings']);
+  });
+
+  test('getMissingRequiredEnv requires provider key for selected providers', () => {
+    const missing = getMissingRequiredEnv({
+      selectedProviders: ['openrouter'],
+      testPathPatterns: ['00-foundation'],
+      env: {}
+    });
+    expect(missing).toEqual(['OPENROUTER_API_KEY']);
+  });
+
+  test('getMissingRequiredEnv requires OpenRouter key for embeddings suite', () => {
+    const missing = getMissingRequiredEnv({
+      selectedProviders: [],
+      testPathPatterns: ['15-embeddings'],
+      env: {}
+    });
+    expect(missing).toEqual(['OPENROUTER_API_KEY']);
+  });
+
+  test('getMissingRequiredEnv requires Qdrant + OpenRouter keys for vector suites', () => {
+    const missing = getMissingRequiredEnv({
+      selectedProviders: [],
+      testPathPatterns: ['16-vector-store'],
+      env: { OPENROUTER_API_KEY: 'x' }
+    });
+    expect(missing).toEqual(['QDRANT_CLOUD_URL', 'QDRANT_API_KEY']);
+  });
+
+  test('getMissingRequiredEnv requires Qdrant + OpenRouter keys for full live suite', () => {
+    const missing = getMissingRequiredEnv({
+      selectedProviders: [],
+      testPathPatterns: ['live'],
+      env: {}
+    });
+    expect(missing).toEqual(['OPENROUTER_API_KEY', 'QDRANT_CLOUD_URL', 'QDRANT_API_KEY']);
+  });
+});
+


### PR DESCRIPTION
Closes #338.

Per `agents.md`, live suites must not skip when creds are missing.

Changes:
- `tests/live/run-live.ts` now loads `.env` early and **fails fast (exit 1)** when required env vars are missing/empty.
- Builds `dist/` once for all transports and sets `LLM_SKIP_TS_BUILD=1` for Jest runs.
- New helper `tests/live/required-env.ts` + unit test to keep logic covered.

Verification:
- `npm test` (100% coverage)
- Manual: `OPENROUTER_API_KEY= npm run test:live:openrouter -- --transport=cli --testPathPattern=00-foundation` exits 1 with a clear missing-env error.
