### PR TITLE
Issue #759: Voice WS token via TwiML Parameter

### DIFF
--- a/extensions/voice/README.md
+++ b/extensions/voice/README.md
@@ -71,6 +71,10 @@ Enable the voice extension on the server via:
 - `LLM_ADAPTER_VOICE_EVENTS_KEEPALIVE_INTERVAL_MS` (default: `15000`)
   - Overrides the default SSE keepalive interval (`server.extensions.voice.events.keepAliveIntervalMs`). Set to `0` to disable keepalives.
 
+- `LLM_ADAPTER_VOICE_MEDIA_WS_TOKEN_FROM_MESSAGE_TIMEOUT_MS` (default: `5000`)
+  - Enables accepting the signed `WS /voice/media` token via the first WebSocket message (JSON key: `voiceMediaToken`) when URL query parameters can’t be preserved.
+  - Set to `0` to disable and require `?token=...` in the URL.
+
 ### Server defaults (optional)
 
 The voice extension supports server-side defaults and settings under `server.extensions.voice`:
@@ -91,6 +95,9 @@ Notes:
 - `events.keepAliveIntervalMs` (default: `15000`): interval for SSE keepalive comments (`: keepalive`) to keep intermediaries from timing out idle streams (set `0` to disable keepalives). Can also be overridden via `LLM_ADAPTER_VOICE_EVENTS_KEEPALIVE_INTERVAL_MS`.
 - `events.maxWriteQueueBytes` (default: `262144`): upper bound on buffered SSE response bytes (in-flight + queued). If exceeded, the server closes the stream to avoid unbounded memory growth.
 - `timeouts.silenceAssistantAudioStartFallbackMs` / `timeouts.silenceAssistantAudioEndFallbackMs`: optional fallback windows used by some provider compats when `assistantFirstTurn.enabled=true` to ensure silence timers still arm when assistant-audio boundary events are missing (see the active compat README under `plugins/voice-compat/*`).
+
+Media WS settings:
+- `mediaWs`: `{ tokenFromMessageTimeoutMs }`
 
 ### Provider plugins
 
@@ -127,7 +134,7 @@ If you run behind a reverse proxy/load balancer, ensure it forwards those header
 
 1. Client calls `POST /voice/calls` (server-side) to create a call config and request an outbound call.
 2. Provider places the outbound call and hits `GET|POST /voice/webhook?callConfigId=<id>`.
-3. The webhook response instructs the provider to connect to `WS /voice/media?token=<...>`.
+3. The webhook response instructs the provider to connect to `WS /voice/media` with a signed token (usually as `?token=...`, or provided in the first WS message when query params can’t be preserved).
 4. The provider streams audio over the media WS; the compat bridges into the core realtime session APIs.
 
 Notes:
@@ -142,6 +149,14 @@ Inbound calls require a pre-existing `callConfigId` and stored call config (e.g.
 1. Your system stores a call config under a stable `callConfigId`.
 2. Your telephony provider is configured to call `GET|POST /voice/webhook?callConfigId=<id>` for inbound calls.
 3. The provider connects to `WS /voice/media` using the minted token returned in the webhook response.
+
+#### Media WS token delivery
+
+By default, the token is included in the `WS /voice/media` URL query as `?token=...`.
+
+If your provider cannot preserve WebSocket URL query parameters, the server can instead accept the token from the first WS message. Send a JSON message containing a `voiceMediaToken` string immediately after connect.
+
+This behavior is controlled by `server.extensions.voice.mediaWs.tokenFromMessageTimeoutMs` (default: `5000`). Set it to `0` to require `?token=...` in the URL.
 
 ## Examples
 

--- a/extensions/voice/internal/server.ts
+++ b/extensions/voice/internal/server.ts
@@ -61,6 +61,53 @@ function parseUrl(rawUrl: string | undefined): URL | null {
   }
 }
 
+function findDeepStringValueByKey(options: { value: unknown; key: string; maxDepth: number }): string | undefined {
+  const keyLower = String(options.key).toLowerCase();
+  const maxDepth = Math.max(0, Math.floor(options.maxDepth));
+
+  const visit = (value: unknown, depth: number): string | undefined => {
+    if (depth > maxDepth) return undefined;
+    if (!value || typeof value !== 'object') return undefined;
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const found = visit(item, depth + 1);
+        if (found) return found;
+      }
+      return undefined;
+    }
+
+    for (const [k, v] of Object.entries(value as any)) {
+      if (String(k).toLowerCase() === keyLower) {
+        if (typeof v === 'string') {
+          const trimmed = v.trim();
+          if (trimmed) return trimmed;
+        }
+      }
+      const found = visit(v, depth + 1);
+      if (found) return found;
+    }
+
+    return undefined;
+  };
+
+  return visit(options.value, 0);
+}
+
+function tryParseWsMessageJson(data: any): any | undefined {
+  try {
+    const buf = Buffer.from(data as any);
+    const text = buf.toString('utf-8');
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function approxWsMessageBytes(data: any): number {
+  return Buffer.byteLength(data as any);
+}
+
 function normalizeRequestId(value: string): string | undefined {
   if (!value) return undefined;
   const first = value.split(',')[0]!.trim();
@@ -552,6 +599,17 @@ export async function createVoiceServerRegistration(ctx: {
   const mediaWsMaxMessageBytes = getMediaWsMaxMessageBytes();
   const mediaWsMaxConcurrentSessions = getMediaWsMaxConcurrentSessions();
   const wss = new wsLib.WebSocketServer({ noServer: true, maxPayload: mediaWsMaxMessageBytes, perMessageDeflate: false });
+
+  const voiceMediaWsDefaults = asPlainObject((voiceDefaults as any)?.mediaWs) ?? {};
+  const mediaWsTokenFromMessageTimeoutMs = (() => {
+    const raw = (voiceMediaWsDefaults as any)?.tokenFromMessageTimeoutMs;
+    if (raw === undefined || raw === null || raw === '') return 5000;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return 5000;
+    const out = Math.floor(n);
+    if (out < 0) return 5000;
+    return out;
+  })();
 
   let draining = false;
   let activeMediaWs = 0;
@@ -1663,70 +1721,17 @@ export async function createVoiceServerRegistration(ctx: {
           return true;
         }
 
-        const token = String(url.searchParams.get('token') ?? '').trim();
-        const verified = verifyVoiceMediaToken(token);
-        if (!verified.ok) {
-          writeHttpUpgradeResponse(socket, 401, 'Unauthorized', 'Unauthorized');
-          socket.destroy();
-          return true;
-        }
-
-        const { callConfigId, voiceProvider, nonce, exp } = verified.payload;
-
-        if (activeMediaWs + pendingMediaWs >= mediaWsMaxConcurrentSessions) {
-          const logger = await resolveLogger(callConfigId);
-          safeLog(logger, 'warning', 'voice.media.rejected', { callConfigId, voiceProvider, reason: 'server_busy' });
-          writeHttpUpgradeResponse(socket, 503, 'Service Unavailable', 'Service Unavailable');
-          socket.destroy();
-          return true;
-        }
-
-        pendingMediaWs += 1;
-        pendingReserved = true;
-
-        const nowSeconds = Math.floor(Date.now() / 1000);
-        const ttlSeconds = Math.max(1, Math.ceil(exp - nowSeconds));
-        const nonceOk = await store.consumeNonceOnce(nonce, { ttlSeconds });
-        if (!nonceOk) {
-          const logger = await resolveLogger(callConfigId);
-          safeLog(logger, 'warning', 'voice.media.rejected', { callConfigId, voiceProvider, reason: 'nonce_replay' });
-          writeHttpUpgradeResponse(socket, 401, 'Unauthorized', 'Unauthorized');
-          socket.destroy();
-          releasePending();
-          return true;
-        }
-
-        const callConfig = await store.getConfig(callConfigId);
-        if (!callConfig) {
-          const logger = await resolveLogger(callConfigId);
-          safeLog(logger, 'warning', 'voice.media.rejected', { callConfigId, voiceProvider, reason: 'unknown_call_config' });
-          writeHttpUpgradeResponse(socket, 404, 'Not Found', 'Not Found');
-          socket.destroy();
-          releasePending();
-          return true;
-        }
-
-        const requestIdFromConfig = readTrimmedStringProperty((callConfig as any)?.metadata, 'requestId');
-        const requestId = requestIdFromConfig ? normalizeRequestId(requestIdFromConfig) : undefined;
-
-        if (String((callConfig as any).voiceProvider ?? '') !== voiceProvider) {
-          const logger = await resolveLogger(callConfigId);
-          safeLog(logger, 'warning', 'voice.media.rejected', { callConfigId, voiceProvider, reason: 'voice_provider_mismatch' });
-          writeHttpUpgradeResponse(socket, 401, 'Unauthorized', 'Unauthorized');
-          socket.destroy();
-          releasePending();
-          return true;
-        }
-
-        const logger = await resolveLogger(callConfigId);
-        const compat = await providerPlugins.getCompat(voiceProvider);
-        let providerDefaults: any | undefined;
-        try {
-          const manifest = await providerPlugins.getManifest?.(voiceProvider);
-          providerDefaults = (manifest as any)?.defaults;
-        } catch {}
-
-        wss.handleUpgrade(req, socket, head, (ws: any) => {
+        const beginMediaSession = (options: {
+          wsReal: any;
+          wsForCompat: any;
+          callConfigId: string;
+          callConfig: any;
+          voiceProvider: string;
+          requestId?: string;
+          logger: VoiceLogger | undefined;
+          compat: any;
+          providerDefaults?: any;
+        }) => {
           releasePending();
           activeMediaWs += 1;
 
@@ -1734,49 +1739,364 @@ export async function createVoiceServerRegistration(ctx: {
             activeMediaWs = Math.max(0, activeMediaWs - 1);
           };
 
-          metrics.mediaWsConnected(voiceProvider);
-          safeLog(logger, 'info', 'voice.media.connected', { callConfigId, voiceProvider, ...(requestId ? { requestId } : {}) });
+          metrics.mediaWsConnected(options.voiceProvider);
+          safeLog(options.logger, 'info', 'voice.media.connected', {
+            callConfigId: options.callConfigId,
+            voiceProvider: options.voiceProvider,
+            ...(options.requestId ? { requestId: options.requestId } : {})
+          });
           try {
-            ws.on?.('close', (code: number) => {
+            options.wsReal.on?.('close', (code: number) => {
               releaseActive();
-              metrics.mediaWsClosed(voiceProvider);
-              safeLog(logger, 'info', 'voice.media.closed', { callConfigId, voiceProvider, code: Number(code), ...(requestId ? { requestId } : {}) });
+              metrics.mediaWsClosed(options.voiceProvider);
+              safeLog(options.logger, 'info', 'voice.media.closed', {
+                callConfigId: options.callConfigId,
+                voiceProvider: options.voiceProvider,
+                code: Number(code),
+                ...(options.requestId ? { requestId: options.requestId } : {})
+              });
             });
-            ws.on?.('error', (err: any) => {
-              metrics.mediaWsError(voiceProvider);
-              safeLog(logger, 'error', 'voice.media.ws_error', { callConfigId, voiceProvider, message: err?.message ?? String(err), ...(requestId ? { requestId } : {}) });
+            options.wsReal.on?.('error', (err: any) => {
+              metrics.mediaWsError(options.voiceProvider);
+              safeLog(options.logger, 'error', 'voice.media.ws_error', {
+                callConfigId: options.callConfigId,
+                voiceProvider: options.voiceProvider,
+                message: err?.message ?? String(err),
+                ...(options.requestId ? { requestId: options.requestId } : {})
+              });
             });
           } catch {}
 
           void Promise.resolve()
             .then(() =>
-              compat.handleMediaConnection({
-                ws,
+              options.compat.handleMediaConnection({
+                ws: options.wsForCompat,
                 req,
-                callConfigId,
-                callConfig,
-                voiceProvider,
+                callConfigId: options.callConfigId,
+                callConfig: options.callConfig,
+                voiceProvider: options.voiceProvider,
                 registry: ctx.registry,
-                providerDefaults,
+                providerDefaults: options.providerDefaults,
                 store,
-                logger,
+                logger: options.logger,
                 events: {
-                  emit: (event: any) => eventsHub.emit(callConfigId, event)
+                  emit: (event: any) => eventsHub.emit(options.callConfigId, event)
                 },
                 metrics
               })
             )
-            .catch((err) => {
-              metrics.compatError('media_connection', voiceProvider);
-              safeLog(logger, 'error', 'voice.media.error', {
-                callConfigId,
-                voiceProvider,
-                ...(requestId ? { requestId } : {}),
+            .catch((err: any) => {
+              metrics.compatError('media_connection', options.voiceProvider);
+              safeLog(options.logger, 'error', 'voice.media.error', {
+                callConfigId: options.callConfigId,
+                voiceProvider: options.voiceProvider,
+                ...(options.requestId ? { requestId: options.requestId } : {}),
                 code: err?.code !== undefined ? String(err.code) : undefined,
                 message: err?.message ?? 'Media handler failed'
               });
-              try { ws.close(); } catch {}
+              try { options.wsReal.close(); } catch {}
             });
+        };
+
+        const urlToken = String(url.searchParams.get('token') ?? '').trim();
+        if (urlToken) {
+          const verified = verifyVoiceMediaToken(urlToken);
+          if (!verified.ok) {
+            writeHttpUpgradeResponse(socket, 401, 'Unauthorized', 'Unauthorized');
+            socket.destroy();
+            return true;
+          }
+
+          const { callConfigId, voiceProvider, nonce, exp } = verified.payload;
+
+          if (activeMediaWs + pendingMediaWs >= mediaWsMaxConcurrentSessions) {
+            const logger = await resolveLogger(callConfigId);
+            safeLog(logger, 'warning', 'voice.media.rejected', { callConfigId, voiceProvider, reason: 'server_busy' });
+            writeHttpUpgradeResponse(socket, 503, 'Service Unavailable', 'Service Unavailable');
+            socket.destroy();
+            return true;
+          }
+
+          pendingMediaWs += 1;
+          pendingReserved = true;
+
+          const nowSeconds = Math.floor(Date.now() / 1000);
+          const ttlSeconds = Math.max(1, Math.ceil(exp - nowSeconds));
+          const nonceOk = await store.consumeNonceOnce(nonce, { ttlSeconds });
+          if (!nonceOk) {
+            const logger = await resolveLogger(callConfigId);
+            safeLog(logger, 'warning', 'voice.media.rejected', { callConfigId, voiceProvider, reason: 'nonce_replay' });
+            writeHttpUpgradeResponse(socket, 401, 'Unauthorized', 'Unauthorized');
+            socket.destroy();
+            releasePending();
+            return true;
+          }
+
+          const callConfig = await store.getConfig(callConfigId);
+          if (!callConfig) {
+            const logger = await resolveLogger(callConfigId);
+            safeLog(logger, 'warning', 'voice.media.rejected', { callConfigId, voiceProvider, reason: 'unknown_call_config' });
+            writeHttpUpgradeResponse(socket, 404, 'Not Found', 'Not Found');
+            socket.destroy();
+            releasePending();
+            return true;
+          }
+
+          const requestIdFromConfig = readTrimmedStringProperty((callConfig as any)?.metadata, 'requestId');
+          const requestId = requestIdFromConfig ? normalizeRequestId(requestIdFromConfig) : undefined;
+
+          if (String((callConfig as any).voiceProvider ?? '') !== voiceProvider) {
+            const logger = await resolveLogger(callConfigId);
+            safeLog(logger, 'warning', 'voice.media.rejected', { callConfigId, voiceProvider, reason: 'voice_provider_mismatch' });
+            writeHttpUpgradeResponse(socket, 401, 'Unauthorized', 'Unauthorized');
+            socket.destroy();
+            releasePending();
+            return true;
+          }
+
+          const logger = await resolveLogger(callConfigId);
+          const compat = await providerPlugins.getCompat(voiceProvider);
+          let providerDefaults: any | undefined;
+          try {
+            const manifest = await providerPlugins.getManifest?.(voiceProvider);
+            providerDefaults = (manifest as any)?.defaults;
+          } catch {}
+
+          wss.handleUpgrade(req, socket, head, (ws: any) => {
+            beginMediaSession({
+              wsReal: ws,
+              wsForCompat: ws,
+              callConfigId,
+              callConfig,
+              voiceProvider,
+              requestId,
+              logger,
+              compat,
+              providerDefaults
+            });
+          });
+
+          return true;
+        }
+
+        // Some providers cannot preserve WS URL query parameters. Allow the token to be provided
+        // via the first WS message (e.g. `voiceMediaToken`) before delegating to the compat.
+        if (mediaWsTokenFromMessageTimeoutMs <= 0) {
+          writeHttpUpgradeResponse(socket, 401, 'Unauthorized', 'Unauthorized');
+          socket.destroy();
+          return true;
+        }
+
+        if (activeMediaWs + pendingMediaWs >= mediaWsMaxConcurrentSessions) {
+          writeHttpUpgradeResponse(socket, 503, 'Service Unavailable', 'Service Unavailable');
+          socket.destroy();
+          return true;
+        }
+
+        pendingMediaWs += 1;
+        pendingReserved = true;
+        wss.handleUpgrade(req, socket, head, (ws: any) => {
+          const tokenKey = 'voiceMediaToken';
+          const maxDepth = 8;
+          const maxBufferedBytes = Math.min(256 * 1024, Math.max(0, Math.floor(mediaWsMaxMessageBytes)));
+
+          let buffered: any[][] = [];
+          let bufferedBytes = 0;
+          let bufferFlushed = false;
+          let bufferingEnabled = true;
+
+          const messageListeners: Array<(...args: any[]) => void> = [];
+
+          let tokenResolved = false;
+          let resolveToken: ((token: string) => void) | undefined;
+          let rejectToken: ((error: any) => void) | undefined;
+          const tokenPromise = new Promise<string>((resolve, reject) => {
+            resolveToken = resolve;
+            rejectToken = reject;
+          });
+
+          const closeWith = (code: number, reason: string) => {
+            try { ws.close(code, reason); } catch {}
+          };
+
+          const timeout = setTimeout(() => {
+            closeWith(1008, 'Unauthorized');
+            rejectToken?.(new Error('missing_ws_token'));
+          }, Math.floor(mediaWsTokenFromMessageTimeoutMs));
+          if (typeof (timeout as any)?.unref === 'function') {
+            (timeout as any).unref();
+          }
+
+          const flushBufferTo = (cb: (...args: any[]) => void) => {
+            if (bufferFlushed) return;
+            bufferFlushed = true;
+            bufferingEnabled = false;
+            const items = buffered;
+            buffered = [];
+            bufferedBytes = 0;
+            for (const args of items) {
+              try { cb(...args); } catch {}
+            }
+          };
+
+          const wsProxy: any = {
+            get readyState() {
+              return ws.readyState;
+            },
+            send: (...args: any[]) => ws.send(...args),
+            close: (code?: number, reason?: string) => ws.close(code, reason),
+            terminate: () => ws.terminate?.(),
+            on: (event: string, cb: (...args: any[]) => void) => {
+              if (event === 'message') {
+                messageListeners.push(cb);
+                flushBufferTo(cb);
+                return wsProxy;
+              }
+              ws.on?.(event, cb);
+              return wsProxy;
+            },
+            off: (event: string, cb: (...args: any[]) => void) => {
+              if (event === 'message') {
+                const idx = messageListeners.indexOf(cb);
+                if (idx >= 0) messageListeners.splice(idx, 1);
+                return wsProxy;
+              }
+              ws.off?.(event, cb);
+              return wsProxy;
+            },
+            once: (event: string, cb: (...args: any[]) => void) => {
+              if (event === 'message') {
+                const wrapper = (...args: any[]) => {
+                  wsProxy.off('message', wrapper);
+                  cb(...args);
+                };
+                wsProxy.on('message', wrapper);
+                return wsProxy;
+              }
+              ws.once?.(event, cb);
+              return wsProxy;
+            },
+            emit: (...args: any[]) => ws.emit?.(...args)
+          };
+
+          const onMessage = (...args: any[]) => {
+            const data = args[0];
+
+            if (bufferingEnabled) {
+              buffered.push(args);
+              bufferedBytes += approxWsMessageBytes(data);
+              if (bufferedBytes > maxBufferedBytes) {
+                closeWith(1009, 'Message too large');
+                return;
+              }
+            }
+
+            if (messageListeners.length > 0) {
+              for (const cb of messageListeners) {
+                try { cb(...args); } catch {}
+              }
+            }
+
+            if (!tokenResolved) {
+              const parsed = tryParseWsMessageJson(data);
+              const token = parsed
+                ? findDeepStringValueByKey({ value: parsed, key: tokenKey, maxDepth })
+                : undefined;
+              if (token) {
+                tokenResolved = true;
+                clearTimeout(timeout);
+                resolveToken?.(token);
+              }
+            }
+          };
+
+          ws.on?.('message', onMessage);
+          ws.on?.('close', () => {
+            clearTimeout(timeout);
+            rejectToken?.(new Error('ws_closed'));
+          });
+          ws.on?.('error', (err: any) => {
+            clearTimeout(timeout);
+            rejectToken?.(err ?? new Error('ws_error'));
+          });
+
+          void (async () => {
+            let token: string;
+            try {
+              token = await tokenPromise;
+            } catch {
+              releasePending();
+              return;
+            }
+
+            const verified = verifyVoiceMediaToken(token);
+            if (!verified.ok) {
+              releasePending();
+              closeWith(1008, 'Unauthorized');
+              return;
+            }
+
+            const { callConfigId, voiceProvider, nonce, exp } = verified.payload;
+
+            const nowSeconds = Math.floor(Date.now() / 1000);
+            const ttlSeconds = Math.max(1, Math.ceil(exp - nowSeconds));
+            const nonceOk = await store.consumeNonceOnce(nonce, { ttlSeconds });
+            if (!nonceOk) {
+              const logger = await resolveLogger(callConfigId);
+              safeLog(logger, 'warning', 'voice.media.rejected', { callConfigId, voiceProvider, reason: 'nonce_replay' });
+              releasePending();
+              closeWith(1008, 'Unauthorized');
+              return;
+            }
+
+            const callConfig = await store.getConfig(callConfigId);
+            if (!callConfig) {
+              const logger = await resolveLogger(callConfigId);
+              safeLog(logger, 'warning', 'voice.media.rejected', { callConfigId, voiceProvider, reason: 'unknown_call_config' });
+              releasePending();
+              closeWith(1008, 'Not Found');
+              return;
+            }
+
+            const requestIdFromConfig = readTrimmedStringProperty((callConfig as any)?.metadata, 'requestId');
+            const requestId = requestIdFromConfig ? normalizeRequestId(requestIdFromConfig) : undefined;
+
+            if (String((callConfig as any).voiceProvider ?? '') !== voiceProvider) {
+              const logger = await resolveLogger(callConfigId);
+              safeLog(logger, 'warning', 'voice.media.rejected', { callConfigId, voiceProvider, reason: 'voice_provider_mismatch' });
+              releasePending();
+              closeWith(1008, 'Unauthorized');
+              return;
+            }
+
+            const logger = await resolveLogger(callConfigId);
+            const compat = await providerPlugins.getCompat(voiceProvider);
+            let providerDefaults: any | undefined;
+            try {
+              const manifest = await providerPlugins.getManifest?.(voiceProvider);
+              providerDefaults = (manifest as any)?.defaults;
+            } catch {}
+
+            // Ensure downstream compats that verify the token via `req.url` still work.
+            const injected = parseUrl(req.url) ?? new URL('/voice/media', 'http://localhost');
+            injected.searchParams.set('token', token);
+            req.url = `${injected.pathname}${injected.search}`;
+
+            beginMediaSession({
+              wsReal: ws,
+              wsForCompat: wsProxy,
+              callConfigId,
+              callConfig,
+              voiceProvider,
+              requestId,
+              logger,
+              compat,
+              providerDefaults
+            });
+          })().catch(() => {
+            releasePending();
+            closeWith(1011, 'Internal Error');
+          });
         });
 
         return true;

--- a/extensions/voice/tests/integration/voice-webhook-media.test.ts
+++ b/extensions/voice/tests/integration/voice-webhook-media.test.ts
@@ -1,9 +1,11 @@
 import { jest } from '@jest/globals';
+import crypto from 'crypto';
 import http from 'http';
 import * as path from 'path';
 
 import voiceExtension from '../../index.ts';
 import { createInMemoryVoiceCallConfigStore } from '../../internal/call-config-store/index.js';
+import { createSignedWsToken } from '@/modules/security/index.ts';
 import { attachUpgradeRouter } from '@/modules/server/internal/transport/upgrade-router.ts';
 import { closeServerAndSockets, trackServerSockets, unrefServer } from '../helpers/http-server.ts';
 
@@ -15,11 +17,32 @@ function extractStreamUrl(xml: string): string {
   return match[1];
 }
 
-function openWs(url: string): Promise<{ ws: WebSocket; messages: any[]; closePromise: Promise<void> }> {
+function toWsUrl(httpBaseUrl: string, pathname: string): string {
+  const url = new URL(pathname, httpBaseUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  return url.toString();
+}
+
+function mintVoiceMediaToken(payload: { callConfigId: string; voiceProvider: string }): string {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return createSignedWsToken({
+    secret: 'secret',
+    payload: {
+      iat: nowSeconds,
+      exp: nowSeconds + 60,
+      nonce: crypto.randomBytes(18).toString('base64url'),
+      purpose: 'voice_media',
+      callConfigId: payload.callConfigId,
+      voiceProvider: payload.voiceProvider
+    } as any
+  });
+}
+
+function openWs(url: string): Promise<{ ws: WebSocket; messages: any[]; closePromise: Promise<{ code: number; reason: string }> }> {
   const ws = new WebSocket(url);
   const messages: any[] = [];
-  const closePromise = new Promise<void>((resolve) => {
-    ws.onclose = () => resolve();
+  const closePromise = new Promise<{ code: number; reason: string }>((resolve) => {
+    ws.onclose = (evt: any) => resolve({ code: Number(evt?.code ?? 0), reason: String(evt?.reason ?? '') });
   });
 
   ws.onmessage = (evt: any) => {
@@ -75,7 +98,7 @@ async function waitForMessage(messages: any[], predicate: (m: any) => boolean, t
   throw new Error('Timed out waiting for WS message');
 }
 
-async function startHarness(options: { store: any; providerPlugins?: any; logging?: any; httpConfig?: any }) {
+async function startHarness(options: { store: any; providerPlugins?: any; logging?: any; httpConfig?: any; preUpgradeHandlers?: any[] }) {
   let handleHttp: any = async () => false;
   const server = http.createServer((req, res) => {
     void (async () => {
@@ -89,6 +112,7 @@ async function startHarness(options: { store: any; providerPlugins?: any; loggin
   const sockets = trackServerSockets(server);
 
   const upgradeRouter = attachUpgradeRouter(server);
+  const preUnregister: Array<() => void> = [];
 
   const reg = await (voiceExtension as any).registerServer({
     server,
@@ -102,6 +126,11 @@ async function startHarness(options: { store: any; providerPlugins?: any; loggin
   });
 
   handleHttp = reg.handleHttp;
+  for (const handler of options.preUpgradeHandlers ?? []) {
+    if (typeof handler === 'function') {
+      preUnregister.push(upgradeRouter.register(handler));
+    }
+  }
   const unregister = upgradeRouter.register(reg.handleUpgrade);
 
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
@@ -112,6 +141,9 @@ async function startHarness(options: { store: any; providerPlugins?: any; loggin
 
   const close = async () => {
     unregister();
+    for (const fn of preUnregister) {
+      try { fn(); } catch {}
+    }
     upgradeRouter.close();
     await reg.close?.();
     await closeServerAndSockets(server, sockets);
@@ -195,6 +227,547 @@ describe('extensions/voice: webhook + media wiring', () => {
 
       // Token replay should fail (nonce is consume-once).
       await expect(openWs(wsUrl)).rejects.toBeDefined();
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test('end-to-end: /voice/media accepts token via first WS message when URL query is missing (replay rejected)', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'test'
+      },
+      { ttlSeconds: 60 }
+    );
+
+    const harness = await startHarness({
+      store,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 250 } } } }
+    });
+    try {
+      const res = await fetch(new URL('/voice/webhook?callConfigId=cfg_1', harness.baseUrl), {
+        headers: { 'x-test-signature': 'ok' }
+      });
+      expect(res.status).toBe(200);
+      const xml = await res.text();
+
+      const wsUrlWithToken = new URL(extractStreamUrl(xml));
+      const token = String(wsUrlWithToken.searchParams.get('token') ?? '').trim();
+      expect(token).toBeTruthy();
+      wsUrlWithToken.searchParams.delete('token');
+      const wsUrlWithoutToken = wsUrlWithToken.toString();
+      expect(wsUrlWithoutToken).toContain('/voice/media');
+      expect(wsUrlWithoutToken).not.toContain('token=');
+
+      const first = await openWs(wsUrlWithoutToken);
+      first.ws.send(JSON.stringify({ voiceMediaToken: token }));
+      const ready = await waitForMessage(first.messages, m => m?.type === 'ready');
+      expect(ready.callConfigId).toBe('cfg_1');
+      await first.closePromise;
+
+      const second = await openWs(wsUrlWithoutToken);
+      second.ws.send(JSON.stringify({ voiceMediaToken: token }));
+      const closeInfo = await second.closePromise;
+      expect(closeInfo.code).toBe(1008);
+      expect(second.messages.some(m => m?.type === 'ready')).toBe(false);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test('end-to-end: token can be found deep in JSON and buffered messages are replayed to the compat', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_proxy_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'p_proxy'
+      },
+      { ttlSeconds: 60 }
+    );
+
+    let resolvePing: (() => void) | undefined;
+    const pingSeen = new Promise<void>((resolve) => {
+      resolvePing = resolve;
+    });
+
+    const providerPlugins = {
+      getManifest: async () => ({ defaults: {} }),
+      getCompat: async () => ({
+        handleMediaConnection: async ({ ws, callConfigId }: any) => {
+          const messagesSeen: string[] = [];
+          const handler1 = (data: any) => {
+            const text = typeof data === 'string' ? data : Buffer.from(data).toString('utf-8');
+            messagesSeen.push(text);
+            if (text.includes('clientPing')) {
+              resolvePing?.();
+            }
+          };
+
+          const handler2 = jest.fn();
+          const handlerThrow = () => {
+            throw new Error('boom');
+          };
+
+          // Exercise the buffered WS proxy behavior.
+          ws.on('message', handler1);
+          ws.on('message', handler2);
+          ws.off('message', handler2);
+          ws.on('message', handlerThrow);
+          ws.once('message', jest.fn());
+
+          const onClose = jest.fn();
+          ws.on('close', onClose);
+          ws.off('close', onClose);
+          ws.once('close', jest.fn());
+
+          const state = Number(ws.readyState);
+          ws.send(JSON.stringify({ type: 'ready', callConfigId, readyState: state, bufferedCount: messagesSeen.length }));
+
+          const timeout = setTimeout(() => resolvePing?.(), 2000);
+          if (typeof (timeout as any)?.unref === 'function') {
+            (timeout as any).unref();
+          }
+          await pingSeen;
+          clearTimeout(timeout);
+
+          ws.emit('message', Buffer.from(JSON.stringify({ serverEmitted: true })));
+          ws.emit('error', new Error('boom'));
+          ws.emit('error');
+          ws.close();
+          ws.terminate?.();
+        }
+      })
+    };
+
+    const harness = await startHarness({
+      store,
+      providerPlugins,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 500 } } } }
+    });
+
+    try {
+      const wsUrl = toWsUrl(harness.baseUrl, '/voice/media');
+      const token = mintVoiceMediaToken({ callConfigId: 'cfg_proxy_1', voiceProvider: 'p_proxy' });
+
+      const client = await openWs(wsUrl);
+      client.ws.send('not-json');
+      client.ws.send(JSON.stringify({ foo: [1, 2, 3], bar: { baz: true } }));
+      const deep: any = {};
+      let cursor = deep;
+      for (let i = 0; i < 12; i++) {
+        cursor.n = {};
+        cursor = cursor.n;
+      }
+      client.ws.send(JSON.stringify(deep));
+      client.ws.send(JSON.stringify({ start: { customParameters: [{ voiceMediaToken: token }] } }));
+
+      const ready = await waitForMessage(client.messages, m => m?.type === 'ready');
+      expect(ready.callConfigId).toBe('cfg_proxy_1');
+
+      client.ws.send(JSON.stringify({ clientPing: true }));
+      await client.closePromise;
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test('end-to-end: closes when token is not provided within the configured timeout', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_timeout_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'p_timeout'
+      },
+      { ttlSeconds: 60 }
+    );
+
+    const harness = await startHarness({
+      store,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 25 } } } }
+    });
+
+    try {
+      const wsUrl = toWsUrl(harness.baseUrl, '/voice/media');
+      const client = await openWs(wsUrl);
+      const closeInfo = await client.closePromise;
+      expect(closeInfo.code).toBe(1008);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test('end-to-end: closes with 1009 when pre-auth buffered messages exceed limit', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_big_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'p_big'
+      },
+      { ttlSeconds: 60 }
+    );
+
+    const harness = await startHarness({
+      store,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 500 } } } }
+    });
+
+    try {
+      const wsUrl = toWsUrl(harness.baseUrl, '/voice/media');
+      const client = await openWs(wsUrl);
+      client.ws.send('x'.repeat(300000));
+      const closeInfo = await client.closePromise;
+      expect(closeInfo.code).toBe(1009);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test('end-to-end: rejects upgrade with 503 when media WS capacity is reached (token-in-message path)', async () => {
+    process.env.LLM_ADAPTER_VOICE_MEDIA_WS_MAX_CONCURRENT_SESSIONS = '1';
+
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_busy_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'p_busy'
+      },
+      { ttlSeconds: 60 }
+    );
+
+    const providerPlugins = {
+      getManifest: async () => ({ defaults: {} }),
+      getCompat: async () => ({
+        handleMediaConnection: async ({ ws, callConfigId }: any) => {
+          try {
+            ws.send(JSON.stringify({ type: 'ready', callConfigId }));
+          } catch {}
+          // keep open until the client closes
+        }
+      })
+    };
+
+    const harness = await startHarness({
+      store,
+      providerPlugins,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 500 } } } }
+    });
+
+    try {
+      const wsUrl = toWsUrl(harness.baseUrl, '/voice/media');
+      const token = mintVoiceMediaToken({ callConfigId: 'cfg_busy_1', voiceProvider: 'p_busy' });
+
+      const first = await openWs(wsUrl);
+      first.ws.send(JSON.stringify({ voiceMediaToken: token }));
+      await waitForMessage(first.messages, m => m?.type === 'ready');
+
+      await expect(openWs(wsUrl)).rejects.toBeDefined();
+
+      first.ws.close();
+      await first.closePromise;
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test('end-to-end: closes when token payload refers to unknown callConfigId or mismatched voiceProvider', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_known_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'p_known'
+      },
+      { ttlSeconds: 60 }
+    );
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_missing_provider_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: undefined
+      } as any,
+      { ttlSeconds: 60 }
+    );
+
+    const providerPlugins = {
+      getManifest: async () => ({ defaults: {} }),
+      getCompat: async () => ({
+        handleMediaConnection: async () => {
+          // should not be reached
+        }
+      })
+    };
+
+    const harness = await startHarness({
+      store,
+      providerPlugins,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 500 } } } }
+    });
+
+    try {
+      const wsUrl = toWsUrl(harness.baseUrl, '/voice/media');
+
+      // Unknown call config
+      const unknownToken = mintVoiceMediaToken({ callConfigId: 'missing_cfg', voiceProvider: 'p_known' });
+      const a = await openWs(wsUrl);
+      a.ws.send(JSON.stringify({ voiceMediaToken: unknownToken }));
+      const closedA = await a.closePromise;
+      expect(closedA.code).toBe(1008);
+
+      // Voice provider mismatch
+      const mismatchToken = mintVoiceMediaToken({ callConfigId: 'cfg_known_1', voiceProvider: 'other' });
+      const b = await openWs(wsUrl);
+      b.ws.send(JSON.stringify({ voiceMediaToken: mismatchToken }));
+      const closedB = await b.closePromise;
+      expect(closedB.code).toBe(1008);
+
+      // Missing voiceProvider in call config (nullish coalescing branch)
+      const missingProviderToken = mintVoiceMediaToken({ callConfigId: 'cfg_missing_provider_1', voiceProvider: 'p_known' });
+      const c = await openWs(wsUrl);
+      c.ws.send(JSON.stringify({ voiceMediaToken: missingProviderToken }));
+      const closedC = await c.closePromise;
+      expect(closedC.code).toBe(1008);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test('end-to-end: token-in-message recovers when req.url becomes invalid before token injection', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_req_mutate_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'p_req_mutate'
+      },
+      { ttlSeconds: 60 }
+    );
+
+    let seenReqUrl: string | undefined;
+    let upgradeReq: any;
+
+    const providerPlugins = {
+      getCompat: async () => ({
+        handleMediaConnection: async ({ ws, req }: any) => {
+          seenReqUrl = String(req?.url ?? '');
+          try {
+            ws.send(JSON.stringify({ type: 'ready' }));
+          } catch {}
+          try { ws.close(); } catch {}
+        }
+      })
+    };
+
+    const harness = await startHarness({
+      store,
+      providerPlugins,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 500 } } } },
+      preUpgradeHandlers: [
+        ({ req, pathname }: any) => {
+          if (pathname === '/voice/media') upgradeReq = req;
+          return false;
+        }
+      ]
+    });
+
+    try {
+      const wsUrl = toWsUrl(harness.baseUrl, '/voice/media');
+      const token = mintVoiceMediaToken({ callConfigId: 'cfg_req_mutate_1', voiceProvider: 'p_req_mutate' });
+
+      const client = await openWs(wsUrl);
+      upgradeReq.url = 'http://%';
+      client.ws.send(JSON.stringify({ voiceMediaToken: token }));
+
+      await waitForMessage(client.messages, m => m?.type === 'ready');
+      await client.closePromise;
+
+      expect(seenReqUrl).toContain('/voice/media?token=');
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test('end-to-end: closes when token in first message is invalid', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_bad_token_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'p_bad_token'
+      },
+      { ttlSeconds: 60 }
+    );
+
+    const providerPlugins = {
+      getCompat: async () => ({
+        handleMediaConnection: async () => {
+          // should not be reached
+        }
+      })
+    };
+
+    const harness = await startHarness({
+      store,
+      providerPlugins,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 500 } } } }
+    });
+
+    try {
+      const wsUrl = toWsUrl(harness.baseUrl, '/voice/media');
+      const client = await openWs(wsUrl);
+      client.ws.send(JSON.stringify({ voiceMediaToken: 'bad' }));
+      const closeInfo = await client.closePromise;
+      expect(closeInfo.code).toBe(1008);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test('end-to-end: token-in-message works without provider manifest defaults and preserves requestId', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_reqid_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'p_reqid',
+        metadata: { requestId: 'req_1' }
+      } as any,
+      { ttlSeconds: 60 }
+    );
+
+    const providerPlugins = {
+      getCompat: async () => ({
+        handleMediaConnection: async ({ ws, callConfigId }: any) => {
+          try {
+            ws.send(JSON.stringify({ type: 'ready', callConfigId }));
+          } catch {}
+          try { ws.close(); } catch {}
+        }
+      })
+    };
+
+    const harness = await startHarness({
+      store,
+      providerPlugins,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 500 } } } }
+    });
+
+    try {
+      const wsUrl = toWsUrl(harness.baseUrl, '/voice/media');
+      const token = mintVoiceMediaToken({ callConfigId: 'cfg_reqid_1', voiceProvider: 'p_reqid' });
+      const client = await openWs(wsUrl);
+      client.ws.send(JSON.stringify({ voiceMediaToken: token }));
+      const ready = await waitForMessage(client.messages, m => m?.type === 'ready');
+      expect(ready.callConfigId).toBe('cfg_reqid_1');
+      await client.closePromise;
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test('end-to-end: closes with 1011 when the compat lookup fails in token-in-message flow', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_err_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'p_err'
+      },
+      { ttlSeconds: 60 }
+    );
+
+    const providerPlugins = {
+      getCompat: async () => {
+        throw new Error('boom');
+      }
+    };
+
+    const harness = await startHarness({
+      store,
+      providerPlugins,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 500 } } } }
+    });
+
+    try {
+      const wsUrl = toWsUrl(harness.baseUrl, '/voice/media');
+      const token = mintVoiceMediaToken({ callConfigId: 'cfg_err_1', voiceProvider: 'p_err' });
+
+      const client = await openWs(wsUrl);
+      client.ws.send(JSON.stringify({ voiceMediaToken: token }));
+      const closeInfo = await client.closePromise;
+      expect(closeInfo.code).toBe(1011);
     } finally {
       await harness.close();
     }

--- a/extensions/voice/tests/unit/voice-server.upgrade.test.ts
+++ b/extensions/voice/tests/unit/voice-server.upgrade.test.ts
@@ -89,7 +89,8 @@ describe('extensions/voice: server upgrade handler', () => {
       pluginsPath: './plugins',
       upgradeRouter: {} as any,
       store,
-      providerPlugins: { getCompat: jest.fn() } as any
+      providerPlugins: { getCompat: jest.fn() } as any,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 0 } } } }
     });
 
     const socketA = makeSocket();
@@ -202,6 +203,53 @@ describe('extensions/voice: server upgrade handler', () => {
     const socket = makeSocket();
     await expect(reg.handleUpgrade({ req: { url: '/voice/media?token=bad' } as any, socket, head: Buffer.alloc(0), pathname: '/voice/media' })).resolves.toBe(true);
     expect(extractStatusLine(socket)).toContain('503 Service Unavailable');
+    expect(socket.destroy).toHaveBeenCalled();
+  });
+
+  test('tokenFromMessageTimeoutMs falls back for invalid config values', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    const common = {
+      server: {} as any,
+      registry: {},
+      pluginsPath: './plugins',
+      upgradeRouter: {} as any,
+      store,
+      providerPlugins: { getCompat: jest.fn() } as any
+    };
+
+    const regA = await createVoiceServerRegistration({
+      ...common,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: 'nope' } } } }
+    });
+    await regA.close();
+
+    const regB = await createVoiceServerRegistration({
+      ...common,
+      httpConfig: { extensions: { voice: { mediaWs: { tokenFromMessageTimeoutMs: -1 } } } }
+    });
+    await regB.close();
+  });
+
+  test('gracefully handles early errors before reserving pending capacity', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    const reg = await createVoiceServerRegistration({
+      server: {} as any,
+      registry: {},
+      pluginsPath: './plugins',
+      upgradeRouter: {} as any,
+      store,
+      providerPlugins: { getCompat: jest.fn() } as any
+    });
+
+    const socket = makeSocket();
+    const req = {
+      get url() {
+        throw new Error('boom');
+      }
+    } as any;
+
+    await expect(reg.handleUpgrade({ req, socket, head: Buffer.alloc(0), pathname: '/voice/media' })).resolves.toBe(true);
+    expect(extractStatusLine(socket)).toContain('500 Internal Server Error');
     expect(socket.destroy).toHaveBeenCalled();
   });
 

--- a/kernel/internal/defaults.ts
+++ b/kernel/internal/defaults.ts
@@ -97,6 +97,9 @@ const FALLBACK_DEFAULTS: DefaultSettings = {
       voice: {
         events: {
           keepAliveIntervalMs: 15000
+        },
+        mediaWs: {
+          tokenFromMessageTimeoutMs: 5000
         }
       }
     }

--- a/plugins/configs/defaults.json
+++ b/plugins/configs/defaults.json
@@ -106,6 +106,9 @@
             "voice": {
                 "events": {
                     "keepAliveIntervalMs": "${LLM_ADAPTER_VOICE_EVENTS_KEEPALIVE_INTERVAL_MS:-15000}"
+                },
+                "mediaWs": {
+                    "tokenFromMessageTimeoutMs": "${LLM_ADAPTER_VOICE_MEDIA_WS_TOKEN_FROM_MESSAGE_TIMEOUT_MS:-5000}"
                 }
             }
         }

--- a/plugins/voice-compat/twilio/README.md
+++ b/plugins/voice-compat/twilio/README.md
@@ -11,6 +11,16 @@ This directory is provider-specific by design and may reference provider convent
 - Enforce media WS token binding (purpose + identifiers) before bridging.
 - Initiate outbound calls.
 
+## Media WS token delivery
+
+The voice extension requires a signed token for `WS /voice/media`.
+
+Twilio Media Streams may drop query parameters on the WebSocket URL. This compat passes the token via TwiML `<Parameter>` (name: `voiceMediaToken`) attached to the `<Stream>` element.
+
+This requires token-in-message support to be enabled on the voice extension (`server.extensions.voice.mediaWs.tokenFromMessageTimeoutMs > 0`, default: `5000`).
+
+For safety, `voiceMediaToken` is treated as a reserved custom parameter and is stripped before call metadata is surfaced to the realtime session.
+
 ## Configuration
 
 This compat reads provider defaults from the voice provider manifest (see `plugins/voice-providers/twilio.json`).

--- a/plugins/voice-compat/twilio/index.ts
+++ b/plugins/voice-compat/twilio/index.ts
@@ -16,6 +16,18 @@ function escapeXmlAttr(value: string): string {
     .replace(/'/g, '&apos;');
 }
 
+function splitMediaWsUrl(mediaWsUrl: string): { wsUrl: string; token: string } {
+  const raw = String(mediaWsUrl);
+  try {
+    const url = new URL(raw);
+    const token = String(url.searchParams.get('token') ?? '').trim();
+    url.searchParams.delete('token');
+    return { wsUrl: url.toString(), token };
+  } catch {
+    return { wsUrl: raw, token: '' };
+  }
+}
+
 function buildTwiMLConnectStream(options: { wsUrl: string; parameters: Record<string, string> }): string {
   const wsUrl = escapeXmlAttr(String(options.wsUrl));
 
@@ -184,13 +196,16 @@ export default class TwilioVoiceCompat {
     const from = typeof callConfig.from === 'string' ? callConfig.from : '';
     const direction = String(callConfig.direction ?? '');
 
+    const split = splitMediaWsUrl(String(options.mediaWsUrl));
+
     const xml = buildTwiMLConnectStream({
-      wsUrl: String(options.mediaWsUrl),
+      wsUrl: split.wsUrl,
       parameters: {
         callConfigId,
         to,
         from,
-        direction
+        direction,
+        voiceMediaToken: split.token
       }
     });
 
@@ -660,9 +675,10 @@ export default class TwilioVoiceCompat {
       url.searchParams.set('callConfigId', callConfigId);
       form.set('Url', url.toString());
     } else if (mode === 'twiml') {
+      const split = splitMediaWsUrl(String(options.mediaWsUrl));
       const twiml = buildTwiMLConnectStream({
-        wsUrl: String(options.mediaWsUrl),
-        parameters: { callConfigId, to, from, direction: 'outbound' }
+        wsUrl: split.wsUrl,
+        parameters: { callConfigId, to, from, direction: 'outbound', voiceMediaToken: split.token }
       });
       form.set('Twiml', twiml);
     } else {

--- a/plugins/voice-compat/twilio/tests/unit/twilio-voice-compat.test.ts
+++ b/plugins/voice-compat/twilio/tests/unit/twilio-voice-compat.test.ts
@@ -144,7 +144,10 @@ describe('plugins/voice-compat/twilio', () => {
 
     expect(res.status).toBe(200);
     expect(res.headers['Content-Type']).toContain('text/xml');
-    expect(res.body).toContain('voice/media?token=abc');
+    expect(res.body).toContain('voice/media');
+    expect(res.body).not.toContain('token=');
+    expect(res.body).toContain('name=\"voiceMediaToken\"');
+    expect(res.body).toContain('value=\"abc\"');
     expect(res.body).toContain('callConfigId');
     expect(res.body).toContain('cfg_1');
     expect(res.body).toContain('direction');
@@ -178,6 +181,36 @@ describe('plugins/voice-compat/twilio', () => {
 
     expect(res.body).toContain('callConfigId');
     expect(res.body).toContain('cfg_1');
+  });
+
+  test('createWebhookResponse tolerates invalid mediaWsUrl and omits voiceMediaToken', async () => {
+    const compat = new TwilioVoiceCompat();
+    const res = await compat.createWebhookResponse({
+      req: new http.IncomingMessage(null as any),
+      callConfigId: 'cfg_1',
+      callConfig: { to: '+1', from: '+2', direction: 'inbound' },
+      voiceProvider: 'twilio',
+      mediaWsUrl: 'not-a-url'
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('url=\"not-a-url\"');
+    expect(res.body).not.toContain('name=\"voiceMediaToken\"');
+  });
+
+  test('createWebhookResponse omits voiceMediaToken when mediaWsUrl has no token param', async () => {
+    const compat = new TwilioVoiceCompat();
+    const res = await compat.createWebhookResponse({
+      req: new http.IncomingMessage(null as any),
+      callConfigId: 'cfg_1',
+      callConfig: { to: '+1', from: '+2', direction: 'inbound' },
+      voiceProvider: 'twilio',
+      mediaWsUrl: 'wss://example.test/voice/media'
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('url=\"wss://example.test/voice/media\"');
+    expect(res.body).not.toContain('name=\"voiceMediaToken\"');
   });
 
   test('handleMediaConnection merges systemPrompt + metadata and bridges start/stop', async () => {
@@ -1657,7 +1690,10 @@ describe('plugins/voice-compat/twilio', () => {
       expect(body.get('To')).toBe('+15551234567');
       expect(body.get('From')).toBe('+15557654321');
       expect(body.get('Url')).toBeNull();
-      expect(String(body.get('Twiml'))).toContain('voice/media?token=abc');
+      expect(String(body.get('Twiml'))).toContain('voice/media');
+      expect(String(body.get('Twiml'))).not.toContain('token=');
+      expect(String(body.get('Twiml'))).toContain('name=\"voiceMediaToken\"');
+      expect(String(body.get('Twiml'))).toContain('value=\"abc\"');
       expect(String(body.get('Twiml'))).toContain('cfg_1');
       expect(String(body.get('Twiml'))).toContain('outbound');
     } finally {

--- a/plugins/voice-modules/twilio-media-streams/README.md
+++ b/plugins/voice-modules/twilio-media-streams/README.md
@@ -125,6 +125,7 @@ Notes:
 - `callSid` / `accountSid` are read from the Twilio `start` payload (if missing they default to `""`).
 - `from`, `to`, and `direction` are best provided via TwiML `<Parameter>` values (Twilio places them under `start.customParameters`).
 - `direction` accepts `direction` or `callDirection` (case-insensitive). Any value other than `"outbound"` is treated as `"inbound"`.
+- `voiceMediaToken` is treated as a reserved custom parameter and is stripped from `customParameters` before metadata is surfaced.
 
 ---
 

--- a/plugins/voice-modules/twilio-media-streams/internal/bridge.ts
+++ b/plugins/voice-modules/twilio-media-streams/internal/bridge.ts
@@ -113,6 +113,7 @@ function sanitizeCustomParameters(value: any): Record<string, string> {
   if (!value || typeof value !== 'object') return {};
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(value)) {
+    if (String(k).toLowerCase() === 'voicemediatoken') continue;
     if (typeof v === 'string') out[String(k)] = v;
     else if (v === null || v === undefined) continue;
     else out[String(k)] = String(v);

--- a/plugins/voice-modules/twilio-media-streams/tests/integration/twilio-media-streams.bridge.test.ts
+++ b/plugins/voice-modules/twilio-media-streams/tests/integration/twilio-media-streams.bridge.test.ts
@@ -196,6 +196,42 @@ describe('plugins/voice-modules/twilio-media-streams (bridge integration)', () =
     expect(session.close).toHaveBeenCalled();
   });
 
+  test('strips voiceMediaToken from call metadata customParameters', async () => {
+    const secret = 'secret';
+    const token = makeToken(secret);
+
+    const session = new MockRealtimeSession();
+    session.push({ type: 'ready', sessionId: 's1' });
+
+    const onCallStart = jest.fn();
+    const bridge = createTwilioMediaStreamsBridge({
+      createSession: async () => session,
+      security: { tokenSecret: secret },
+      limits: { startTimeoutMs: 0, idleTimeoutMs: 0, maxSessionDurationMs: 0 },
+      audio: { pacing: { enabled: false } },
+      callbacks: { onCallStart }
+    });
+
+    const ws = new MockWebSocket();
+    const task = bridge.handleConnection(ws as any, { url: `/ws?token=${encodeURIComponent(token)}` });
+    ws.emitMessage(startMessage({
+      customParameters: {
+        from: '+15551234567',
+        to: '+15557654321',
+        direction: 'inbound',
+        voiceMediaToken: 'abc'
+      }
+    }));
+    await flush();
+
+    expect(onCallStart).toHaveBeenCalledTimes(1);
+    const metadata = onCallStart.mock.calls[0]![0];
+    expect(metadata?.customParameters?.voiceMediaToken).toBeUndefined();
+
+    ws.emitMessage(stopMessage({}));
+    await task;
+  });
+
   test('drops in-flight audio after playback.clear_requested', async () => {
     const secret = 'secret';
     const token = makeToken(secret);


### PR DESCRIPTION
Closes #759

## Summary
- Add voice media WS auth via first message (`voiceMediaToken`) when URL query params are missing; configurable via `server.extensions.voice.mediaWs.tokenFromMessageTimeoutMs` (default `5000`).
- Update Twilio voice compat to pass the WS token via TwiML `<Parameter name="voiceMediaToken" ...>` and strip `token` from the stream URL.
- Strip `voiceMediaToken` from Twilio media stream `customParameters` before surfacing metadata.

## Tests
- `npm run test:extensions:voice`
- `npm test`
- `npm run test:live:openrouter -- --transport=both`
- `npm run test:live:realtime -- --transport=both`
