### PR TITLE
Issue #791: fix first-turn transcript + grok realtime audio modalities

### DIFF
--- a/extensions/voice/README.md
+++ b/extensions/voice/README.md
@@ -92,7 +92,7 @@ The voice extension supports server-side defaults and settings under `server.ext
 
 Call defaults (applied to `POST /voice/calls` when a field is omitted):
 - `assistantFirstTurn`: `{ enabled, prompt, role, delayMs, missingPromptBehavior }`
-- `timeouts`: `{ callTimeoutMs, silenceTimeoutMs, silenceAssistantAudioStartFallbackMs, silenceAssistantAudioEndFallbackMs }`
+- `timeouts`: `{ callTimeoutMs, silenceTimeoutMs, firstTurnGraceMs, silenceAssistantAudioStartFallbackMs, silenceAssistantAudioEndFallbackMs }`
 - `recording`: `{ enabled, mode, format, channels }`
 
 Events stream defaults/settings (applied to `GET /voice/calls/:callConfigId/events`):
@@ -105,6 +105,7 @@ Notes:
 - `events.callTtlMs` (default: `900000`): sweep inactive call channels after this TTL (set `0` to disable TTL-based sweeping).
 - `events.keepAliveIntervalMs` (default: `15000`): interval for SSE keepalive comments (`: keepalive`) to keep intermediaries from timing out idle streams (set `0` to disable keepalives). Can also be overridden via `LLM_ADAPTER_VOICE_EVENTS_KEEPALIVE_INTERVAL_MS`.
 - `events.maxWriteQueueBytes` (default: `262144`): upper bound on buffered SSE response bytes (in-flight + queued). If exceeded, the server closes the stream to avoid unbounded memory growth.
+- `timeouts.firstTurnGraceMs`: optional non-negative millisecond window used by some voice compats/bridges to adjust first-turn commit behavior immediately after realtime `ready` (see the active compat README under `plugins/voice-compat/*`).
 - `timeouts.silenceAssistantAudioStartFallbackMs` / `timeouts.silenceAssistantAudioEndFallbackMs`: optional fallback windows used by some provider compats when `assistantFirstTurn.enabled=true` to ensure silence timers still arm when assistant-audio boundary events are missing (see the active compat README under `plugins/voice-compat/*`).
 
 Media WS settings:

--- a/extensions/voice/internal/call-config-store/index.ts
+++ b/extensions/voice/internal/call-config-store/index.ts
@@ -13,6 +13,7 @@ export type VoiceCallTimeoutsConfig = {
   silenceTimeoutMs?: number;
   silenceAssistantAudioStartFallbackMs?: number;
   silenceAssistantAudioEndFallbackMs?: number;
+  firstTurnGraceMs?: number;
 };
 
 export type VoiceCallRecordingProviderRecording = {

--- a/extensions/voice/internal/server.ts
+++ b/extensions/voice/internal/server.ts
@@ -165,6 +165,15 @@ function readPositiveInt(value: unknown, label: string): number {
   return out;
 }
 
+function readNonNegativeInt(value: unknown, label: string): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  const out = Math.floor(n);
+  if (!Number.isFinite(n) || out < 0) {
+    throw makeHttpError({ message: `Invalid ${label}`, statusCode: 400, code: 'validation_error' });
+  }
+  return out;
+}
+
 function normalizeVoiceCallTimeouts(options: {
   raw: unknown;
   defaults: unknown;
@@ -175,6 +184,10 @@ function normalizeVoiceCallTimeouts(options: {
 
   const callTimeoutMsRaw = raw?.callTimeoutMs !== undefined ? raw.callTimeoutMs : defaults?.callTimeoutMs;
   const silenceTimeoutMsRaw = raw?.silenceTimeoutMs !== undefined ? raw.silenceTimeoutMs : defaults?.silenceTimeoutMs;
+  const firstTurnGraceMsRaw =
+    raw?.firstTurnGraceMs !== undefined
+      ? raw.firstTurnGraceMs
+      : defaults?.firstTurnGraceMs;
   const silenceAssistantAudioStartFallbackMsRaw =
     raw?.silenceAssistantAudioStartFallbackMs !== undefined
       ? raw.silenceAssistantAudioStartFallbackMs
@@ -190,6 +203,9 @@ function normalizeVoiceCallTimeouts(options: {
   }
   if (silenceTimeoutMsRaw !== undefined && silenceTimeoutMsRaw !== null && silenceTimeoutMsRaw !== '') {
     out.silenceTimeoutMs = readPositiveInt(silenceTimeoutMsRaw, 'timeouts.silenceTimeoutMs');
+  }
+  if (firstTurnGraceMsRaw !== undefined && firstTurnGraceMsRaw !== null && firstTurnGraceMsRaw !== '') {
+    out.firstTurnGraceMs = readNonNegativeInt(firstTurnGraceMsRaw, 'timeouts.firstTurnGraceMs');
   }
   if (
     silenceAssistantAudioStartFallbackMsRaw !== undefined &&

--- a/extensions/voice/tests/unit/voice-server.http.test.ts
+++ b/extensions/voice/tests/unit/voice-server.http.test.ts
@@ -2049,6 +2049,119 @@ describe('extensions/voice: server http handlers', () => {
     expect(callConfig?.timeouts).toMatchObject({ silenceAssistantAudioStartFallbackMs: 111, silenceAssistantAudioEndFallbackMs: 222 });
   });
 
+  test('POST /voice/calls rejects negative timeouts.firstTurnGraceMs', async () => {
+    process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = 'secret';
+
+    const store = createInMemoryVoiceCallConfigStore();
+
+    const providerPlugins: any = {
+      getManifest: jest.fn(async () => ({ defaults: {} })),
+      getCompat: jest.fn(async () => ({ createOutboundCall: jest.fn(async () => ({ providerCallId: 'pc_1' })) }))
+    };
+
+    const reg = await createVoiceServerRegistration({
+      server: {} as any,
+      registry: {},
+      pluginsPath: './plugins',
+      upgradeRouter: {} as any,
+      store,
+      providerPlugins,
+      httpConfig: { auth: { enabled: true, apiKeys: ['k1'] } }
+    });
+
+    const res = createMockRes();
+    await expect(
+      reg.handleHttp(
+        createJsonReq({
+          url: '/voice/calls',
+          method: 'POST',
+          headers: { authorization: 'Bearer k1', host: 'localhost' },
+          body: {
+            to: 'to',
+            from: 'from',
+            realtimeSpec: {},
+            voiceProvider: 'test',
+            timeouts: { firstTurnGraceMs: -1 }
+          }
+        }),
+        res
+      )
+    ).resolves.toBe(true);
+
+    expect(String(res.writeHead.mock.calls[0][0])).toBe('400');
+  });
+
+  test('POST /voice/calls accepts timeouts.firstTurnGraceMs (including 0) and persists it to the call config', async () => {
+    process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = 'secret';
+
+    const store = createInMemoryVoiceCallConfigStore();
+
+    const createOutboundCall = jest.fn(async () => ({ providerCallId: 'pc_1' }));
+    const providerPlugins: any = {
+      getManifest: jest.fn(async () => ({ defaults: {} })),
+      getCompat: jest.fn(async () => ({ createOutboundCall }))
+    };
+
+    const reg = await createVoiceServerRegistration({
+      server: {} as any,
+      registry: {},
+      pluginsPath: './plugins',
+      upgradeRouter: {} as any,
+      store,
+      providerPlugins,
+      httpConfig: { auth: { enabled: true, apiKeys: ['k1'] } }
+    });
+
+    const resZero = createMockRes();
+    await expect(
+      reg.handleHttp(
+        createJsonReq({
+          url: '/voice/calls',
+          method: 'POST',
+          headers: { authorization: 'Bearer k1', host: 'localhost' },
+          body: {
+            to: 'to',
+            from: 'from',
+            realtimeSpec: {},
+            voiceProvider: 'test',
+            timeouts: { firstTurnGraceMs: 0 }
+          }
+        }),
+        resZero
+      )
+    ).resolves.toBe(true);
+
+    expect(String(resZero.writeHead.mock.calls[0][0])).toBe('200');
+    expect(createOutboundCall).toHaveBeenCalled();
+    const responseZero = JSON.parse(String(resZero.end.mock.calls[0][0]));
+    const callConfigZero = await store.getConfig(String(responseZero.callConfigId));
+    expect(callConfigZero?.timeouts).toMatchObject({ firstTurnGraceMs: 0 });
+
+    const resPositive = createMockRes();
+    await expect(
+      reg.handleHttp(
+        createJsonReq({
+          url: '/voice/calls',
+          method: 'POST',
+          headers: { authorization: 'Bearer k1', host: 'localhost' },
+          body: {
+            to: 'to',
+            from: 'from',
+            realtimeSpec: {},
+            voiceProvider: 'test',
+            timeouts: { firstTurnGraceMs: '250' }
+          }
+        }),
+        resPositive
+      )
+    ).resolves.toBe(true);
+
+    expect(String(resPositive.writeHead.mock.calls[0][0])).toBe('200');
+    const responsePositive = JSON.parse(String(resPositive.end.mock.calls[0][0]));
+    const callConfigPositive = await store.getConfig(String(responsePositive.callConfigId));
+    expect(callConfigPositive?.timeouts).toMatchObject({ firstTurnGraceMs: 250 });
+  });
+
   test('POST /voice/calls uses backoff/jitter when idempotency lock is held', async () => {
     jest.useFakeTimers();
     const setTimeoutSpy = jest.spyOn(global, 'setTimeout');

--- a/plugins/realtime-compat/grok/README.md
+++ b/plugins/realtime-compat/grok/README.md
@@ -37,3 +37,18 @@ Create a realtime provider manifest at `plugins/realtime-providers/grok.json`:
   - Provider is expected to auto-create responses for audio turns.
   - `session.commit()` only sends `response.create` for **text turns** (e.g. typed input / DTMF), avoiding duplicate turns for telephony bridges that commit on `user_speech.stopped`.
 
+## Response creation
+
+When committing a turn, this compat always requests both text and audio output:
+
+- `response.modalities = ['text', 'audio']`
+
+If a tool choice is supplied by the session controller, it is forwarded as `response.tool_choice`.
+
+## Provider event logging (debug)
+
+Set `LLM_ADAPTER_REALTIME_LOG_PROVIDER_EVENTS_MS=<ms>` to log raw provider events for the first N milliseconds after the session becomes `ready`.
+
+Notes:
+- Logging is best-effort; failures to initialize logging are ignored.
+- Base64 audio payloads in `response.output_audio.delta` events are redacted (`[REDACTED_BASE64]`), but other fields (including transcripts) are logged as-is.

--- a/plugins/realtime-compat/grok/internal/commands.ts
+++ b/plugins/realtime-compat/grok/internal/commands.ts
@@ -203,10 +203,13 @@ export function buildInputAudioCommitEvent(): GrokRealtimeClientEvent {
 }
 
 export function buildResponseCreateEvent(options: { toolChoice?: any } = {}): GrokRealtimeClientEvent {
+  const response: any = {
+    modalities: ['text', 'audio']
+  };
   if (options.toolChoice !== undefined) {
-    return { type: 'response.create', response: { tool_choice: options.toolChoice } };
+    response.tool_choice = options.toolChoice;
   }
-  return { type: 'response.create' };
+  return { type: 'response.create', response };
 }
 
 export function buildResponseCancelEvent(): GrokRealtimeClientEvent {

--- a/plugins/realtime-compat/grok/internal/session-core.ts
+++ b/plugins/realtime-compat/grok/internal/session-core.ts
@@ -35,6 +35,23 @@ function generateSessionId(): string {
   return `sess_local_${Date.now()}_${Math.random().toString(16).slice(2)}`;
 }
 
+function readEnvPositiveInt(name: string): number | undefined {
+  const raw = process.env[name];
+  const n = raw === undefined || raw === null || raw === '' ? NaN : Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.floor(n);
+}
+
+function sanitizeProviderEventForLog(event: any): any {
+  if (!event || typeof event !== 'object') return event;
+  const cloned = Array.isArray(event) ? [...event] : { ...event };
+  const type = String((cloned as any).type ?? '');
+  if (type === 'response.output_audio.delta' && typeof (cloned as any).delta === 'string') {
+    (cloned as any).delta = '[REDACTED_BASE64]';
+  }
+  return cloned;
+}
+
 export function createGrokRealtimeCompatSessionWithTransport(
   options: Parameters<IRealtimeCompat['createSession']>[0],
   transport: RealtimeTransport
@@ -72,6 +89,43 @@ export function createGrokRealtimeCompatSessionWithTransport(
   let closed = false;
   let hasAudioSinceCommit = false;
   let pendingTextTurn = false;
+
+  const providerEventLogWindowMs = readEnvPositiveInt('LLM_ADAPTER_REALTIME_LOG_PROVIDER_EVENTS_MS');
+  let providerEventLogUntilMs: number | undefined;
+  let providerEventLogger: any | undefined;
+  let providerEventLoggerLoading: Promise<any> | undefined;
+  const getProviderEventLogger = async (): Promise<any | undefined> => {
+    if (providerEventLogger) return providerEventLogger;
+    if (!providerEventLoggerLoading) {
+      providerEventLoggerLoading = (async () => {
+        const logging = await import('../../../../modules/logging/index.js');
+        return logging.getRealtimeLogger();
+      })();
+    }
+    try {
+      providerEventLogger = await providerEventLoggerLoading;
+    } catch {
+      providerEventLoggerLoading = undefined;
+      providerEventLogger = undefined;
+    }
+    return providerEventLogger;
+  };
+  const maybeLogProviderEvent = async (event: any): Promise<void> => {
+    if (!providerEventLogWindowMs) return;
+    const until = providerEventLogUntilMs;
+    if (!until) return;
+    const now = Date.now();
+    if (now > until) {
+      providerEventLogUntilMs = undefined;
+      return;
+    }
+    try {
+      const logger = await getProviderEventLogger();
+      logger?.info?.('realtime.provider_event', { providerEvent: sanitizeProviderEventForLog(event) });
+    } catch {
+      // best-effort
+    }
+  };
 
   const commitMode = spec.turnDetection?.mode ?? 'manual_commit';
   const forceToolChoiceOnCommit = typeof spec.toolChoice === 'object' && spec.toolChoice?.type === 'single';
@@ -125,6 +179,9 @@ export function createGrokRealtimeCompatSessionWithTransport(
     if (readySent) return;
     readySent = true;
     clearReadyFallback();
+    if (providerEventLogWindowMs && !providerEventLogUntilMs) {
+      providerEventLogUntilMs = Date.now() + providerEventLogWindowMs;
+    }
     queue.push({
       type: 'ready',
       sessionId,
@@ -196,6 +253,7 @@ export function createGrokRealtimeCompatSessionWithTransport(
           continue;
         }
 
+        const readyAlreadySent = readySent;
         const msgType = String(parsed?.type ?? '');
 
         if (msgType === 'conversation.created' && !sessionUpdateSent) {
@@ -207,6 +265,10 @@ export function createGrokRealtimeCompatSessionWithTransport(
         // Wait for session.updated before declaring ready so the session config is in effect.
         if (!readySent && (msgType === 'session.updated' || msgType === 'error')) {
           emitReadyOnce();
+        }
+
+        if (readyAlreadySent) {
+          await maybeLogProviderEvent(parsed);
         }
 
         if (msgType === 'input_audio_buffer.committed') {

--- a/plugins/voice-compat/twilio/README.md
+++ b/plugins/voice-compat/twilio/README.md
@@ -55,6 +55,9 @@ This is **dynamic** (LLM-generated) and does not use pre-recorded audio. The pro
   - applied to the outbound call via Twilio `TimeLimit` (seconds).
 - `callConfig.timeouts.silenceTimeoutMs`:
   - enforced adapter-side during the media bridge (hang up after no user input for the configured duration).
+- `callConfig.timeouts.firstTurnGraceMs` (optional, non-negative):
+  - forwarded to the Twilio media-streams bridge as `limits.firstTurnGraceMs` (see `plugins/voice-modules/twilio-media-streams/README.md`).
+  - When omitted, this compat defaults to `500` only when `callConfig.realtimeSpec.provider === "grok"`; otherwise it is disabled.
 - `callConfig.timeouts.silenceAssistantAudioEndFallbackMs` (optional):
   - when `assistantFirstTurn.enabled=true`, treats assistant audio as ended this many milliseconds after the first `assistant_audio.chunk` if `assistant_audio.end` is never emitted.
   - default: `min(2000, max(500, silenceTimeoutMs))`.
@@ -85,6 +88,8 @@ To harden against SSRF, the recording URL received from the webhook is validated
 
 After a call ends, this compat attempts to fetch and persist Twilio-side call artifacts under:
 - `logs/voice/twilio/call-<CallSid>-<timestamp>/`
+
+This is best-effort and non-blocking; capture runs asynchronously and does not delay media WS cleanup.
 
 Artifacts are best-effort (permissions vary by account/project). When available, the compat writes:
 - `call.json` (call resource)

--- a/plugins/voice-compat/twilio/index.ts
+++ b/plugins/voice-compat/twilio/index.ts
@@ -457,12 +457,12 @@ export default class TwilioVoiceCompat {
     logger?: any;
     metrics?: any;
   }): Promise<void> {
-    const callConfig = options.callConfig ?? {};
-    const systemPrompt = callConfig.systemPrompt;
-    const realtimeSpec = callConfig.realtimeSpec ?? {};
-    const requestId = typeof callConfig?.metadata?.requestId === 'string'
-      ? String(callConfig.metadata.requestId).trim()
-      : '';
+	    const callConfig = options.callConfig ?? {};
+	    const systemPrompt = callConfig.systemPrompt;
+	    const realtimeSpec = callConfig.realtimeSpec ?? {};
+	    const requestId = typeof callConfig?.metadata?.requestId === 'string'
+	      ? String(callConfig.metadata.requestId).trim()
+	      : '';
 
     const logger = options.logger;
     const safeLog = (level: 'debug' | 'info' | 'warning' | 'error', message: string, data?: any) => {
@@ -478,12 +478,12 @@ export default class TwilioVoiceCompat {
         if (typeof fn === 'function') fn(...args);
       } catch {}
     };
-    const baseFields = {
-      callConfigId: String(options.callConfigId),
-      voiceProvider: String(options.voiceProvider),
-      ...(systemPrompt !== undefined ? { systemPrompt: String(systemPrompt) } : {}),
-      ...(requestId ? { requestId } : {})
-    };
+	    const baseFields = {
+	      callConfigId: String(options.callConfigId),
+	      voiceProvider: String(options.voiceProvider),
+	      ...(requestId ? { requestId } : {})
+	    };
+	    const systemPromptField = systemPrompt !== undefined ? { systemPrompt: String(systemPrompt) } : {};
 
     const emitEvent = (event: any) => {
       try {
@@ -504,6 +504,23 @@ export default class TwilioVoiceCompat {
     if (silenceTimeoutMs !== undefined && (!Number.isFinite(silenceTimeoutMs) || silenceTimeoutMs <= 0)) {
       throw makeHttpError({ message: 'Invalid timeouts.silenceTimeoutMs', statusCode: 400, code: 'validation_error' });
     }
+
+    const firstTurnGraceMsRaw = (timeouts as any)?.firstTurnGraceMs;
+    const firstTurnGraceMsExplicit =
+      firstTurnGraceMsRaw === undefined || firstTurnGraceMsRaw === null || firstTurnGraceMsRaw === ''
+        ? undefined
+        : Number(firstTurnGraceMsRaw);
+    if (firstTurnGraceMsExplicit !== undefined && (!Number.isFinite(firstTurnGraceMsExplicit) || firstTurnGraceMsExplicit < 0)) {
+      throw makeHttpError({ message: 'Invalid timeouts.firstTurnGraceMs', statusCode: 400, code: 'validation_error' });
+    }
+
+    const realtimeProvider = String((realtimeSpec as any)?.provider ?? '').trim();
+    const firstTurnGraceMs =
+      firstTurnGraceMsExplicit !== undefined
+        ? Math.floor(firstTurnGraceMsExplicit)
+        : realtimeProvider === 'grok'
+          ? 500
+          : undefined;
 
     const silenceAssistantAudioEndFallbackMsRaw = (timeouts as any)?.silenceAssistantAudioEndFallbackMs;
     const silenceAssistantAudioEndFallbackMs =
@@ -587,24 +604,25 @@ export default class TwilioVoiceCompat {
       clearAssistantAudioEndFallback();
     };
 
-    const requestEndCallOnce = async (reason: string) => {
-      if (callEnded) return;
-      callEnded = true;
-      clearAllTimers();
+	    const requestEndCallOnce = async (reason: string) => {
+	      if (callEnded) return;
+	      callEnded = true;
+	      clearAllTimers();
 
       emitEvent({ type: 'voice.call.end_requested', reason, ...(providerCallId ? { providerCallId } : {}) });
 
-      if (providerCallId) {
-        try {
-          await this.endCall({ providerCallId, providerDefaults: options.providerDefaults });
-        } catch (error: any) {
-          safeLog('error', 'voice.call.end_failed', {
-            ...baseFields,
-            providerCallId,
-            reason,
-            message: error?.message ?? String(error),
-            code: error?.code !== undefined ? String(error.code) : undefined,
-            statusCode: Number(error?.statusCode ?? error?.status ?? 0) || undefined
+	      if (providerCallId) {
+	        try {
+	          await this.endCall({ providerCallId, providerDefaults: options.providerDefaults });
+	        } catch (error: any) {
+	          safeLog('error', 'voice.call.end_failed', {
+	            ...baseFields,
+	            ...systemPromptField,
+	            providerCallId,
+	            reason,
+	            message: error?.message ?? String(error),
+	            code: error?.code !== undefined ? String(error.code) : undefined,
+	            statusCode: Number(error?.statusCode ?? error?.status ?? 0) || undefined
           });
         }
       }
@@ -731,16 +749,17 @@ export default class TwilioVoiceCompat {
           voiceProvider: String(options.voiceProvider)
         }
       },
+      ...(firstTurnGraceMs !== undefined ? { limits: { firstTurnGraceMs } } : {}),
       callbacks: {
-        onCallStart: (metadata) => {
-          providerCallId = metadata.callSid;
-          providerStreamId = metadata.streamSid;
+	        onCallStart: (metadata) => {
+	          providerCallId = metadata.callSid;
+	          providerStreamId = metadata.streamSid;
 
-          safeLog('info', 'voice.media.stream_started', {
-            ...baseFields,
-            providerStreamId: metadata.streamSid,
-            providerCallId: metadata.callSid
-          });
+	          safeLog('info', 'voice.media.stream_started', {
+	            ...baseFields,
+	            providerStreamId: metadata.streamSid,
+	            providerCallId: metadata.callSid
+	          });
 
           emitEvent({ type: 'voice.call.connected', providerStreamId: metadata.streamSid, providerCallId: metadata.callSid });
 
@@ -755,14 +774,14 @@ export default class TwilioVoiceCompat {
             startSilenceTimer(silenceTimeoutMs);
           }
         },
-        onRealtimeEvent: ({ event, metadata }) => {
-          if (event?.type === 'ready') {
-            safeLog('info', 'voice.realtime.ready', {
-              ...baseFields,
-              providerStreamId: metadata.streamSid,
-              realtimeSessionId: (event as any).sessionId
-            });
-          }
+	        onRealtimeEvent: ({ event, metadata }) => {
+	          if (event?.type === 'ready') {
+	            safeLog('info', 'voice.realtime.ready', {
+	              ...baseFields,
+	              providerStreamId: metadata.streamSid,
+	              realtimeSessionId: (event as any).sessionId
+	            });
+	          }
 
           const type = String((event as any)?.type ?? '');
           if (
@@ -801,42 +820,45 @@ export default class TwilioVoiceCompat {
             clearAllTimers();
           }
         },
-        onError: ({ message, code, metadata }) => {
-          safeLog('error', 'voice.media.bridge_error', {
-            ...baseFields,
-            ...(metadata?.streamSid ? { providerStreamId: metadata.streamSid } : {}),
-            ...(metadata?.callSid ? { providerCallId: metadata.callSid } : {}),
-            code: String(code),
-            message: String(message)
-          });
+	        onError: ({ message, code, metadata }) => {
+	          safeLog('error', 'voice.media.bridge_error', {
+	            ...baseFields,
+	            ...systemPromptField,
+	            ...(metadata?.streamSid ? { providerStreamId: metadata.streamSid } : {}),
+	            ...(metadata?.callSid ? { providerCallId: metadata.callSid } : {}),
+	            code: String(code),
+	            message: String(message)
+	          });
           safeMetric('compatError', 'media_bridge', baseFields.voiceProvider);
         }
       }
     });
 
-    try {
-      await bridge.handleConnection(options.ws, options.req);
-    } finally {
-      clearAllTimers();
+	    try {
+	      await bridge.handleConnection(options.ws, options.req);
+	    } finally {
+	      clearAllTimers();
 
-      if (providerCallId) {
-        try {
-          await this.persistCallLogs({
-            callConfigId: String(options.callConfigId),
-            providerCallId,
-            providerDefaults: options.providerDefaults,
-            logger
-          });
-        } catch (error: any) {
-          safeLog('warning', 'voice.twilio.call_logs.persist_failed', {
-            ...baseFields,
-            providerCallId,
-            message: error?.message ?? String(error)
-          });
-        }
-      }
-    }
-  }
+	      if (providerCallId) {
+	        void (async () => {
+	          try {
+	            await this.persistCallLogs({
+	              callConfigId: String(options.callConfigId),
+	              providerCallId,
+	              providerDefaults: options.providerDefaults,
+	              logger
+	            });
+	          } catch (error: any) {
+	            safeLog('warning', 'voice.twilio.call_logs.persist_failed', {
+	              ...baseFields,
+	              providerCallId,
+	              message: error?.message ?? String(error)
+	            });
+	          }
+	        })();
+	      }
+	    }
+	  }
 
   async createOutboundCall(options: {
     to: string;

--- a/plugins/voice-compat/twilio/tests/unit/twilio-voice-call-logs.test.ts
+++ b/plugins/voice-compat/twilio/tests/unit/twilio-voice-call-logs.test.ts
@@ -13,6 +13,249 @@ describe('plugins/voice-compat/twilio: call log capture', () => {
     jest.resetModules();
   });
 
+  test('fetchPaginatedJson returns empty pages when initialUrl is blank', async () => {
+    const mod = await import('../../index.js');
+    const TwilioVoiceCompat = (mod as any).default;
+    const compat = new TwilioVoiceCompat();
+
+    const fetchSpy = jest.spyOn(compat as any, 'fetchJsonWithRetry');
+
+    await expect((compat as any).fetchPaginatedJson({
+      initialUrl: '',
+      headers: {},
+      apiBaseUrl: 'https://api.twilio.com',
+      maxPages: 1,
+      retry: { maxRetries: 0, baseDelayMs: 0, maxDelayMs: 0 }
+    })).resolves.toMatchObject({ pages: [] });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('fetchPaginatedJson follows absolute next_page_uri urls', async () => {
+    const mod = await import('../../index.js');
+    const TwilioVoiceCompat = (mod as any).default;
+    const compat = new TwilioVoiceCompat();
+
+    const fetchSpy = jest.spyOn(compat as any, 'fetchJsonWithRetry');
+    fetchSpy
+      .mockResolvedValueOnce({ events: [{ sid: 'EV1' }], next_page_uri: 'https://api.twilio.com/next' })
+      .mockResolvedValueOnce({ events: [{ sid: 'EV2' }], next_page_uri: null });
+
+    const result = await (compat as any).fetchPaginatedJson({
+      initialUrl: 'https://api.twilio.com/start',
+      headers: { Authorization: 'Basic test' },
+      apiBaseUrl: 'https://api.twilio.com',
+      maxPages: 10,
+      retry: { maxRetries: 0, baseDelayMs: 0, maxDelayMs: 0 }
+    });
+
+    expect(result.pages).toHaveLength(2);
+    expect(fetchSpy.mock.calls[0]?.[0]?.url).toBe('https://api.twilio.com/start');
+    expect(fetchSpy.mock.calls[1]?.[0]?.url).toBe('https://api.twilio.com/next');
+  });
+
+  test('fetchPaginatedJson prefixes non-slash relative next_page_uri urls with "/"', async () => {
+    const mod = await import('../../index.js');
+    const TwilioVoiceCompat = (mod as any).default;
+    const compat = new TwilioVoiceCompat();
+
+    const fetchSpy = jest.spyOn(compat as any, 'fetchJsonWithRetry');
+    fetchSpy
+      .mockResolvedValueOnce({ events: [{ sid: 'EV1' }], next_page_uri: 'next' })
+      .mockResolvedValueOnce({ events: [{ sid: 'EV2' }], next_page_uri: null });
+
+    const result = await (compat as any).fetchPaginatedJson({
+      initialUrl: 'https://api.twilio.com/start',
+      headers: { Authorization: 'Basic test' },
+      apiBaseUrl: 'https://api.twilio.com',
+      maxPages: 10,
+      retry: { maxRetries: 0, baseDelayMs: 0, maxDelayMs: 0 }
+    });
+
+    expect(result.pages).toHaveLength(2);
+    expect(fetchSpy.mock.calls[1]?.[0]?.url).toBe('https://api.twilio.com/next');
+  });
+
+  test('persistCallLogs is a no-op when providerCallId is undefined', async () => {
+    await withTempCwd('twilio-call-logs-no-callid', async (cwd) => {
+      const fetchSpy = jest.spyOn(globalThis as any, 'fetch').mockImplementation(async () => {
+        throw new Error('fetch should not be called');
+      });
+
+      try {
+        const mod = await import('../../index.js');
+        const TwilioVoiceCompat = (mod as any).default;
+        const compat = new TwilioVoiceCompat();
+
+        await expect((compat as any).persistCallLogs({ callConfigId: 'cfg_1', providerCallId: undefined })).resolves.toBeUndefined();
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(fs.existsSync(path.join(cwd, 'logs', 'voice', 'twilio'))).toBe(false);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  test('persistCallLogs is a no-op when credentials are missing', async () => {
+    await withTempCwd('twilio-call-logs-no-creds', async (cwd) => {
+      const fetchSpy = jest.spyOn(globalThis as any, 'fetch').mockImplementation(async () => {
+        throw new Error('fetch should not be called');
+      });
+
+      try {
+        const mod = await import('../../index.js');
+        const TwilioVoiceCompat = (mod as any).default;
+        const compat = new TwilioVoiceCompat();
+
+        await expect((compat as any).persistCallLogs({
+          callConfigId: 'cfg_1',
+          providerCallId: 'CA123',
+          providerDefaults: { accountSid: 'AC123' }
+        })).resolves.toBeUndefined();
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(fs.existsSync(path.join(cwd, 'logs', 'voice', 'twilio'))).toBe(false);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  test('persistCallLogs falls back to default apiBaseUrl when apiBaseUrl is blank', async () => {
+    await withTempCwd('twilio-call-logs-default-api-base', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2025-10-18T10:00:00.000Z'));
+
+      const providerCallId = 'CA123';
+      const accountSid = 'AC123';
+      const apiBaseUrl = 'https://api.twilio.com';
+
+      const callUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}.json`;
+      const eventsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Events.json`;
+      const recordingsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Recordings.json`;
+      const debuggerEventsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Debugger/Events.json`;
+
+      const fetchSpy = jest.spyOn(globalThis as any, 'fetch').mockImplementation(async (url: any) => {
+        const u = String(url);
+        if (u === callUrl) return { ok: true, status: 200, json: async () => ({ sid: providerCallId }) } as any;
+        if (u === eventsUrl) return { ok: true, status: 200, json: async () => ({ events: [], next_page_uri: null }) } as any;
+        if (u === recordingsUrl) return { ok: true, status: 200, json: async () => ({ recordings: [], next_page_uri: null }) } as any;
+        if (u === debuggerEventsUrl) return { ok: true, status: 200, json: async () => ({ events: [], next_page_uri: null }) } as any;
+        return { ok: false, status: 404, text: async () => 'not found' } as any;
+      });
+
+      try {
+        const mod = await import('../../index.js');
+        const TwilioVoiceCompat = (mod as any).default;
+        const compat = new TwilioVoiceCompat();
+
+        await expect((compat as any).persistCallLogs({
+          callConfigId: 'cfg_1',
+          providerCallId,
+          providerDefaults: { accountSid, authToken: 'token', apiBaseUrl: '   ' }
+        })).resolves.toBeUndefined();
+
+        expect(fetchSpy.mock.calls.some(([u]) => String(u).startsWith('https://api.twilio.com/'))).toBe(true);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  test('persistCallLogs uses default apiBaseUrl when apiBaseUrl is undefined', async () => {
+    await withTempCwd('twilio-call-logs-default-api-base-undefined', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2025-10-18T10:00:00.000Z'));
+
+      const providerCallId = 'CA123';
+      const accountSid = 'AC123';
+      const apiBaseUrl = 'https://api.twilio.com';
+
+      const callUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}.json`;
+      const eventsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Events.json`;
+      const recordingsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Recordings.json`;
+      const debuggerEventsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Debugger/Events.json`;
+
+      const fetchSpy = jest.spyOn(globalThis as any, 'fetch').mockImplementation(async (url: any) => {
+        const u = String(url);
+        if (u === callUrl) return { ok: true, status: 200, json: async () => ({ sid: providerCallId }) } as any;
+        if (u === eventsUrl) return { ok: true, status: 200, json: async () => ({ events: [], next_page_uri: null }) } as any;
+        if (u === recordingsUrl) return { ok: true, status: 200, json: async () => ({ recordings: [], next_page_uri: null }) } as any;
+        if (u === debuggerEventsUrl) return { ok: true, status: 200, json: async () => ({ events: [], next_page_uri: null }) } as any;
+        return { ok: false, status: 404, text: async () => 'not found' } as any;
+      });
+
+      try {
+        const mod = await import('../../index.js');
+        const TwilioVoiceCompat = (mod as any).default;
+        const compat = new TwilioVoiceCompat();
+
+        await expect((compat as any).persistCallLogs({
+          callConfigId: 'cfg_1',
+          providerCallId,
+          providerDefaults: { accountSid, authToken: 'token' }
+        })).resolves.toBeUndefined();
+
+        expect(fetchSpy.mock.calls.some(([u]) => String(u).startsWith('https://api.twilio.com/'))).toBe(true);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  test('persistCallLogs captures failures even when error has no status/body', async () => {
+    await withTempCwd('twilio-call-logs-no-status', async (cwd) => {
+      jest.useFakeTimers().setSystemTime(new Date('2025-10-18T10:00:00.000Z'));
+
+      const providerCallId = 'CA123';
+      const accountSid = 'AC123';
+      const apiBaseUrl = 'https://api.twilio.com';
+
+      const callUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}.json`;
+      const eventsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Events.json`;
+      const recordingsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Recordings.json`;
+      const debuggerEventsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Debugger/Events.json`;
+
+      const logger: any = { warning: jest.fn() };
+
+      const fetchSpy = jest.spyOn(globalThis as any, 'fetch').mockImplementation(async (url: any) => {
+        const u = String(url);
+        if (u === callUrl) throw 'network down';
+        if (u === eventsUrl) return { ok: true, status: 200, json: async () => ({ events: [], next_page_uri: null }) } as any;
+        if (u === recordingsUrl) return { ok: true, status: 200, json: async () => ({ recordings: [], next_page_uri: null }) } as any;
+        if (u === debuggerEventsUrl) return { ok: true, status: 200, json: async () => ({ events: [], next_page_uri: null }) } as any;
+        return { ok: false, status: 404, text: async () => 'not found' } as any;
+      });
+
+      try {
+        const mod = await import('../../index.js');
+        const TwilioVoiceCompat = (mod as any).default;
+        const compat = new TwilioVoiceCompat();
+
+        await expect((compat as any).persistCallLogs({
+          callConfigId: undefined,
+          providerCallId,
+          providerDefaults: { accountSid, authToken: 'token', apiBaseUrl },
+          logger
+        })).resolves.toBeUndefined();
+
+        const baseDir = path.join(cwd, 'logs', 'voice', 'twilio');
+        const callDirs = fs.readdirSync(baseDir).filter(d => d.startsWith(`call-${providerCallId}-`));
+        expect(callDirs.length).toBe(1);
+
+        const dir = path.join(baseDir, callDirs[0] as string);
+        const call = JSON.parse(fs.readFileSync(path.join(dir, 'call.json'), 'utf-8'));
+        expect(call).toMatchObject({ error: { message: 'network down' } });
+        expect(call.error?.status).toBeUndefined();
+        expect(call.error?.body).toBeUndefined();
+
+        const warn = logger.warning.mock.calls.find(([msg]) => msg === 'voice.twilio.call_logs.call_failed');
+        expect(warn?.[1]).toMatchObject({ callConfigId: '', providerCallId, message: 'network down' });
+        expect((warn?.[1] as any)?.status).toBeUndefined();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
   test('persists call resource + events + recordings under logs/voice/twilio and is best-effort on failures', async () => {
     await withTempCwd('twilio-call-logs', async (cwd) => {
       jest.useFakeTimers().setSystemTime(new Date('2025-10-18T10:00:00.000Z'));
@@ -171,6 +414,75 @@ describe('plugins/voice-compat/twilio: call log capture', () => {
         expect(events.pages[0].events[0].sid).toBe('EV1');
 
         expect(fetchSpy.mock.calls.some(([u]) => String(u) === eventsNextUrl)).toBe(false);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  test('stops pagination when next_page_uri repeats a previously seen url', async () => {
+    await withTempCwd('twilio-call-logs-pagination-repeat', async (cwd) => {
+      jest.useFakeTimers().setSystemTime(new Date('2025-10-18T10:00:00.000Z'));
+
+      const providerCallId = 'CA123';
+      const accountSid = 'AC123';
+      const apiBaseUrl = 'https://api.twilio.com';
+
+      const callUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}.json`;
+      const eventsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Events.json`;
+      const recordingsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Recordings.json`;
+      const debuggerEventsUrl = `${apiBaseUrl}/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Debugger/Events.json`;
+
+      const fetchSpy = jest.spyOn(globalThis as any, 'fetch').mockImplementation(async (url: any) => {
+        const u = String(url);
+
+        if (u === callUrl) {
+          return { ok: true, status: 200, json: async () => ({ sid: providerCallId }) } as any;
+        }
+
+        if (u === eventsUrl) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              events: [{ sid: 'EV1' }],
+              next_page_uri: `/2010-04-01/Accounts/${accountSid}/Calls/${providerCallId}/Events.json`
+            })
+          } as any;
+        }
+
+        if (u === recordingsUrl) {
+          return { ok: true, status: 200, json: async () => ({ recordings: [], next_page_uri: null }) } as any;
+        }
+
+        if (u === debuggerEventsUrl) {
+          return { ok: true, status: 200, json: async () => ({ events: [], next_page_uri: null }) } as any;
+        }
+
+        return { ok: false, status: 404, text: async () => 'not found' } as any;
+      });
+
+      try {
+        const mod = await import('../../index.js');
+        const TwilioVoiceCompat = (mod as any).default;
+        const compat = new TwilioVoiceCompat();
+
+        await expect((compat as any).persistCallLogs({
+          callConfigId: 'cfg_1',
+          providerCallId,
+          providerDefaults: { accountSid, authToken: 'token', apiBaseUrl }
+        })).resolves.toBeUndefined();
+
+        const baseDir = path.join(cwd, 'logs', 'voice', 'twilio');
+        const callDirs = fs.readdirSync(baseDir).filter(d => d.startsWith(`call-${providerCallId}-`));
+        expect(callDirs.length).toBe(1);
+
+        const dir = path.join(baseDir, callDirs[0] as string);
+        const events = JSON.parse(fs.readFileSync(path.join(dir, 'events.json'), 'utf-8'));
+        expect(events.pages.length).toBe(1);
+        expect(events.pages[0].events[0].sid).toBe('EV1');
+
+        expect(fetchSpy.mock.calls.filter(([u]) => String(u) === eventsUrl)).toHaveLength(1);
       } finally {
         fetchSpy.mockRestore();
       }

--- a/plugins/voice-compat/twilio/tests/unit/twilio-voice-compat.first-turn-grace.test.ts
+++ b/plugins/voice-compat/twilio/tests/unit/twilio-voice-compat.first-turn-grace.test.ts
@@ -1,0 +1,68 @@
+import http from 'http';
+import { jest } from '@jest/globals';
+
+describe('plugins/voice-compat/twilio — firstTurnGraceMs wiring', () => {
+  const prevSecret = process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET;
+
+  afterEach(() => {
+    if (prevSecret === undefined) delete process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET;
+    else process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = prevSecret;
+    jest.restoreAllMocks();
+  });
+
+  test('defaults grace only for grok and allows explicit override (including 0)', async () => {
+    process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = 'secret';
+
+    await jest.isolateModulesAsync(async () => {
+      let captured: any;
+
+      jest.unstable_mockModule('../../../../voice-modules/twilio-media-streams/index.js', () => ({
+        createTwilioMediaStreamsBridge: (options: any) => {
+          captured = options;
+          return { handleConnection: async () => {} };
+        }
+      }));
+
+      const TwilioVoiceCompat = (await import('../../index.ts')).default;
+      const compat = new TwilioVoiceCompat();
+
+      await compat.handleMediaConnection({
+        ws: {},
+        req: new http.IncomingMessage(null as any),
+        callConfigId: 'cfg_1',
+        callConfig: { realtimeSpec: { provider: 'grok' } },
+        voiceProvider: 'twilio',
+        registry: {},
+        providerDefaults: {}
+      });
+
+      expect(captured?.limits?.firstTurnGraceMs).toBe(500);
+
+      captured = undefined;
+      await compat.handleMediaConnection({
+        ws: {},
+        req: new http.IncomingMessage(null as any),
+        callConfigId: 'cfg_2',
+        callConfig: { realtimeSpec: { provider: 'grok' }, timeouts: { firstTurnGraceMs: 0 } },
+        voiceProvider: 'twilio',
+        registry: {},
+        providerDefaults: {}
+      });
+
+      expect(captured?.limits?.firstTurnGraceMs).toBe(0);
+
+      captured = undefined;
+      await compat.handleMediaConnection({
+        ws: {},
+        req: new http.IncomingMessage(null as any),
+        callConfigId: 'cfg_3',
+        callConfig: { realtimeSpec: { provider: 'openai' } },
+        voiceProvider: 'twilio',
+        registry: {},
+        providerDefaults: {}
+      });
+
+      expect(captured?.limits?.firstTurnGraceMs).toBeUndefined();
+    });
+  });
+});

--- a/plugins/voice-compat/twilio/tests/unit/twilio-voice-compat.test.ts
+++ b/plugins/voice-compat/twilio/tests/unit/twilio-voice-compat.test.ts
@@ -527,9 +527,8 @@ describe('plugins/voice-compat/twilio', () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
 
-    const fetchSpy = jest.spyOn(globalThis as any, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } }) as any
-    );
+    let endCallSpy: any;
+    let persistSpy: any;
 
     try {
       process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = 'secret';
@@ -553,6 +552,8 @@ describe('plugins/voice-compat/twilio', () => {
       });
 
       const compat = new TwilioVoiceCompat();
+      endCallSpy = jest.spyOn(compat, 'endCall').mockResolvedValue({ ok: true } as any);
+      persistSpy = jest.spyOn(compat as any, 'persistCallLogs').mockResolvedValue(undefined);
       const ws = new MockWebSocket();
       const taskPromise = compat.handleMediaConnection({
         ws: ws as any,
@@ -573,15 +574,16 @@ describe('plugins/voice-compat/twilio', () => {
 
       // With fallback=200ms and silenceTimeout=1000ms, end should happen at ~300ms (chunk) + 200ms + 1000ms = 1500ms.
       await jest.advanceTimersByTimeAsync(1400);
-      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(endCallSpy).not.toHaveBeenCalled();
 
       await jest.advanceTimersByTimeAsync(200);
-      expect(fetchSpy).toHaveBeenCalled();
+      expect(endCallSpy).toHaveBeenCalledTimes(1);
 
       ws.close();
       await taskPromise;
     } finally {
-      fetchSpy.mockRestore();
+      if (endCallSpy) endCallSpy.mockRestore();
+      if (persistSpy) persistSpy.mockRestore();
       jest.useRealTimers();
     }
   });
@@ -590,9 +592,8 @@ describe('plugins/voice-compat/twilio', () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
 
-    const fetchSpy = jest.spyOn(globalThis as any, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } }) as any
-    );
+    let endCallSpy: any;
+    let persistSpy: any;
 
     try {
       process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = 'secret';
@@ -606,6 +607,8 @@ describe('plugins/voice-compat/twilio', () => {
       });
 
       const compat = new TwilioVoiceCompat();
+      endCallSpy = jest.spyOn(compat, 'endCall').mockResolvedValue({ ok: true } as any);
+      persistSpy = jest.spyOn(compat as any, 'persistCallLogs').mockResolvedValue(undefined);
       const ws = new MockWebSocket();
       const taskPromise = compat.handleMediaConnection({
         ws: ws as any,
@@ -626,15 +629,16 @@ describe('plugins/voice-compat/twilio', () => {
 
       // Fallback=200ms + silenceTimeout=1000ms => should end by ~1200ms even without audio boundary events.
       await jest.advanceTimersByTimeAsync(1100);
-      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(endCallSpy).not.toHaveBeenCalled();
 
       await jest.advanceTimersByTimeAsync(200);
-      expect(fetchSpy).toHaveBeenCalled();
+      expect(endCallSpy).toHaveBeenCalledTimes(1);
 
       ws.close();
       await taskPromise;
     } finally {
-      fetchSpy.mockRestore();
+      if (endCallSpy) endCallSpy.mockRestore();
+      if (persistSpy) persistSpy.mockRestore();
       jest.useRealTimers();
     }
   });
@@ -712,17 +716,15 @@ describe('plugins/voice-compat/twilio', () => {
     }
   });
 
-  test('does not schedule assistant-audio-start fallback once assistant audio has already ended', async () => {
-    jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+	  test('does not schedule assistant-audio-start fallback once assistant audio has already ended', async () => {
+	    jest.useFakeTimers();
+	    jest.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+	    let endCallSpy: any;
+	    let persistSpy: any;
 
-    const fetchSpy = jest.spyOn(globalThis as any, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } }) as any
-    );
-
-    try {
-      process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = 'secret';
-      const token = makeToken('secret', { purpose: 'voice_media', callConfigId: 'cfg_1', voiceProvider: 'twilio' });
+	    try {
+	      process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = 'secret';
+	      const token = makeToken('secret', { purpose: 'voice_media', callConfigId: 'cfg_1', voiceProvider: 'twilio' });
 
       const { registry, compatSession } = createRegistryHarnessWithCompatSession({
         events: async function* () {
@@ -732,15 +734,17 @@ describe('plugins/voice-compat/twilio', () => {
         }
       });
 
-      compatSession.commit.mockImplementation(async () => {
-        await new Promise(resolve => setTimeout(resolve, 50));
-      });
+	      compatSession.commit.mockImplementation(async () => {
+	        await new Promise(resolve => setTimeout(resolve, 50));
+	      });
 
-      const compat = new TwilioVoiceCompat();
-      const ws = new MockWebSocket();
-      const taskPromise = compat.handleMediaConnection({
-        ws: ws as any,
-        req: { url: `/voice/media?token=${encodeURIComponent(token)}` } as any,
+	      const compat = new TwilioVoiceCompat();
+	      endCallSpy = jest.spyOn(compat, 'endCall').mockResolvedValue({ ok: true } as any);
+	      persistSpy = jest.spyOn(compat as any, 'persistCallLogs').mockResolvedValue(undefined);
+	      const ws = new MockWebSocket();
+	      const taskPromise = compat.handleMediaConnection({
+	        ws: ws as any,
+	        req: { url: `/voice/media?token=${encodeURIComponent(token)}` } as any,
         callConfigId: 'cfg_1',
         callConfig: {
           realtimeSpec: { provider: 'realtime_p1' },
@@ -753,19 +757,20 @@ describe('plugins/voice-compat/twilio', () => {
       } as any);
 
       ws.emitMessage(startMessage());
-      await jest.advanceTimersByTimeAsync(0);
+	      await jest.advanceTimersByTimeAsync(0);
 
-      // assistant_audio.end should arrive before the assistantFirstTurn commit finishes.
-      await jest.advanceTimersByTimeAsync(60);
-      expect(fetchSpy).not.toHaveBeenCalled();
+	      // assistant_audio.end should arrive before the assistantFirstTurn commit finishes.
+	      await jest.advanceTimersByTimeAsync(60);
+	      expect(endCallSpy).not.toHaveBeenCalled();
 
-      ws.close();
-      await taskPromise;
-    } finally {
-      fetchSpy.mockRestore();
-      jest.useRealTimers();
-    }
-  });
+	      ws.close();
+	      await taskPromise;
+	    } finally {
+	      if (endCallSpy) endCallSpy.mockRestore();
+	      if (persistSpy) persistSpy.mockRestore();
+	      jest.useRealTimers();
+	    }
+	  });
 
   test('handleMediaConnection throws validation_error for invalid timeouts.callTimeoutMs', async () => {
     const { registry } = createRegistryHarness();
@@ -805,6 +810,25 @@ describe('plugins/voice-compat/twilio', () => {
     ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
   });
 
+  test('handleMediaConnection throws validation_error for invalid timeouts.firstTurnGraceMs', async () => {
+    const { registry } = createRegistryHarness();
+    const compat = new TwilioVoiceCompat();
+
+    await expect(
+      compat.handleMediaConnection({
+        ws: new MockWebSocket() as any,
+        req: { url: '/voice/media?token=x' } as any,
+        callConfigId: 'cfg_1',
+        callConfig: {
+          realtimeSpec: { provider: 'realtime_p1' },
+          timeouts: { firstTurnGraceMs: -1 }
+        },
+        voiceProvider: 'twilio',
+        registry
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
+  });
+
   test('handleMediaConnection throws validation_error for invalid timeouts.silenceAssistantAudioEndFallbackMs', async () => {
     const { registry } = createRegistryHarness();
     const compat = new TwilioVoiceCompat();
@@ -822,6 +846,86 @@ describe('plugins/voice-compat/twilio', () => {
         registry
       } as any)
     ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
+  });
+
+  test('handleMediaConnection logs call_logs.persist_failed when persistCallLogs throws', async () => {
+    process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = 'secret';
+    const token = makeToken('secret', { purpose: 'voice_media', callConfigId: 'cfg_1', voiceProvider: 'twilio' });
+
+    const { registry } = createRegistryHarness();
+    const logger = createSpyLogger();
+
+    const compat = new TwilioVoiceCompat();
+    const persistSpy = jest.spyOn(compat as any, 'persistCallLogs').mockImplementation(async () => {
+      throw new Error('boom');
+    });
+
+    try {
+      const ws = new MockWebSocket();
+      const task = compat.handleMediaConnection({
+        ws: ws as any,
+        req: { url: `/voice/media?token=${encodeURIComponent(token)}` } as any,
+        callConfigId: 'cfg_1',
+        callConfig: {
+          realtimeSpec: { provider: 'realtime_p1' }
+        },
+        voiceProvider: 'twilio',
+        registry,
+        logger,
+        providerDefaults: { accountSid: 'AC123', authToken: 'token', apiBaseUrl: 'https://api.example.test' }
+      } as any);
+
+      ws.emitMessage(startMessage());
+      await flush();
+      ws.emitMessage(stopMessage());
+      await task;
+      await flush();
+
+      expect(logger.warning.mock.calls.some(([msg]) => msg === 'voice.twilio.call_logs.persist_failed')).toBe(true);
+    } finally {
+      persistSpy.mockRestore();
+    }
+  });
+
+  test('handleMediaConnection uses String(error) fallback when persistCallLogs throws non-Error', async () => {
+    process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = 'secret';
+    const token = makeToken('secret', { purpose: 'voice_media', callConfigId: 'cfg_1', voiceProvider: 'twilio' });
+
+    const { registry } = createRegistryHarness();
+    const logger = createSpyLogger();
+
+    const compat = new TwilioVoiceCompat();
+    const persistSpy = jest.spyOn(compat as any, 'persistCallLogs').mockImplementation(async () => {
+      // eslint-disable-next-line no-throw-literal
+      throw 'boom';
+    });
+
+    try {
+      const ws = new MockWebSocket();
+      const task = compat.handleMediaConnection({
+        ws: ws as any,
+        req: { url: `/voice/media?token=${encodeURIComponent(token)}` } as any,
+        callConfigId: 'cfg_1',
+        callConfig: {
+          realtimeSpec: { provider: 'realtime_p1' }
+        },
+        voiceProvider: 'twilio',
+        registry,
+        logger,
+        providerDefaults: { accountSid: 'AC123', authToken: 'token', apiBaseUrl: 'https://api.example.test' }
+      } as any);
+
+      ws.emitMessage(startMessage());
+      await flush();
+      ws.emitMessage(stopMessage());
+      await task;
+      await flush();
+
+      const warning = logger.warning.mock.calls.find(([msg]) => msg === 'voice.twilio.call_logs.persist_failed');
+      expect(warning?.[1]).toMatchObject({ message: 'boom' });
+    } finally {
+      persistSpy.mockRestore();
+    }
   });
 
   test('handleMediaConnection throws validation_error for invalid timeouts.silenceAssistantAudioStartFallbackMs', async () => {

--- a/plugins/voice-modules/twilio-media-streams/README.md
+++ b/plugins/voice-modules/twilio-media-streams/README.md
@@ -48,7 +48,8 @@ const bridge = createTwilioMediaStreamsBridge({
     maxSessionDurationMs: 3600000,
     startTimeoutMs: 5000,
     maxPendingInboundFrames: 200,
-    maxPendingOutboundAudioMs: 10000
+    maxPendingOutboundAudioMs: 10000,
+    firstTurnGraceMs: 0
   },
   audio: {
     frameMs: 20,
@@ -161,7 +162,7 @@ In `digit` mode, each key press is injected as a user turn and committed immedia
 
 - Twilio inbound audio is assumed to be **g711_ulaw @ 8000 Hz mono** (the common Media Streams format).
 - Before the realtime session is `ready`, inbound frames are buffered (bounded by `maxPendingInboundFrames`).
-- After `ready`, inbound frames are converted to the session’s negotiated `audio.input` spec if needed, then forwarded via `session.sendAudio(...)`.
+- After `ready`, inbound frames (including any buffered pre-ready frames) are converted to the session’s negotiated `audio.input` spec if needed, then forwarded via `session.sendAudio(...)`.
 
 ### Outbound (session → caller)
 
@@ -200,6 +201,16 @@ In practice, `playback.clear_requested` is emitted when:
 - a session timeout/error requests playback to stop
 
 ---
+
+## First-turn grace window (optional)
+
+Telephony bridges often auto-commit on `user_speech.stopped`, but some realtime providers emit transcript deltas before a proper `user_speech.started` boundary. `limits.firstTurnGraceMs` provides a short “settling” window immediately after the realtime session becomes `ready`:
+
+- During the grace window, `user_transcript.delta` / `user_transcript.final` events are suppressed until the first `user_speech.started`.
+- When a `user_speech.stopped` arrives during the grace window, the bridge schedules the first `session.commit()` for the end of the grace window instead of committing immediately.
+- If the user starts speaking again during the grace window, any scheduled grace commit is cancelled; the turn will commit on the next `user_speech.stopped` after the grace window.
+
+Default: `0` (disabled).
 
 ## TwiML examples (inbound/outbound)
 

--- a/plugins/voice-modules/twilio-media-streams/internal/bridge.ts
+++ b/plugins/voice-modules/twilio-media-streams/internal/bridge.ts
@@ -39,6 +39,7 @@ export interface TwilioMediaStreamsBridgeLimits {
   startTimeoutMs?: number;
   maxPendingInboundFrames?: number;
   maxPendingOutboundAudioMs?: number;
+  firstTurnGraceMs?: number;
 }
 
 export interface TwilioMediaStreamsBridgeAudioOptions {
@@ -86,7 +87,8 @@ const DEFAULT_LIMITS: Required<TwilioMediaStreamsBridgeLimits> = {
   maxSessionDurationMs: 3600000,
   startTimeoutMs: 5000,
   maxPendingInboundFrames: 200,
-  maxPendingOutboundAudioMs: 10000
+  maxPendingOutboundAudioMs: 10000,
+  firstTurnGraceMs: 0
 };
 
 const DEFAULT_AUDIO: Required<Pick<TwilioMediaStreamsBridgeAudioOptions, 'frameMs' | 'markEveryMs'>> = {
@@ -260,6 +262,7 @@ export function createTwilioMediaStreamsBridge(options: TwilioMediaStreamsBridge
       let idleTimer: any | undefined;
       let durationTimer: any | undefined;
       let startTimer: any | undefined;
+      let firstTurnGraceTimer: any | undefined;
 
       let closed = false;
       let metadata: TwilioCallMetadata | undefined;
@@ -297,6 +300,8 @@ export function createTwilioMediaStreamsBridge(options: TwilioMediaStreamsBridge
         if (idleTimer) clearTimeout(idleTimer);
         if (durationTimer) clearTimeout(durationTimer);
         if (startTimer) clearTimeout(startTimer);
+        clearTimeout(firstTurnGraceTimer);
+        firstTurnGraceTimer = undefined;
 
         inboundAudioQueue.close();
         outboundAudioQueue.close();
@@ -380,6 +385,33 @@ export function createTwilioMediaStreamsBridge(options: TwilioMediaStreamsBridge
             const next = await inboundAudioQueue.next();
             if (!next) return;
             try {
+              const target = sessionReadyAudioInput;
+              if (target) {
+                const frame = next.value;
+                const inputSpec: AudioSpec = {
+                  format: frame.format as AudioSpec['format'],
+                  sampleRateHz: Number(frame.sampleRateHz),
+                  channels: frame.channels as 1 | 2
+                };
+
+                const sameFormat = inputSpec.format === target.format;
+                const sameRate = Math.floor(inputSpec.sampleRateHz) === Math.floor(target.sampleRateHz);
+                const sameCh = inputSpec.channels === target.channels;
+
+                if (!sameFormat || !sameRate || !sameCh) {
+                  const inputBytes = base64ToBytes(frame.dataBase64);
+                  const converted = convertAudioBytes({ input: inputBytes, inputSpec, outputSpec: target });
+                  const outBase64 = bytesToBase64(converted);
+                  await localSession.sendAudio({
+                    format: target.format as any,
+                    sampleRateHz: target.sampleRateHz,
+                    channels: target.channels,
+                    dataBase64: outBase64
+                  });
+                  continue;
+                }
+              }
+
               await localSession.sendAudio(next.value);
             } catch (err: any) {
               callbacks.onError?.({ message: err?.message ?? String(err), code: 'session_send_audio_failed', metadata });
@@ -437,16 +469,62 @@ export function createTwilioMediaStreamsBridge(options: TwilioMediaStreamsBridge
 
             callbacks.onRealtimeEvent?.({ event: first.value, metadata: call });
 
+            const firstTurnGraceMs = Math.max(0, Math.floor(Number(limits.firstTurnGraceMs ?? 0)));
+            const readyAtMs = Date.now();
+            const firstTurnGraceEndsAtMs = firstTurnGraceMs > 0 ? readyAtMs + firstTurnGraceMs : 0;
+            let firstAutoCommitDone = false;
+            let sawUserSpeechStarted = false;
+
+            const scheduleCommitAfterGrace = () => {
+              const delay = Math.max(0, firstTurnGraceEndsAtMs - Date.now());
+              clearTimeout(firstTurnGraceTimer);
+              firstTurnGraceTimer = setTimeout(() => {
+                firstTurnGraceTimer = undefined;
+                void (async () => {
+                  try {
+                    await localSession.commit();
+                    firstAutoCommitDone = true;
+                  } catch (err: any) {
+                    callbacks.onError?.({ message: err?.message ?? String(err), code: 'session_commit_failed', metadata });
+                    void closeAll();
+                  }
+                })();
+              }, delay);
+              if (typeof (firstTurnGraceTimer as any)?.unref === 'function') {
+                try {
+                  (firstTurnGraceTimer as any).unref();
+                } catch {}
+              }
+            };
+
             for await (const event of { [Symbol.asyncIterator]: () => iter } as AsyncIterable<RealtimeEvent>) {
-              callbacks.onRealtimeEvent?.({ event, metadata: call });
+              const inGrace = Boolean(firstTurnGraceEndsAtMs) && Date.now() < firstTurnGraceEndsAtMs && !firstAutoCommitDone;
+              const suppressUserTranscripts =
+                inGrace &&
+                !sawUserSpeechStarted &&
+                (event.type === 'user_transcript.delta' || event.type === 'user_transcript.final');
+
+              if (!suppressUserTranscripts) {
+                callbacks.onRealtimeEvent?.({ event, metadata: call });
+              }
 
               if (event.type === 'user_speech.started') {
                 pendingUserSpeech = true;
+                if (inGrace) sawUserSpeechStarted = true;
+                if (inGrace) {
+                  clearTimeout(firstTurnGraceTimer);
+                  firstTurnGraceTimer = undefined;
+                }
               } else if (event.type === 'user_speech.stopped') {
                 if (pendingUserSpeech) {
                   pendingUserSpeech = false;
                   try {
-                    await localSession.commit();
+                    if (inGrace && !firstAutoCommitDone) {
+                      scheduleCommitAfterGrace();
+                    } else {
+                      await localSession.commit();
+                      firstAutoCommitDone = true;
+                    }
                   } catch (err: any) {
                     callbacks.onError?.({ message: err?.message ?? String(err), code: 'session_commit_failed', metadata });
                     void closeAll();

--- a/plugins/voice-modules/twilio-media-streams/tests/integration/twilio-media-streams.bridge.test.ts
+++ b/plugins/voice-modules/twilio-media-streams/tests/integration/twilio-media-streams.bridge.test.ts
@@ -196,6 +196,50 @@ describe('plugins/voice-modules/twilio-media-streams (bridge integration)', () =
     expect(session.close).toHaveBeenCalled();
   });
 
+  test('converts buffered pre-ready inbound media to negotiated pcm16 input', async () => {
+    const secret = 'secret';
+    const token = makeToken(secret);
+
+    const session = new MockRealtimeSession();
+
+    const bridge = createTwilioMediaStreamsBridge({
+      createSession: async () => session,
+      security: { tokenSecret: secret },
+      limits: { startTimeoutMs: 0, idleTimeoutMs: 0, maxSessionDurationMs: 0 },
+      audio: { pacing: { enabled: false } }
+    });
+
+    const ws = new MockWebSocket();
+    const task = bridge.handleConnection(ws as any, { url: `/ws?token=${encodeURIComponent(token)}` });
+
+    ws.emitMessage(startMessage({}));
+    await flush();
+
+    const inboundBytes = new Uint8Array(160).fill(0xff);
+    ws.emitMessage(mediaMessage({ payloadBase64: bytesToBase64(inboundBytes) }));
+    await flush();
+
+    session.push({
+      type: 'ready',
+      sessionId: 's1',
+      audio: {
+        input: { format: 'pcm16', sampleRateHz: 8000, channels: 1 },
+        output: { format: 'g711_ulaw', sampleRateHz: 8000, channels: 1 }
+      }
+    } as any);
+    await flush();
+
+    expect(session.sendAudio).toHaveBeenCalledTimes(1);
+    const sentFrame = (session.sendAudio as any).mock.calls[0][0];
+    expect(sentFrame.format).toBe('pcm16');
+    expect(sentFrame.sampleRateHz).toBe(8000);
+    expect(sentFrame.channels).toBe(1);
+    expect(base64ToBytes(sentFrame.dataBase64).length).toBeGreaterThan(inboundBytes.length);
+
+    ws.emitMessage(stopMessage({}));
+    await task;
+  });
+
   test('strips voiceMediaToken from call metadata customParameters', async () => {
     const secret = 'secret';
     const token = makeToken(secret);
@@ -323,6 +367,116 @@ describe('plugins/voice-modules/twilio-media-streams (bridge integration)', () =
     await flush();
 
     expect(session.commit).toHaveBeenCalledTimes(1);
+
+    ws.emitMessage(stopMessage({}));
+    await task;
+  });
+
+  test('firstTurnGraceMs delays first auto-commit within the grace window', async () => {
+    const secret = 'secret';
+    const token = makeToken(secret);
+
+    const session = new MockRealtimeSession();
+    session.push({ type: 'ready', sessionId: 's1' });
+
+    const bridge = createTwilioMediaStreamsBridge({
+      createSession: async () => session,
+      security: { tokenSecret: secret },
+      limits: { startTimeoutMs: 0, idleTimeoutMs: 0, maxSessionDurationMs: 0, firstTurnGraceMs: 50 } as any,
+      audio: { pacing: { enabled: false } }
+    });
+
+    const ws = new MockWebSocket();
+    const task = bridge.handleConnection(ws as any, { url: `/ws?token=${encodeURIComponent(token)}` });
+    ws.emitMessage(startMessage({}));
+    await flush();
+
+    session.push({ type: 'user_speech.started' } as any);
+    session.push({ type: 'user_speech.stopped' } as any);
+    await flush();
+
+    expect(session.commit).toHaveBeenCalledTimes(0);
+
+    await new Promise(resolve => setTimeout(resolve, 60));
+    await flush();
+
+    expect(session.commit).toHaveBeenCalledTimes(1);
+
+    ws.emitMessage(stopMessage({}));
+    await task;
+  });
+
+  test('firstTurnGraceMs suppresses early user_transcript.final when no speech has started', async () => {
+    const secret = 'secret';
+    const token = makeToken(secret);
+
+    const session = new MockRealtimeSession();
+    session.push({ type: 'ready', sessionId: 's1' });
+
+    const onRealtimeEvent = jest.fn();
+    const bridge = createTwilioMediaStreamsBridge({
+      createSession: async () => session,
+      security: { tokenSecret: secret },
+      limits: { startTimeoutMs: 0, idleTimeoutMs: 0, maxSessionDurationMs: 0, firstTurnGraceMs: 50 } as any,
+      audio: { pacing: { enabled: false } },
+      callbacks: { onRealtimeEvent }
+    });
+
+    const ws = new MockWebSocket();
+    const task = bridge.handleConnection(ws as any, { url: `/ws?token=${encodeURIComponent(token)}` });
+    ws.emitMessage(startMessage({}));
+    await flush();
+
+    session.push({ type: 'user_transcript.final', text: 'bogus' } as any);
+    await flush();
+
+    const emittedBogus = onRealtimeEvent.mock.calls.some(([arg]) =>
+      arg?.event?.type === 'user_transcript.final' && arg?.event?.text === 'bogus'
+    );
+    expect(emittedBogus).toBe(false);
+
+    await new Promise(resolve => setTimeout(resolve, 60));
+    session.push({ type: 'user_transcript.final', text: 'ok' } as any);
+    await flush();
+
+    const emittedOk = onRealtimeEvent.mock.calls.some(([arg]) =>
+      arg?.event?.type === 'user_transcript.final' && arg?.event?.text === 'ok'
+    );
+    expect(emittedOk).toBe(true);
+
+    ws.emitMessage(stopMessage({}));
+    await task;
+  });
+
+  test('firstTurnGraceMs does not suppress transcripts once speech has started', async () => {
+    const secret = 'secret';
+    const token = makeToken(secret);
+
+    const session = new MockRealtimeSession();
+    session.push({ type: 'ready', sessionId: 's1' });
+
+    const onRealtimeEvent = jest.fn();
+    const bridge = createTwilioMediaStreamsBridge({
+      createSession: async () => session,
+      security: { tokenSecret: secret },
+      limits: { startTimeoutMs: 0, idleTimeoutMs: 0, maxSessionDurationMs: 0, firstTurnGraceMs: 50 } as any,
+      audio: { pacing: { enabled: false } },
+      callbacks: { onRealtimeEvent }
+    });
+
+    const ws = new MockWebSocket();
+    const task = bridge.handleConnection(ws as any, { url: `/ws?token=${encodeURIComponent(token)}` });
+    ws.emitMessage(startMessage({}));
+    await flush();
+
+    session.push({ type: 'user_speech.started' } as any);
+    session.push({ type: 'user_transcript.final', text: 'hello' } as any);
+    await flush();
+
+    const emitted = onRealtimeEvent.mock.calls.some(([arg]) =>
+      arg?.event?.type === 'user_transcript.final' && arg?.event?.text === 'hello'
+    );
+    expect(emitted).toBe(true);
 
     ws.emitMessage(stopMessage({}));
     await task;

--- a/plugins/voice-modules/twilio-media-streams/tests/unit/twilio-media-streams.bridge-coverage.test.ts
+++ b/plugins/voice-modules/twilio-media-streams/tests/unit/twilio-media-streams.bridge-coverage.test.ts
@@ -1004,11 +1004,197 @@ describe('plugins/voice-modules/twilio-media-streams — bridge coverage cases',
     jest.useRealTimers();
   });
 
-  test('bridge_error uses fallback code when non-coded error thrown in message handler', async () => {
-    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
-    const secret = 'secret';
-    const token = makeToken(secret);
-    const onError = jest.fn();
+	  test('grace-window scheduled commit failure reports session_commit_failed', async () => {
+	    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+	    const secret = 'secret';
+	    const token = makeToken(secret);
+	    const onError = jest.fn();
+	    let resolveSawStopped: (() => void) | undefined;
+	    const sawStopped = new Promise<void>(resolve => {
+	      resolveSawStopped = resolve;
+	    });
+
+	    const session = new MockRealtimeSession();
+	    session.commit.mockImplementation(async () => { throw new Error('commit boom'); });
+	    session.push({ type: 'ready', sessionId: 's1' });
+
+	    const bridge = createTwilioMediaStreamsBridge({
+	      createSession: async () => session,
+	      security: { tokenSecret: secret },
+	      limits: { startTimeoutMs: 0, idleTimeoutMs: 0, maxSessionDurationMs: 0, firstTurnGraceMs: 50 } as any,
+	      callbacks: {
+	        onError,
+	        onRealtimeEvent: ({ event }) => {
+	          if (event?.type === 'user_speech.stopped') resolveSawStopped?.();
+	        }
+	      }
+	    });
+
+	    const ws = new MockWebSocket();
+	    const task = bridge.handleConnection(ws as any, { url: `/ws?token=${encodeURIComponent(token)}` });
+	    ws.emitMessage(startMessage({ customParameters: { from: 'x', to: 'y' } }));
+	    await flush();
+
+	    session.push({ type: 'user_speech.started' });
+	    session.push({ type: 'user_speech.stopped' });
+	    await flush();
+	    await sawStopped;
+
+	    expect(session.commit).not.toHaveBeenCalled();
+	    expect(onError).not.toHaveBeenCalled();
+	    expect(ws.closed.length).toBe(0);
+
+    jest.advanceTimersByTime(49);
+    await flush();
+
+    expect(session.commit).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    await flush();
+
+    await task;
+
+	    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ code: 'session_commit_failed', message: 'commit boom' }));
+	    jest.useRealTimers();
+	  });
+
+	  test('grace-window scheduled commit failure uses String(err) fallback when non-Error thrown', async () => {
+	    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+	    const secret = 'secret';
+	    const token = makeToken(secret);
+	    const onError = jest.fn();
+	    let resolveSawStopped: (() => void) | undefined;
+	    const sawStopped = new Promise<void>(resolve => {
+	      resolveSawStopped = resolve;
+	    });
+
+	    const session = new MockRealtimeSession();
+	    // eslint-disable-next-line no-throw-literal
+	    session.commit.mockImplementation(async () => { throw 'boom'; });
+	    session.push({ type: 'ready', sessionId: 's1' });
+
+	    const bridge = createTwilioMediaStreamsBridge({
+	      createSession: async () => session,
+	      security: { tokenSecret: secret },
+	      limits: { startTimeoutMs: 0, idleTimeoutMs: 0, maxSessionDurationMs: 0, firstTurnGraceMs: 50 } as any,
+	      callbacks: {
+	        onError,
+	        onRealtimeEvent: ({ event }) => {
+	          if (event?.type === 'user_speech.stopped') resolveSawStopped?.();
+	        }
+	      }
+	    });
+
+	    const ws = new MockWebSocket();
+	    const task = bridge.handleConnection(ws as any, { url: `/ws?token=${encodeURIComponent(token)}` });
+	    ws.emitMessage(startMessage({ customParameters: { from: 'x', to: 'y' } }));
+	    await flush();
+
+	    session.push({ type: 'user_speech.started' });
+	    session.push({ type: 'user_speech.stopped' });
+	    await flush();
+	    await sawStopped;
+
+	    jest.advanceTimersByTime(60);
+	    await flush();
+
+	    await task;
+
+	    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ code: 'session_commit_failed', message: 'boom' }));
+	    jest.useRealTimers();
+	  });
+
+	  test('grace-window cancels pending commit if user starts speaking again before grace ends', async () => {
+	    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+	    const secret = 'secret';
+	    const token = makeToken(secret);
+
+	    const session = new MockRealtimeSession();
+	    session.push({ type: 'ready', sessionId: 's1' });
+
+	    let startedCount = 0;
+	    let stoppedCount = 0;
+	    let resolveFirstStop: (() => void) | undefined;
+	    let resolveSecondStart: (() => void) | undefined;
+	    let resolveSecondStop: (() => void) | undefined;
+	    const firstStop = new Promise<void>(resolve => { resolveFirstStop = resolve; });
+	    const secondStart = new Promise<void>(resolve => { resolveSecondStart = resolve; });
+	    const secondStop = new Promise<void>(resolve => { resolveSecondStop = resolve; });
+
+	    const bridge = createTwilioMediaStreamsBridge({
+	      createSession: async () => session,
+	      security: { tokenSecret: secret },
+	      limits: { startTimeoutMs: 0, idleTimeoutMs: 0, maxSessionDurationMs: 0, firstTurnGraceMs: 50 } as any,
+	      callbacks: {
+	        onRealtimeEvent: ({ event }) => {
+	          if (event?.type === 'user_speech.started') {
+	            startedCount += 1;
+	            if (startedCount === 2) resolveSecondStart?.();
+	          } else if (event?.type === 'user_speech.stopped') {
+	            stoppedCount += 1;
+	            if (stoppedCount === 1) resolveFirstStop?.();
+	            if (stoppedCount === 2) resolveSecondStop?.();
+	          }
+	        }
+	      }
+	    });
+
+	    const ws = new MockWebSocket();
+	    const task = bridge.handleConnection(ws as any, { url: `/ws?token=${encodeURIComponent(token)}` });
+	    ws.emitMessage(startMessage({ customParameters: { from: 'x', to: 'y' } }));
+	    await flush();
+
+	    session.push({ type: 'user_speech.started' });
+	    session.push({ type: 'user_speech.stopped' });
+	    await firstStop;
+
+	    // Start speaking again before grace ends, which should cancel the pending grace commit.
+	    session.push({ type: 'user_speech.started' });
+	    await secondStart;
+
+	    jest.advanceTimersByTime(60);
+	    await flush();
+	    expect(session.commit).not.toHaveBeenCalled();
+
+	    // Stop speaking after grace ends; commit should happen immediately (non-grace path).
+	    session.push({ type: 'user_speech.stopped' });
+	    await secondStop;
+	    expect(session.commit).toHaveBeenCalledTimes(1);
+
+	    ws.emitMessage(stopMessage({}));
+	    await task;
+	    jest.useRealTimers();
+	  });
+
+	  test('treats firstTurnGraceMs as 0 when explicitly undefined', async () => {
+	    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+	    const secret = 'secret';
+	    const token = makeToken(secret);
+
+	    const session = new MockRealtimeSession();
+	    session.push({ type: 'ready', sessionId: 's1' });
+
+	    const bridge = createTwilioMediaStreamsBridge({
+	      createSession: async () => session,
+	      security: { tokenSecret: secret },
+	      limits: { startTimeoutMs: 0, idleTimeoutMs: 0, maxSessionDurationMs: 0, firstTurnGraceMs: undefined } as any
+	    });
+
+	    const ws = new MockWebSocket();
+	    const task = bridge.handleConnection(ws as any, { url: `/ws?token=${encodeURIComponent(token)}` });
+	    ws.emitMessage(startMessage({ customParameters: { from: 'x', to: 'y' } }));
+	    await flush();
+	    ws.emitMessage(stopMessage({}));
+	    await task;
+	    jest.useRealTimers();
+	  });
+
+	  test('bridge_error uses fallback code when non-coded error thrown in message handler', async () => {
+	    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+	    const secret = 'secret';
+	    const token = makeToken(secret);
+	    const onError = jest.fn();
 
     const bridge = createTwilioMediaStreamsBridge({
       createSession: async () => new MockRealtimeSession(),

--- a/tests/unit/realtime-compat/grok-realtime-commands.test.ts
+++ b/tests/unit/realtime-compat/grok-realtime-commands.test.ts
@@ -318,8 +318,13 @@ describe('realtime-compat/grok — commands', () => {
   });
 
   test('buildResponseCreateEvent includes tool_choice when provided', () => {
-    expect(buildResponseCreateEvent().response).toBeUndefined();
-    expect(buildResponseCreateEvent({ toolChoice: 'required' }).response.tool_choice).toBe('required');
+    const base = buildResponseCreateEvent();
+    expect(base.response?.modalities).toEqual(['text', 'audio']);
+    expect(base.response?.tool_choice).toBeUndefined();
+
+    const forced = buildResponseCreateEvent({ toolChoice: 'required' });
+    expect(forced.response?.modalities).toEqual(['text', 'audio']);
+    expect(forced.response?.tool_choice).toBe('required');
   });
 
   test('buildToolResultItemCreateEvent serializes string and JSON results', () => {

--- a/tests/unit/realtime-compat/grok-realtime-provider-event-logging.test.ts
+++ b/tests/unit/realtime-compat/grok-realtime-provider-event-logging.test.ts
@@ -1,0 +1,255 @@
+import fs from 'fs';
+import path from 'path';
+import { jest } from '@jest/globals';
+
+import type { RealtimeEvent } from '@/kernel/index.ts';
+import { AsyncQueue } from '@/kernel/index.ts';
+import { withTempCwd } from '@tests/helpers/temp-files.ts';
+
+type TransportEvent =
+  | { type: 'open' }
+  | { type: 'message'; data: string }
+  | { type: 'error'; error: unknown; code?: string }
+  | { type: 'close' };
+
+function createFakeTransport() {
+  const q = new AsyncQueue<TransportEvent>();
+  const sent: any[] = [];
+  let closed = false;
+
+  return {
+    sent,
+    push: (evt: TransportEvent) => q.push(evt),
+    close: () => {
+      if (closed) return;
+      closed = true;
+      q.push({ type: 'close' });
+      q.close();
+    },
+    transport: {
+      send: (data: string) => {
+        sent.push(JSON.parse(data));
+      },
+      events: () => q.iterate(),
+      close: () => {
+        if (closed) return;
+        closed = true;
+        q.push({ type: 'close' });
+        q.close();
+      }
+    }
+  };
+}
+
+async function waitForEvent<T extends RealtimeEvent = RealtimeEvent>(
+  iter: AsyncIterator<RealtimeEvent>,
+  predicate: (value: RealtimeEvent) => boolean,
+  timeoutMs = 2000
+): Promise<T> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const next = await iter.next();
+    if (next.done) throw new Error('session events closed');
+    if (predicate(next.value as any)) return next.value as any;
+  }
+  throw new Error('timed out waiting for event');
+}
+
+async function flush(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function readRealtimeLogLines(cwd: string): any[] {
+  const dir = path.join(cwd, 'logs', 'realtime');
+  if (!fs.existsSync(dir)) return [];
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.log'));
+  if (files.length === 0) return [];
+  const content = fs.readFileSync(path.join(dir, files[0] as string), 'utf-8');
+  return content
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+}
+
+describe('realtime-compat/grok — provider event logging', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.useRealTimers();
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  const provider: any = {
+    id: 'grok',
+    compat: 'grok',
+    endpoint: { urlTemplate: 'wss://api.x.ai/v1/realtime', headers: { Authorization: 'Bearer sk' } },
+    metadata: { defaultVoice: 'ara' }
+  };
+
+  test('disabled by default: does not emit provider-event logs', async () => {
+    await withTempCwd('grok-rt-provider-log-disabled', async (cwd) => {
+      delete process.env.LLM_ADAPTER_REALTIME_LOG_PROVIDER_EVENTS_MS;
+      process.env.LLM_ADAPTER_DISABLE_FILE_LOGS = '0';
+
+      await jest.isolateModulesAsync(async () => {
+        const { createGrokRealtimeCompatSessionWithTransport } = await import(
+          '@/plugins/realtime-compat/grok/internal/session-core.ts'
+        );
+
+        const fake = createFakeTransport();
+        const session = createGrokRealtimeCompatSessionWithTransport(
+          { provider, spec: { provider: 'grok' } as any } as any,
+          fake.transport as any
+        );
+
+        const it = session.events()[Symbol.asyncIterator]();
+        fake.push({ type: 'open' });
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'conversation.created' }) });
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'session.updated' }) });
+        await waitForEvent(it, e => e.type === 'ready');
+
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'response.output_audio.delta', delta: 'AA==' }) });
+        await flush();
+
+        const lines = readRealtimeLogLines(cwd);
+        expect(lines.length).toBe(0);
+
+        await session.close();
+      });
+    });
+  });
+
+  test('redacts audio payloads and stops logging after the configured window', async () => {
+    await withTempCwd('grok-rt-provider-log-enabled', async (cwd) => {
+      process.env.LLM_ADAPTER_DISABLE_FILE_LOGS = '0';
+      process.env.LLM_ADAPTER_REALTIME_LOG_PROVIDER_EVENTS_MS = '20';
+
+      await jest.isolateModulesAsync(async () => {
+        const { createGrokRealtimeCompatSessionWithTransport } = await import(
+          '@/plugins/realtime-compat/grok/internal/session-core.ts'
+        );
+
+        const fake = createFakeTransport();
+        const session = createGrokRealtimeCompatSessionWithTransport(
+          { provider, spec: { provider: 'grok' } as any } as any,
+          fake.transport as any
+        );
+
+        const it = session.events()[Symbol.asyncIterator]();
+        fake.push({ type: 'open' });
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'conversation.created' }) });
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'session.updated' }) });
+        await waitForEvent(it, e => e.type === 'ready');
+
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'response.output_audio.delta', delta: 'AA==' }) });
+        await flush();
+
+        await new Promise(resolve => setTimeout(resolve, 30));
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'response.output_audio.delta', delta: 'BB==' }) });
+        await flush();
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'response.output_audio.delta', delta: 'CC==' }) });
+        await flush();
+
+        const logging = await import('@/modules/logging/index.ts');
+        await logging.closeLogger();
+
+        const lines = readRealtimeLogLines(cwd);
+        const providerLogs = lines.filter(l => l?.message === 'realtime.provider_event');
+        expect(providerLogs).toHaveLength(1);
+
+        const first = providerLogs[0];
+        expect(first?.data?.providerEvent?.type).toBe('response.output_audio.delta');
+        expect(first?.data?.providerEvent?.delta).toBe('[REDACTED_BASE64]');
+
+        const content = JSON.stringify(providerLogs);
+        expect(content).not.toContain('AA==');
+        expect(content).not.toContain('BB==');
+        expect(content).not.toContain('CC==');
+
+        await session.close();
+      });
+    });
+  });
+
+  test('logs non-object provider payloads and reuses the logger within the window', async () => {
+    await withTempCwd('grok-rt-provider-log-varied', async (cwd) => {
+      process.env.LLM_ADAPTER_DISABLE_FILE_LOGS = '0';
+      process.env.LLM_ADAPTER_REALTIME_LOG_PROVIDER_EVENTS_MS = '200';
+
+      await jest.isolateModulesAsync(async () => {
+        const { createGrokRealtimeCompatSessionWithTransport } = await import(
+          '@/plugins/realtime-compat/grok/internal/session-core.ts'
+        );
+
+        const fake = createFakeTransport();
+        const session = createGrokRealtimeCompatSessionWithTransport(
+          { provider, spec: { provider: 'grok' } as any } as any,
+          fake.transport as any
+        );
+
+        const it = session.events()[Symbol.asyncIterator]();
+        fake.push({ type: 'open' });
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'conversation.created' }) });
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'session.updated' }) });
+        await waitForEvent(it, e => e.type === 'ready');
+
+        fake.push({ type: 'message', data: JSON.stringify('hi') });
+        fake.push({ type: 'message', data: JSON.stringify([1, 2, 3]) });
+        await flush();
+
+        const logging = await import('@/modules/logging/index.ts');
+        await logging.closeLogger();
+
+        const lines = readRealtimeLogLines(cwd);
+        const providerLogs = lines.filter(l => l?.message === 'realtime.provider_event');
+        expect(providerLogs).toHaveLength(2);
+        expect(providerLogs[0]?.data?.providerEvent).toBe('hi');
+        expect(providerLogs[1]?.data?.providerEvent).toEqual([1, 2, 3]);
+
+        await session.close();
+      });
+    });
+  });
+
+  test('best-effort: logger initialization failure does not break the session', async () => {
+    await withTempCwd('grok-rt-provider-log-logger-failure', async () => {
+      process.env.LLM_ADAPTER_DISABLE_FILE_LOGS = '0';
+      process.env.LLM_ADAPTER_REALTIME_LOG_PROVIDER_EVENTS_MS = '50';
+
+      await jest.isolateModulesAsync(async () => {
+        let getRealtimeLogger: any;
+        jest.unstable_mockModule('../../../modules/logging/index.js', () => ({
+          getRealtimeLogger: (getRealtimeLogger = jest.fn(() => {
+            throw new Error('boom');
+          }))
+        }));
+
+        const { createGrokRealtimeCompatSessionWithTransport } = await import(
+          '@/plugins/realtime-compat/grok/internal/session-core.ts'
+        );
+
+        const fake = createFakeTransport();
+        const session = createGrokRealtimeCompatSessionWithTransport(
+          { provider, spec: { provider: 'grok' } as any } as any,
+          fake.transport as any
+        );
+
+        const it = session.events()[Symbol.asyncIterator]();
+        fake.push({ type: 'open' });
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'conversation.created' }) });
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'session.updated' }) });
+        await waitForEvent(it, e => e.type === 'ready');
+
+        fake.push({ type: 'message', data: JSON.stringify({ type: 'input_audio_buffer.speech_started' }) });
+        await waitForEvent(it, e => e.type === 'user_speech.started');
+
+        expect(getRealtimeLogger).toHaveBeenCalled();
+
+        await session.close();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Implements #791 (and subissues #792–#796).\n\nKey changes:\n- Grok realtime: always request audio+text modalities on response.create; forward tool_choice when present.\n- Twilio media-streams: convert pre-ready buffered inbound audio into negotiated session input format before sendAudio.\n- First-turn mitigation: configurable grace window (timeouts.firstTurnGraceMs) to delay first auto-commit/suppress early user transcripts; default enabled only for grok via Twilio voice compat.\n- Grok realtime: env-gated raw provider event logging window (LLM_ADAPTER_REALTIME_LOG_PROVIDER_EVENTS_MS) with audio delta redaction.\n- Docs updates for the above.\n\nVerification:\n- npm test (100% coverage)\n- npm run test:extensions:voice (100% coverage)\n- npm run test:live:openrouter -- --transport=both\n- npm run test:live:realtime -- --transport=both\n