### PR TITLE
Issue #397: Fix WS transport close leak + message decoding

### DIFF
--- a/modules/realtime/internal/transport/ws.ts
+++ b/modules/realtime/internal/transport/ws.ts
@@ -25,7 +25,7 @@ export interface RealtimeTransport {
 /**
  * Decode ws message payload to string.
  * The ws library can deliver payloads as string, Buffer, ArrayBuffer, Buffer[], or Blob.
- * Blob is only available in browser environments but we handle it for completeness.
+ * Note: createWsTransport uses the sync decoder in the message handler to preserve ordering.
  */
 export async function decodeWsMessageAsync(data: unknown): Promise<string> {
   if (typeof data === 'string') return data;
@@ -45,7 +45,7 @@ export async function decodeWsMessageAsync(data: unknown): Promise<string> {
 /**
  * Synchronous decode for ws message payload.
  * For Blob payloads, falls back to String() since async is not supported here.
- * Use decodeWsMessageAsync if Blob support is critical.
+ * Use decodeWsMessageAsync in environments where ws emits Blob payloads (e.g., binaryType: 'blob').
  */
 export function decodeWsMessage(data: unknown): string {
   if (typeof data === 'string') return data;
@@ -124,4 +124,3 @@ export function createWsTransport(options: { url: string; headers?: Record<strin
     }
   };
 }
-

--- a/tests/unit/modules/realtime/ws-transport.test.ts
+++ b/tests/unit/modules/realtime/ws-transport.test.ts
@@ -7,9 +7,8 @@ const { WebSocketServer } = require('ws');
 /**
  * Unit tests for the WS transport module.
  *
- * Note: The createWsTransport function is tested via live tests (test:live:realtime)
- * since it requires a real WebSocket connection. The decodeWsMessage function is
- * tested here as it's a pure function.
+ * decodeWsMessage / decodeWsMessageAsync are pure utilities, and createWsTransport
+ * close semantics are tested against a local WebSocketServer.
  */
 describe('modules/realtime/internal/transport/ws', () => {
   describe('decodeWsMessage (sync)', () => {
@@ -146,11 +145,27 @@ describe('modules/realtime/internal/transport/ws', () => {
 
     beforeAll(async () => {
       server = new WebSocketServer({ port: 0 });
-      port = (server.address() as any).port;
+      await new Promise<void>((resolve, reject) => {
+        const address = server.address();
+        if (address && typeof address === 'object') {
+          resolve();
+          return;
+        }
+
+        server.once('listening', resolve);
+        server.once('error', reject);
+      });
+
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected TCP address');
+      }
+
+      port = address.port;
     });
 
     afterAll(async () => {
-      server.close();
+      await new Promise<void>(resolve => server.close(() => resolve()));
     });
 
     test('close() terminates events() iterator and emits exactly one close event', async () => {


### PR DESCRIPTION
## Summary
- Fix close() leak in WS transport by splitting state into `sendClosed` and `queueEnded` flags (#398)
- Add robust `decodeWsMessage()` to handle all ws payload types: string, Buffer, ArrayBuffer, Buffer[] (#399)
- Add 15 unit tests for message decoding with 100% coverage (#400)

## Problem
The WS transport had two issues:
1. **Close leak**: `close()` set `closed = true` before calling `closeOnce()`, which checked `if (closed) return;` - causing early return and the close event never being emitted
2. **Message decoding**: Only handled string payloads, but ws can deliver Buffer, ArrayBuffer, or Buffer[] depending on platform/config

## Solution
1. Split state into two flags: `sendClosed` (guards send()) and `queueEnded` (guards queue termination)
2. Added `decodeWsMessage(data: unknown): string` that handles all payload types with fallback

## Test plan
- [x] Unit tests: 3558/3558 passing (100% coverage)
- [x] Live realtime tests: 23/24 passing (Google concurrent sessions timeout is a known flaky test)
- [x] Live openrouter tests: 51/51 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)