### PR TITLE
Issue #339: live test files hard-fail missing env (no describe.skip gating)

### DIFF
--- a/tests/helpers/require-env.ts
+++ b/tests/helpers/require-env.ts
@@ -1,0 +1,13 @@
+export function requireEnv(options: {
+  required: string[];
+  env?: NodeJS.ProcessEnv;
+  label?: string;
+}): void {
+  const env = options.env ?? process.env;
+  const missing = options.required.filter(key => !env?.[key] || String(env[key]).trim() === '');
+  if (missing.length === 0) return;
+
+  const label = options.label ? ` (${options.label})` : '';
+  throw new Error(`Missing required env var(s)${label}: ${missing.join(', ')}`);
+}
+

--- a/tests/live/test-files/15-embeddings.live.test.ts
+++ b/tests/live/test-files/15-embeddings.live.test.ts
@@ -10,10 +10,13 @@
  */
 
 import { runEmbeddingCoordinator } from '@tests/helpers/node-cli.ts';
+import { requireEnv } from '@tests/helpers/require-env.ts';
 
 const runLive = process.env.LLM_LIVE === '1';
-const hasKey = Boolean(process.env.OPENROUTER_API_KEY);
-const describeLive = runLive && hasKey ? describe : describe.skip;
+if (runLive) {
+  requireEnv({ required: ['OPENROUTER_API_KEY'], label: '15-embeddings' });
+}
+const describeLive = runLive ? describe : describe.skip;
 
 const pluginsPath = './plugins';
 

--- a/tests/live/test-files/16-vector-store.live.test.ts
+++ b/tests/live/test-files/16-vector-store.live.test.ts
@@ -12,11 +12,16 @@
  */
 
 import { runEmbeddingCoordinator, runVectorCoordinator } from '@tests/helpers/node-cli.ts';
+import { requireEnv } from '@tests/helpers/require-env.ts';
 
 const runLive = process.env.LLM_LIVE === '1';
-const hasQdrantConfig = Boolean(process.env.QDRANT_CLOUD_URL && process.env.QDRANT_API_KEY);
-const hasEmbeddingKey = Boolean(process.env.OPENROUTER_API_KEY);
-const describeLive = runLive && hasQdrantConfig && hasEmbeddingKey ? describe : describe.skip;
+if (runLive) {
+  requireEnv({
+    required: ['QDRANT_CLOUD_URL', 'QDRANT_API_KEY', 'OPENROUTER_API_KEY'],
+    label: '16-vector-store'
+  });
+}
+const describeLive = runLive ? describe : describe.skip;
 
 const pluginsPath = './plugins';
 const testCollection = `test_collection_${Date.now()}`;
@@ -218,4 +223,3 @@ describeLive('16-vector-store (transported)', () => {
     expect(stillHasDoc).toBe(false);
   }, 90000);
 });
-

--- a/tests/live/test-files/17-vector-cli.live.test.ts
+++ b/tests/live/test-files/17-vector-cli.live.test.ts
@@ -12,11 +12,16 @@
  */
 
 import { runEmbeddingCoordinator, runVectorCoordinator } from '@tests/helpers/node-cli.ts';
+import { requireEnv } from '@tests/helpers/require-env.ts';
 
 const runLive = process.env.LLM_LIVE === '1';
-const required = ['QDRANT_CLOUD_URL', 'QDRANT_API_KEY', 'OPENROUTER_API_KEY'];
-const missing = required.filter(key => !process.env[key]);
-const describeLive = runLive && missing.length === 0 ? describe : describe.skip;
+if (runLive) {
+  requireEnv({
+    required: ['QDRANT_CLOUD_URL', 'QDRANT_API_KEY', 'OPENROUTER_API_KEY'],
+    label: '17-vector-cli'
+  });
+}
+const describeLive = runLive ? describe : describe.skip;
 
 const pluginsPath = './plugins';
 const testCollection = `test-cli-${Date.now()}`;
@@ -59,11 +64,6 @@ describeLive('17-vector-cli (transported)', () => {
   let dimensions = 0;
 
   beforeAll(async () => {
-    if (missing.length > 0) {
-      console.warn(`Missing environment variables: ${missing.join(', ')}`);
-      return;
-    }
-
     const dimsRes = await runEmbedding({
       operation: 'dimensions',
       provider: 'openrouter-embeddings'
@@ -89,8 +89,6 @@ describeLive('17-vector-cli (transported)', () => {
   }, 120000);
 
   afterAll(async () => {
-    if (missing.length > 0) return;
-
     try {
       await runVector({
         operation: 'collections',
@@ -221,4 +219,3 @@ describeLive('17-vector-cli (transported)', () => {
     }, 90000);
   });
 });
-

--- a/tests/live/test-files/18-vector-auto-inject.live.test.ts
+++ b/tests/live/test-files/18-vector-auto-inject.live.test.ts
@@ -12,11 +12,16 @@
  */
 
 import { runCoordinator, runEmbeddingCoordinator, runVectorCoordinator } from '@tests/helpers/node-cli.ts';
+import { requireEnv } from '@tests/helpers/require-env.ts';
 
 const runLive = process.env.LLM_LIVE === '1';
-const required = ['QDRANT_CLOUD_URL', 'QDRANT_API_KEY', 'OPENROUTER_API_KEY'];
-const missing = required.filter(key => !process.env[key]);
-const describeLive = runLive && missing.length === 0 ? describe : describe.skip;
+if (runLive) {
+  requireEnv({
+    required: ['QDRANT_CLOUD_URL', 'QDRANT_API_KEY', 'OPENROUTER_API_KEY'],
+    label: '18-vector-auto-inject'
+  });
+}
+const describeLive = runLive ? describe : describe.skip;
 
 const pluginsPath = './plugins';
 const testCollection = `test-inject-${Date.now()}`;
@@ -55,11 +60,6 @@ describeLive('18-vector-auto-inject (transported)', () => {
   let dimensions = 0;
 
   beforeAll(async () => {
-    if (missing.length > 0) {
-      console.warn(`Missing environment variables: ${missing.join(', ')}`);
-      return;
-    }
-
     const dimsRes = await runEmbedding({
       operation: 'dimensions',
       provider: 'openrouter-embeddings'
@@ -116,8 +116,6 @@ describeLive('18-vector-auto-inject (transported)', () => {
   }, 180000);
 
   afterAll(async () => {
-    if (missing.length > 0) return;
-
     try {
       await runVector({
         operation: 'collections',
@@ -239,4 +237,3 @@ describeLive('18-vector-auto-inject (transported)', () => {
     }, 120000);
   });
 });
-

--- a/tests/live/test-files/19-vector-search-locks.live.test.ts
+++ b/tests/live/test-files/19-vector-search-locks.live.test.ts
@@ -12,11 +12,14 @@
  */
 
 import { runCoordinator, runEmbeddingCoordinator, runVectorCoordinator } from '@tests/helpers/node-cli.ts';
+import { requireEnv } from '@tests/helpers/require-env.ts';
 
 const runLive = process.env.LLM_LIVE === '1';
 const required = ['QDRANT_CLOUD_URL', 'QDRANT_API_KEY', 'OPENROUTER_API_KEY'];
-const missing = required.filter(key => !process.env[key]);
-const describeLive = runLive && missing.length === 0 ? describe : describe.skip;
+if (runLive) {
+  requireEnv({ required, label: '19-vector-search-locks' });
+}
+const describeLive = runLive ? describe : describe.skip;
 
 const pluginsPath = './plugins';
 const testCollection = `test-locks-${Date.now()}`;
@@ -62,11 +65,6 @@ const expectNoVectorErrors = (response: any) => {
 
 describeLive('19-vector-search-locks (transported)', () => {
   beforeAll(async () => {
-    if (missing.length > 0) {
-      console.warn(`Missing environment variables: ${missing.join(', ')}`);
-      return;
-    }
-
     const dimsRes = await runEmbedding({
       operation: 'dimensions',
       provider: 'openrouter-embeddings'
@@ -127,8 +125,6 @@ describeLive('19-vector-search-locks (transported)', () => {
   }, 180000);
 
   afterAll(async () => {
-    if (missing.length > 0) return;
-
     try {
       await runVector({
         operation: 'collections',
@@ -386,4 +382,3 @@ describeLive('19-vector-search-locks (transported)', () => {
     }, 180000);
   });
 });
-


### PR DESCRIPTION
Closes #339.

Per `agents.md`, live tests should never skip due to missing env.

Changes:
- Added `tests/helpers/require-env.ts`.
- Updated embedding/vector live suites to:
  - assert required env vars when `LLM_LIVE=1`
  - only skip when not running live (`LLM_LIVE` not set)
  - remove `missing.length` early-returns that silently skipped setup/cleanup.

Verification:
- `npm test` (100% coverage)
