### PR TITLE
Issue #828: Realtime compat fixes (OpenAI voice + Gemini thinking settings)

### DIFF
--- a/plugins/realtime-compat/gemini/README.md
+++ b/plugins/realtime-compat/gemini/README.md
@@ -89,14 +89,14 @@ Pass extended settings via `spec.settings`. All settings support both camelCase 
 | `topK` | int | Top-K sampling parameter |
 | `enableAffectiveDialog` | boolean | Enable affective dialog (adapts response style to input tone) |
 | `proactiveAudio` | boolean | Enable proactive audio responses |
-| `thinkingBudget` | int | Thinking token budget for reasoning models |
-| `includeThoughts` | boolean | Include thinking process in responses |
 | `startOfSpeechSensitivity` | string | Speech start detection sensitivity (e.g., `"START_SENSITIVITY_LOW"`) |
 | `endOfSpeechSensitivity` | string | Speech end detection sensitivity (e.g., `"END_SENSITIVITY_HIGH"`) |
 | `vadPrefixPaddingMs` | int | Audio padding before speech detection |
 | `vadSilenceDurationMs` | int | Silence duration to end turn |
 
 Note: `int` values are parsed as **positive integers (>0)**.
+
+Note: Thinking settings are **not supported** for Live sessions. If provided, they will be ignored and surfaced as `unsupported_session_settings`.
 
 Example:
 ```ts
@@ -110,7 +110,6 @@ const session = await createRealtimeSession(registry, {
     top_p: 0.95,
     enable_affective_dialog: true,
     proactive_audio: true,
-    thinking_budget: 1024,
     start_of_speech_sensitivity: 'START_SENSITIVITY_LOW',
     vad_silence_duration_ms: 300
   }

--- a/plugins/realtime-compat/gemini/internal/commands.ts
+++ b/plugins/realtime-compat/gemini/internal/commands.ts
@@ -15,8 +15,6 @@ const GEMINI_SESSION_SETTINGS_DEFINITIONS = {
   topK: { type: 'int', aliases: ['top_k'] },
   enableAffectiveDialog: { type: 'boolean', aliases: ['enable_affective_dialog'] },
   proactiveAudio: { type: 'boolean', aliases: ['proactive_audio'] },
-  thinkingBudget: { type: 'int', aliases: ['thinking_budget'] },
-  includeThoughts: { type: 'boolean', aliases: ['include_thoughts'] },
   startOfSpeechSensitivity: { type: 'string', aliases: ['start_of_speech_sensitivity'] },
   endOfSpeechSensitivity: { type: 'string', aliases: ['end_of_speech_sensitivity'] },
   vadPrefixPaddingMs: { type: 'int', aliases: ['vad_prefix_padding_ms'] },
@@ -80,9 +78,6 @@ export function buildGeminiSetupMessage(options: {
     typeof settingsValues.enableAffectiveDialog === 'boolean' ? settingsValues.enableAffectiveDialog : undefined;
   const proactiveAudio =
     typeof settingsValues.proactiveAudio === 'boolean' ? settingsValues.proactiveAudio : undefined;
-  const thinkingBudget = typeof settingsValues.thinkingBudget === 'number' ? settingsValues.thinkingBudget : undefined;
-  const includeThoughts =
-    typeof settingsValues.includeThoughts === 'boolean' ? settingsValues.includeThoughts : undefined;
   const startOfSpeechSensitivity =
     typeof settingsValues.startOfSpeechSensitivity === 'string' ? settingsValues.startOfSpeechSensitivity : undefined;
   const endOfSpeechSensitivity =
@@ -123,13 +118,6 @@ export function buildGeminiSetupMessage(options: {
   // Apply proactive audio
   if (proactiveAudio !== undefined) {
     setup.proactivity = { proactiveAudio };
-  }
-
-  // Apply thinking config
-  if (thinkingBudget !== undefined || includeThoughts !== undefined) {
-    setup.thinkingConfig = {};
-    if (thinkingBudget !== undefined) setup.thinkingConfig.thinkingBudget = thinkingBudget;
-    if (includeThoughts !== undefined) setup.thinkingConfig.includeThoughts = includeThoughts;
   }
 
   const history = Array.isArray(options.spec.history) ? options.spec.history : [];

--- a/plugins/realtime-compat/openai/internal/commands.ts
+++ b/plugins/realtime-compat/openai/internal/commands.ts
@@ -246,7 +246,6 @@ export function buildSessionUpdateEvent(options: {
       type: 'realtime',
       instructions: options.spec.systemPrompt ?? undefined,
       output_modalities: ['audio'],
-      ...(voice ? { voice } : {}),
       ...(temperature !== undefined ? { temperature } : {}),
       ...(speed !== undefined ? { speed } : {}),
       ...(maxResponseOutputTokens ? { max_response_output_tokens: maxResponseOutputTokens } : {}),
@@ -265,7 +264,8 @@ export function buildSessionUpdateEvent(options: {
           turn_detection: turnDetection
         },
         output: {
-          format: toOpenAIAudioFormat(audio.output.format)
+          format: toOpenAIAudioFormat(audio.output.format),
+          ...(voice ? { voice } : {})
         }
       },
       ...(toolsForSession ? { tools: toolsForSession } : {}),

--- a/tests/unit/realtime-compat/gemini-realtime-commands.test.ts
+++ b/tests/unit/realtime-compat/gemini-realtime-commands.test.ts
@@ -457,8 +457,8 @@ describe('realtime-compat/gemini — commands', () => {
     expect(message.setup.proactivity).toEqual({ proactiveAudio: true });
   });
 
-  test('buildGeminiSetupMessage applies thinkingConfig', () => {
-    const { message } = buildGeminiSetupMessage({
+  test('buildGeminiSetupMessage treats thinking settings as unsupported (does not set thinkingConfig)', () => {
+    const { message, settingsWarnings } = buildGeminiSetupMessage({
       model: 'm',
       spec: {
         provider: 'google',
@@ -467,14 +467,13 @@ describe('realtime-compat/gemini — commands', () => {
       }
     });
 
-    expect(message.setup.thinkingConfig).toEqual({
-      thinkingBudget: 1024,
-      includeThoughts: true
-    });
+    expect(message.setup.thinkingConfig).toBeUndefined();
+    expect(settingsWarnings.invalidKeys).toEqual([]);
+    expect(settingsWarnings.unknownKeys.sort()).toEqual(['include_thoughts', 'thinking_budget']);
   });
 
-  test('buildGeminiSetupMessage applies thinkingConfig with only thinkingBudget', () => {
-    const { message } = buildGeminiSetupMessage({
+  test('buildGeminiSetupMessage treats thinkingBudget as unsupported (camelCase)', () => {
+    const { message, settingsWarnings } = buildGeminiSetupMessage({
       model: 'm',
       spec: {
         provider: 'google',
@@ -483,7 +482,9 @@ describe('realtime-compat/gemini — commands', () => {
       }
     });
 
-    expect(message.setup.thinkingConfig).toEqual({ thinkingBudget: 512 });
+    expect(message.setup.thinkingConfig).toBeUndefined();
+    expect(settingsWarnings.invalidKeys).toEqual([]);
+    expect(settingsWarnings.unknownKeys).toEqual(['thinkingBudget']);
   });
 
   test('buildGeminiSetupMessage applies VAD settings in server_vad mode', () => {
@@ -544,7 +545,7 @@ describe('realtime-compat/gemini — commands', () => {
   });
 
   test('buildGeminiSetupMessage combines all extended settings correctly', () => {
-    const { message } = buildGeminiSetupMessage({
+    const { message, settingsWarnings } = buildGeminiSetupMessage({
       model: 'm',
       spec: {
         provider: 'google',
@@ -573,7 +574,9 @@ describe('realtime-compat/gemini — commands', () => {
     expect(message.setup.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName).toBe('Aoede');
     expect(message.setup.enableAffectiveDialog).toBe(true);
     expect(message.setup.proactivity).toEqual({ proactiveAudio: true });
-    expect(message.setup.thinkingConfig).toEqual({ thinkingBudget: 512 });
+    expect(message.setup.thinkingConfig).toBeUndefined();
+    expect(settingsWarnings.invalidKeys).toEqual([]);
+    expect(settingsWarnings.unknownKeys).toEqual(['thinkingBudget']);
     expect(message.setup.realtimeInputConfig.automaticActivityDetection.startOfSpeechSensitivity).toBe('START_SENSITIVITY_HIGH');
     expect(message.setup.realtimeInputConfig.automaticActivityDetection.silenceDurationMs).toBe(300);
   });

--- a/tests/unit/realtime-compat/openai-realtime-commands.test.ts
+++ b/tests/unit/realtime-compat/openai-realtime-commands.test.ts
@@ -87,7 +87,7 @@ describe('realtime-compat/openai — commands', () => {
       }
     });
 
-    expect(event.session.voice).toBe('voice_1');
+    expect(event.session.audio.output.voice).toBe('voice_1');
     expect(event.session.temperature).toBe(0.7);
     expect(settingsWarnings.unknownKeys.sort()).toEqual(['badVoice', 'extra']);
     expect(settingsWarnings.invalidKeys).toEqual([]);
@@ -102,7 +102,7 @@ describe('realtime-compat/openai — commands', () => {
       }
     });
 
-    expect(event.session.voice).toBeUndefined();
+    expect(event.session.audio.output.voice).toBeUndefined();
     expect(event.session.temperature).toBeUndefined();
     expect(settingsWarnings.unknownKeys).toEqual([]);
     expect(settingsWarnings.invalidKeys.sort()).toEqual(['temperature', 'voice']);
@@ -559,7 +559,7 @@ describe('realtime-compat/openai — commands', () => {
       }
     });
 
-    expect(event.session.voice).toBe('marin');
+    expect(event.session.audio.output.voice).toBe('marin');
     expect(event.session.temperature).toBe(0.8);
     expect(event.session.speed).toBe(1.2);
     expect(event.session.max_response_output_tokens).toBe('inf');


### PR DESCRIPTION
Fixes #828

## Summary
- OpenAI realtime: map `spec.settings.voice` to `session.audio.output.voice` (no `session.voice`).
- Gemini realtime: treat `thinkingBudget` / `includeThoughts` as unsupported for Live sessions and stop sending `thinkingConfig`.

## Validation
- `npm test` (100% passing + 100% coverage)
- `npm run test:live:openrouter -- --transport=both`
- `LLM_TEST_PROVIDERS=openai,google npm run test:live:realtime -- --transport=both`
