### PR TITLE
Issue #852 Fix OpenAI Realtime session.update mapping

### DIFF
--- a/plugins/realtime-compat/openai/README.md
+++ b/plugins/realtime-compat/openai/README.md
@@ -75,9 +75,8 @@ Pass extended settings via `spec.settings`. All settings support both camelCase 
 | Setting | Type | Description |
 |---------|------|-------------|
 | `voice` | string | Voice identifier for audio output |
-| `temperature` | number | Sampling temperature (0.0-2.0) |
-| `speed` | number | Audio playback speed multiplier |
-| `maxResponseOutputTokens` | string | Max output tokens (e.g., `"4096"` or `"inf"`) |
+| `speed` | number | Speech speed multiplier (mapped to `session.audio.output.speed`) |
+| `maxResponseOutputTokens` | string | Max output tokens (e.g., `"4096"` or `"inf"`) (mapped to `session.max_output_tokens`) |
 | `transcriptionModel` | string | Transcription model (default: `whisper-1`) |
 | `noiseReduction` | string | Noise reduction type (e.g., `"near_field"`) |
 | `vadType` | string | VAD type: `"server_vad"` (default) or `"semantic_vad"` |
@@ -86,6 +85,8 @@ Pass extended settings via `spec.settings`. All settings support both camelCase 
 | `vadSilenceDurationMs` | int | Silence duration to end turn (server_vad only) |
 | `vadIdleTimeoutMs` | int | Idle timeout before auto-response (server_vad only) |
 | `vadEagerness` | string | Interruption eagerness: `"low"`, `"medium"`, `"high"`, `"auto"` (semantic_vad only) |
+
+Note: `temperature` is currently not applied for this compat. If provided, it is treated as an unsupported session setting and ignored.
 
 Note: `int` values are parsed as **positive integers (>0)**.
 
@@ -97,7 +98,8 @@ const session = await createRealtimeSession(registry, {
   turnDetection: { mode: 'server_vad' },
   settings: {
     voice: 'marin',
-    temperature: 0.8,
+    speed: 1.0,
+    max_output_tokens: 1024,
     transcription_model: 'gpt-4o-transcribe',
     noise_reduction: 'near_field',
     vad_type: 'semantic_vad',

--- a/plugins/realtime-compat/openai/internal/commands.ts
+++ b/plugins/realtime-compat/openai/internal/commands.ts
@@ -4,10 +4,9 @@ import { parseRealtimeSessionSettings } from '../../../../kernel/index.js';
 type OpenAIRealtimeClientEvent = Record<string, any>;
 
 const OPENAI_SESSION_SETTINGS_DEFINITIONS = {
-  temperature: { type: 'number' },
   voice: { type: 'string' },
   speed: { type: 'number' },
-  maxResponseOutputTokens: { type: 'string', aliases: ['max_response_output_tokens'] },
+  maxResponseOutputTokens: { type: 'string', aliases: ['max_response_output_tokens', 'max_output_tokens'] },
   transcriptionModel: { type: 'string', aliases: ['transcription_model'] },
   noiseReduction: { type: 'string', aliases: ['noise_reduction'] },
   vadType: { type: 'string', aliases: ['vad_type'] },
@@ -185,10 +184,24 @@ export function buildSessionUpdateEvent(options: {
   };
 
   const voice = typeof settingsValues.voice === 'string' ? settingsValues.voice : undefined;
-  const temperature = typeof settingsValues.temperature === 'number' ? settingsValues.temperature : undefined;
   const speed = typeof settingsValues.speed === 'number' ? settingsValues.speed : undefined;
   const maxResponseOutputTokens =
     typeof settingsValues.maxResponseOutputTokens === 'string' ? settingsValues.maxResponseOutputTokens : undefined;
+  let maxOutputTokens: string | number | undefined;
+  if (maxResponseOutputTokens) {
+    if (maxResponseOutputTokens.toLowerCase() === 'inf') {
+      maxOutputTokens = 'inf';
+    } else {
+      const parsed = Number(maxResponseOutputTokens);
+      if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) {
+        maxOutputTokens = parsed;
+      } else {
+        addInvalidKey(
+          getProvidedKey(['maxResponseOutputTokens', 'max_response_output_tokens', 'max_output_tokens'], 'maxResponseOutputTokens')
+        );
+      }
+    }
+  }
   const transcriptionModel =
     typeof settingsValues.transcriptionModel === 'string' ? settingsValues.transcriptionModel : undefined;
   const noiseReduction = typeof settingsValues.noiseReduction === 'string' ? settingsValues.noiseReduction : undefined;
@@ -246,9 +259,7 @@ export function buildSessionUpdateEvent(options: {
       type: 'realtime',
       instructions: options.spec.systemPrompt ?? undefined,
       output_modalities: ['audio'],
-      ...(temperature !== undefined ? { temperature } : {}),
-      ...(speed !== undefined ? { speed } : {}),
-      ...(maxResponseOutputTokens ? { max_response_output_tokens: maxResponseOutputTokens } : {}),
+      ...(maxOutputTokens !== undefined ? { max_output_tokens: maxOutputTokens } : {}),
       audio: {
         input: {
           format: toOpenAIAudioFormat(audio.input.format),
@@ -265,7 +276,8 @@ export function buildSessionUpdateEvent(options: {
         },
         output: {
           format: toOpenAIAudioFormat(audio.output.format),
-          ...(voice ? { voice } : {})
+          ...(voice ? { voice } : {}),
+          ...(speed !== undefined ? { speed } : {})
         }
       },
       ...(toolsForSession ? { tools: toolsForSession } : {}),

--- a/tests/unit/realtime-compat/openai-realtime-commands.test.ts
+++ b/tests/unit/realtime-compat/openai-realtime-commands.test.ts
@@ -78,7 +78,7 @@ describe('realtime-compat/openai — commands', () => {
     expect(event.session.audio.input.transcription.language).toBeUndefined();
   });
 
-  test('buildSessionUpdateEvent maps session settings (voice, temperature) and reports unknown/invalid keys', () => {
+  test('buildSessionUpdateEvent maps session settings (voice) and reports unknown/invalid keys', () => {
     const { event, settingsWarnings } = buildSessionUpdateEvent({
       spec: {
         provider: 'openai',
@@ -88,8 +88,8 @@ describe('realtime-compat/openai — commands', () => {
     });
 
     expect(event.session.audio.output.voice).toBe('voice_1');
-    expect(event.session.temperature).toBe(0.7);
-    expect(settingsWarnings.unknownKeys.sort()).toEqual(['badVoice', 'extra']);
+    expect((event.session as any).temperature).toBeUndefined();
+    expect(settingsWarnings.unknownKeys.sort()).toEqual(['badVoice', 'extra', 'temperature']);
     expect(settingsWarnings.invalidKeys).toEqual([]);
   });
 
@@ -103,9 +103,9 @@ describe('realtime-compat/openai — commands', () => {
     });
 
     expect(event.session.audio.output.voice).toBeUndefined();
-    expect(event.session.temperature).toBeUndefined();
-    expect(settingsWarnings.unknownKeys).toEqual([]);
-    expect(settingsWarnings.invalidKeys.sort()).toEqual(['temperature', 'voice']);
+    expect((event.session as any).temperature).toBeUndefined();
+    expect(settingsWarnings.unknownKeys).toEqual(['temperature']);
+    expect(settingsWarnings.invalidKeys.sort()).toEqual(['voice']);
   });
 
   test('buildSessionUpdateEvent validates audio constraints (channels and sample rates)', () => {
@@ -342,8 +342,8 @@ describe('realtime-compat/openai — commands', () => {
       }
     });
 
-    expect(event.session.speed).toBe(1.5);
-    expect(event.session.max_response_output_tokens).toBe('4096');
+    expect(event.session.audio.output.speed).toBe(1.5);
+    expect(event.session.max_output_tokens).toBe(4096);
     expect(settingsWarnings.unknownKeys).toEqual([]);
     expect(settingsWarnings.invalidKeys).toEqual([]);
   });
@@ -357,7 +357,32 @@ describe('realtime-compat/openai — commands', () => {
       }
     });
 
-    expect(event.session.max_response_output_tokens).toBe('2048');
+    expect(event.session.max_output_tokens).toBe(2048);
+  });
+
+  test('buildSessionUpdateEvent maps maxResponseOutputTokens via max_output_tokens alias', () => {
+    const { event } = buildSessionUpdateEvent({
+      spec: {
+        provider: 'openai',
+        model: 'm',
+        settings: { max_output_tokens: 2048 } as any
+      }
+    });
+
+    expect(event.session.max_output_tokens).toBe(2048);
+  });
+
+  test('buildSessionUpdateEvent reports invalid max_output_tokens values', () => {
+    const { event, settingsWarnings } = buildSessionUpdateEvent({
+      spec: {
+        provider: 'openai',
+        model: 'm',
+        settings: { max_output_tokens: 0 } as any
+      }
+    });
+
+    expect(event.session.max_output_tokens).toBeUndefined();
+    expect(settingsWarnings.invalidKeys).toEqual(['max_output_tokens']);
   });
 
   test('buildSessionUpdateEvent uses custom transcriptionModel instead of whisper-1', () => {
@@ -538,7 +563,7 @@ describe('realtime-compat/openai — commands', () => {
   });
 
   test('buildSessionUpdateEvent combines all extended settings correctly', () => {
-    const { event } = buildSessionUpdateEvent({
+    const { event, settingsWarnings } = buildSessionUpdateEvent({
       spec: {
         provider: 'openai',
         model: 'm',
@@ -560,9 +585,11 @@ describe('realtime-compat/openai — commands', () => {
     });
 
     expect(event.session.audio.output.voice).toBe('marin');
-    expect(event.session.temperature).toBe(0.8);
-    expect(event.session.speed).toBe(1.2);
-    expect(event.session.max_response_output_tokens).toBe('inf');
+    expect((event.session as any).temperature).toBeUndefined();
+    expect(event.session.audio.output.speed).toBe(1.2);
+    expect(event.session.max_output_tokens).toBe('inf');
+    expect(settingsWarnings.unknownKeys).toEqual(['temperature']);
+    expect(settingsWarnings.invalidKeys).toEqual([]);
     expect(event.session.audio.input.noise_reduction).toEqual({ type: 'near_field' });
     expect(event.session.audio.input.transcription.model).toBe('gpt-4o-transcribe');
     expect(event.session.audio.input.turn_detection.type).toBe('server_vad');

--- a/tests/unit/realtime-compat/openai-realtime-webrtc.test.ts
+++ b/tests/unit/realtime-compat/openai-realtime-webrtc.test.ts
@@ -864,7 +864,7 @@ describe('plugins/realtime-compat/openai — webrtc transport + session', () => 
         compat: 'openai',
         endpoint: { urlTemplate: 'ws://x?model={model}', headers: {} }
       } as any,
-      spec: { provider: 'openai', model: 'm', settings: { unknownKey: 'x', temperature: 'nope' } }
+      spec: { provider: 'openai', model: 'm', settings: { unknownKey: 'x', temperature: 'nope', voice: '' } }
     } as any, transport as any);
 
     const events = await collectN(session.events()[Symbol.asyncIterator](), 4);


### PR DESCRIPTION
Fixes OpenAI Realtime `session.update` payload mapping.

- Move `speed` to `session.audio.output.speed`.
- Map `maxResponseOutputTokens` to `session.max_output_tokens` (supports `max_output_tokens` + legacy `max_response_output_tokens` aliases).
- Treat `temperature` as unsupported for this compat (ignored + warned).

Tests:
- `npm test`
- `npm run test:live:openrouter -- --transport=both`
- `npm run test:live:realtime -- --transport=both`