### PR TITLE
Issue #391: Extract createDeferred utility to shared module

### DIFF
--- a/modules/shared/README.md
+++ b/modules/shared/README.md
@@ -52,3 +52,32 @@ normalizeFlag('maybe', false);   // false (unrecognized → default)
 - `string` → `'true'/'1'/'yes'/'y'/'on'` → true, `'false'/'0'/'no'/'n'/'off'` → false
 - `null/undefined` → returns `defaultValue`
 - other → converted via `Boolean()`
+
+### `createDeferred<T>()`
+
+Creates a deferred promise with externally accessible resolve/reject handlers.
+Equivalent to the ES2024 `Promise.withResolvers()` API.
+
+```typescript
+import { createDeferred } from '../shared/index.js';
+
+// Basic usage (void)
+const signal = createDeferred();
+setTimeout(() => signal.resolve(), 1000);
+await signal.promise;
+
+// With value type
+const deferred = createDeferred<string>();
+deferred.resolve('hello');
+const value = await deferred.promise; // 'hello'
+
+// Error handling
+const failing = createDeferred<number>();
+failing.reject(new Error('oops'));
+await failing.promise; // throws Error('oops')
+```
+
+**Returns:** `Deferred<T>` object with:
+- `promise` - The Promise instance
+- `resolve(value: T)` - Function to resolve the promise
+- `reject(reason?: unknown)` - Function to reject the promise

--- a/modules/shared/index.ts
+++ b/modules/shared/index.ts
@@ -36,3 +36,31 @@ export function normalizeFlag(value: unknown, defaultValue: boolean): boolean {
   }
   return Boolean(value);
 }
+
+/**
+ * A deferred promise with externally accessible resolve/reject handlers.
+ */
+export interface Deferred<T = void> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+/**
+ * Creates a deferred promise with externally accessible resolve/reject.
+ * Equivalent to the ES2024 Promise.withResolvers() API.
+ *
+ * @example
+ * const deferred = createDeferred<string>();
+ * setTimeout(() => deferred.resolve('done'), 1000);
+ * await deferred.promise; // 'done'
+ */
+export function createDeferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}

--- a/plugins/realtime-compat/grok/internal/session-core.ts
+++ b/plugins/realtime-compat/grok/internal/session-core.ts
@@ -6,6 +6,7 @@ import type {
   RealtimeSessionSpec
 } from '../../../../modules/kernel/index.js';
 import { AsyncQueue, LruMap, resolveRealtimeToolCallTrackingMaxEntries } from '../../../../modules/kernel/index.js';
+import { createDeferred, type Deferred } from '../../../../modules/shared/index.js';
 
 import {
   buildConversationItemCreateEvent,
@@ -76,15 +77,7 @@ export function createGrokRealtimeCompatSessionWithTransport(
   const forceToolChoiceOnCommit = typeof spec.toolChoice === 'object' && spec.toolChoice?.type === 'single';
   const preReadyEvents: RealtimeEvent[] = [];
 
-  let pendingCancel: { promise: Promise<void>; resolve: () => void } | undefined;
-
-  const createDeferred = (): { promise: Promise<void>; resolve: () => void } => {
-    let resolve!: () => void;
-    const promise = new Promise<void>((res) => {
-      resolve = res;
-    });
-    return { promise, resolve };
-  };
+  let pendingCancel: Deferred<void> | undefined;
 
   const send = (event: any): void => {
     transport.send(JSON.stringify(event));

--- a/plugins/realtime-compat/openai/internal/session-core.ts
+++ b/plugins/realtime-compat/openai/internal/session-core.ts
@@ -6,6 +6,7 @@ import type {
   RealtimeSessionSpec
 } from '../../../../modules/kernel/index.js';
 import { AsyncQueue, LruMap, resolveRealtimeToolCallTrackingMaxEntries } from '../../../../modules/kernel/index.js';
+import { createDeferred, type Deferred } from '../../../../modules/shared/index.js';
 
 import {
   buildConversationItemCreateEvent,
@@ -75,15 +76,7 @@ export function createOpenAIRealtimeCompatSessionWithTransport(
   const forceToolChoiceOnCommit = typeof spec.toolChoice === 'object' && spec.toolChoice?.type === 'single';
   const preReadyEvents: RealtimeEvent[] = [];
 
-  let pendingCancel: { promise: Promise<void>; resolve: () => void } | undefined;
-
-  const createDeferred = (): { promise: Promise<void>; resolve: () => void } => {
-    let resolve!: () => void;
-    const promise = new Promise<void>((res) => {
-      resolve = res;
-    });
-    return { promise, resolve };
-  };
+  let pendingCancel: Deferred<void> | undefined;
 
   const send = (event: any): void => {
     transport.send(JSON.stringify(event));

--- a/tests/unit/modules/shared/shared.test.ts
+++ b/tests/unit/modules/shared/shared.test.ts
@@ -1,4 +1,4 @@
-import { normalizeFlag } from '@/modules/shared/index.ts';
+import { normalizeFlag, createDeferred, type Deferred } from '@/modules/shared/index.ts';
 
 describe('modules/shared', () => {
   describe('normalizeFlag', () => {
@@ -66,6 +66,92 @@ describe('modules/shared', () => {
       expect(normalizeFlag({}, false)).toBe(true);
       expect(normalizeFlag([], false)).toBe(true);
       expect(normalizeFlag(() => {}, false)).toBe(true);
+    });
+  });
+
+  describe('createDeferred', () => {
+    test('resolve() settles promise with value', async () => {
+      const deferred = createDeferred<string>();
+      deferred.resolve('hello');
+      await expect(deferred.promise).resolves.toBe('hello');
+    });
+
+    test('reject() settles promise with error', async () => {
+      const deferred = createDeferred<string>();
+      const error = new Error('test error');
+      deferred.reject(error);
+      await expect(deferred.promise).rejects.toBe(error);
+    });
+
+    test('works with void type (default)', async () => {
+      const deferred = createDeferred();
+      deferred.resolve();
+      await expect(deferred.promise).resolves.toBeUndefined();
+    });
+
+    test('works with number type', async () => {
+      const deferred = createDeferred<number>();
+      deferred.resolve(42);
+      await expect(deferred.promise).resolves.toBe(42);
+    });
+
+    test('works with object type', async () => {
+      const deferred = createDeferred<{ name: string }>();
+      const obj = { name: 'test' };
+      deferred.resolve(obj);
+      await expect(deferred.promise).resolves.toBe(obj);
+    });
+
+    test('multiple deferreds are independent', async () => {
+      const deferred1 = createDeferred<string>();
+      const deferred2 = createDeferred<string>();
+
+      deferred1.resolve('first');
+      deferred2.resolve('second');
+
+      await expect(deferred1.promise).resolves.toBe('first');
+      await expect(deferred2.promise).resolves.toBe('second');
+    });
+
+    test('resolving before await still works', async () => {
+      const deferred = createDeferred<string>();
+      deferred.resolve('early');
+      // Wait a tick to ensure resolution happened
+      await new Promise(r => setTimeout(r, 0));
+      await expect(deferred.promise).resolves.toBe('early');
+    });
+
+    test('rejecting before await still works', async () => {
+      const deferred = createDeferred<string>();
+      const error = new Error('early error');
+      // Attach a no-op catch handler to prevent unhandled rejection warning
+      deferred.promise.catch(() => {});
+      deferred.reject(error);
+      // Wait a tick to ensure rejection happened
+      await new Promise(r => setTimeout(r, 0));
+      await expect(deferred.promise).rejects.toBe(error);
+    });
+
+    test('reject() with string reason', async () => {
+      const deferred = createDeferred<void>();
+      deferred.promise.catch(() => {});
+      deferred.reject('string reason');
+      await expect(deferred.promise).rejects.toBe('string reason');
+    });
+
+    test('reject() with undefined reason', async () => {
+      const deferred = createDeferred<void>();
+      deferred.promise.catch(() => {});
+      deferred.reject();
+      await expect(deferred.promise).rejects.toBeUndefined();
+    });
+
+    test('returns Deferred interface shape', () => {
+      const deferred: Deferred<string> = createDeferred<string>();
+      expect(typeof deferred.promise).toBe('object');
+      expect(deferred.promise instanceof Promise).toBe(true);
+      expect(typeof deferred.resolve).toBe('function');
+      expect(typeof deferred.reject).toBe('function');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Extracts the duplicated `createDeferred()` pattern to `modules/shared/index.ts`
- Adds `Deferred<T>` interface for type-safe usage
- Migrates OpenAI and Grok realtime compats to use the shared utility
- Adds comprehensive unit tests (11 test cases)

## Changes

| File | Change |
|------|--------|
| `modules/shared/index.ts` | Add `createDeferred<T>()` + `Deferred<T>` interface |
| `modules/shared/README.md` | Document the new utility |
| `plugins/realtime-compat/openai/internal/session-core.ts` | Use shared utility |
| `plugins/realtime-compat/grok/internal/session-core.ts` | Use shared utility |
| `tests/unit/modules/shared/shared.test.ts` | Add 11 test cases |

## Test plan

- [x] `npm test` - 3554 tests passing, 100% coverage
- [x] `LLM_TEST_PROVIDERS=grok npm run test:live:realtime -- --transport=both` - 8/8 passing
- [x] `LLM_TEST_PROVIDERS=openai npm run test:live:realtime -- --transport=both` - 8/8 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)