### PR TITLE
Issue #771: fix voice SSE write-queue compaction

### DIFF
--- a/extensions/voice/internal/server.ts
+++ b/extensions/voice/internal/server.ts
@@ -29,6 +29,7 @@ import type {
 import { createVoiceCallConfigStoreFromEnv } from './call-config-store/index.js';
 import { createVoiceCallEventHub, type VoiceCallEventHub, type VoiceCallEventEnvelope } from './call-events.js';
 import { createVoiceMetrics } from './metrics.js';
+import { StringChunkQueue } from './string-chunk-queue.js';
 
 type VoiceMediaTokenPayload = {
   iat: number;
@@ -50,41 +51,6 @@ type VoiceLogger = {
 type VoiceLogging = {
   getLogger: (correlationId?: string) => VoiceLogger;
 };
-
-class StringChunkQueue {
-  private readonly chunks: string[] = [];
-  private readonly byteLengths: number[] = [];
-  private start = 0;
-  private totalBytes = 0;
-
-  byteLength(): number {
-    return this.totalBytes;
-  }
-
-  push(chunk: string): void {
-    const bytes = Buffer.byteLength(chunk, 'utf8');
-    this.chunks.push(chunk);
-    this.byteLengths.push(bytes);
-    this.totalBytes += bytes;
-  }
-
-  shift(): { chunk: string; bytes: number } | undefined {
-    if (this.start >= this.chunks.length) return undefined;
-    const chunk = this.chunks[this.start] as string;
-    const bytes = this.byteLengths[this.start] as number;
-    this.start += 1;
-    this.totalBytes -= bytes;
-    if (this.start >= this.chunks.length) this.clear();
-    return { chunk, bytes };
-  }
-
-  clear(): void {
-    this.chunks.length = 0;
-    this.byteLengths.length = 0;
-    this.start = 0;
-    this.totalBytes = 0;
-  }
-}
 
 function parseUrl(rawUrl: string | undefined): URL | null {
   const raw = rawUrl ?? '/';

--- a/extensions/voice/internal/string-chunk-queue.ts
+++ b/extensions/voice/internal/string-chunk-queue.ts
@@ -1,0 +1,60 @@
+export class StringChunkQueue {
+  private readonly chunks: string[] = [];
+  private readonly byteLengths: number[] = [];
+  private start = 0;
+  private totalBytes = 0;
+
+  byteLength(): number {
+    return this.totalBytes;
+  }
+
+  push(chunk: string): void {
+    const bytes = Buffer.byteLength(chunk, 'utf8');
+    this.chunks.push(chunk);
+    this.byteLengths.push(bytes);
+    this.totalBytes += bytes;
+  }
+
+  shift(): { chunk: string; bytes: number } | undefined {
+    if (this.start >= this.chunks.length) return undefined;
+
+    const idx = this.start;
+    const chunk = this.chunks[idx] as string;
+    const bytes = this.byteLengths[idx] as number;
+
+    // Release references for consumed slots (the queue may never fully drain under backpressure).
+    this.chunks[idx] = '';
+    this.byteLengths[idx] = 0;
+
+    this.start = idx + 1;
+    this.totalBytes -= bytes;
+
+    if (this.start >= this.chunks.length) {
+      this.clear();
+      return { chunk, bytes };
+    }
+
+    this.compactIfNeeded();
+    return { chunk, bytes };
+  }
+
+  clear(): void {
+    this.chunks.length = 0;
+    this.byteLengths.length = 0;
+    this.start = 0;
+    this.totalBytes = 0;
+  }
+
+  private compactIfNeeded(): void {
+    const consumed = this.start;
+    if (consumed <= 0) return;
+
+    // Avoid unbounded growth of the backing arrays when the queue never fully drains.
+    if (consumed < 1024) return;
+    if (consumed * 2 < this.chunks.length) return;
+
+    this.chunks.splice(0, consumed);
+    this.byteLengths.splice(0, consumed);
+    this.start = 0;
+  }
+}

--- a/extensions/voice/tests/unit/string-chunk-queue.test.ts
+++ b/extensions/voice/tests/unit/string-chunk-queue.test.ts
@@ -1,0 +1,58 @@
+import { StringChunkQueue } from '../../internal/string-chunk-queue.js';
+
+describe('extensions/voice/internal/StringChunkQueue', () => {
+  test('tracks byte length and shift ordering', () => {
+    const q = new StringChunkQueue();
+    q.push('a');
+    q.push('bb');
+    expect(q.byteLength()).toBe(3);
+
+    const first = q.shift();
+    expect(first).toEqual({ chunk: 'a', bytes: 1 });
+    expect(q.byteLength()).toBe(2);
+
+    const second = q.shift();
+    expect(second).toEqual({ chunk: 'bb', bytes: 2 });
+    expect(q.byteLength()).toBe(0);
+
+    expect(q.shift()).toBeUndefined();
+  });
+
+  test('does not compact when nothing consumed', () => {
+    const q = new StringChunkQueue();
+    (q as any).compactIfNeeded();
+    const internal = q as any;
+    expect(internal.chunks.length).toBe(0);
+    expect(internal.start).toBe(0);
+  });
+
+  test('does not compact when consumed is small relative to backing length', () => {
+    const q = new StringChunkQueue();
+
+    for (let i = 0; i < 5000; i += 1) q.push('x');
+    for (let i = 0; i < 1024; i += 1) q.shift();
+
+    const internal = q as any;
+    expect(internal.start).toBe(1024);
+    expect(internal.chunks.length).toBe(5000);
+  });
+
+  test('compacts consumed prefix when the queue never fully drains', () => {
+    const q = new StringChunkQueue();
+    q.push('seed');
+
+    for (let i = 0; i < 5000; i += 1) {
+      q.push('x');
+      q.shift();
+    }
+
+    // Private fields are inspected here to ensure internal storage stays bounded under steady-state usage.
+    const internal = q as any;
+    expect(internal.chunks.length).toBeLessThan(2048);
+    expect(internal.start).toBeLessThan(2048);
+
+    const last = q.shift();
+    expect(last?.chunk).toBe('x');
+    expect(q.byteLength()).toBe(0);
+  });
+});

--- a/tests/live/test-files/33-realtime-tools-disabled.live.test.ts
+++ b/tests/live/test-files/33-realtime-tools-disabled.live.test.ts
@@ -43,7 +43,8 @@ if (filteredRealtimeTestRuns.length === 0) {
   for (const runCfg of filteredRealtimeTestRuns) {
     describeLive(`${TEST_FILE} — ${runCfg.name}`, () => {
       test('toolChoice=single executes tool and emits tool events', async () => {
-        const token = `ECHO_${runCfg.name}_${Date.now()}_${Math.random().toString(16).slice(2, 6)}`;
+        // Keep the token copy-safe across providers (avoid long numeric sequences that can be mis-copied).
+        const token = `ECHO_${runCfg.name}_${Date.now().toString(36)}_${Math.random().toString(16).slice(2, 10)}`;
 
         const result = await runRealtimeScenario({
           pluginsPath,
@@ -103,7 +104,7 @@ if (filteredRealtimeTestRuns.length === 0) {
       }, 180_000);
 
       test('toolChoice=none disables tool execution (no tool events)', async () => {
-        const token = `NO_TOOL_${runCfg.name}_${Date.now()}_${Math.random().toString(16).slice(2, 6)}`;
+        const token = `NO_TOOL_${runCfg.name}_${Date.now().toString(36)}_${Math.random().toString(16).slice(2, 10)}`;
 
         const result = await runRealtimeScenario({
           pluginsPath,


### PR DESCRIPTION
Closes #771

Summary
- Fix `GET /voice/calls/:callConfigId/events` SSE write queue to avoid backing-array growth under sustained backpressure.
- Add unit tests for the queue behavior and compaction.
- Live realtime: make the tool-call token copy-safe (avoid long numeric sequences) to reduce flakiness.

Validation
- `npm test`
- `npm run test:extensions:voice`
- `npm run test:live:openrouter -- --transport=both`
- `npm run test:live:realtime -- --transport=both`