### PR TITLE
Issue #876/#877/#878: Vapi voice provider + webhook JSON + Vapi realtime unclamp

### DIFF
--- a/extensions/voice/README.md
+++ b/extensions/voice/README.md
@@ -135,6 +135,14 @@ By default, webhook validation is **required**. If the active compat does not im
 
 For local/dev only, set `LLM_ADAPTER_VOICE_WEBHOOK_VALIDATION_REQUIRED=0` to allow missing validation.
 
+### Webhook request bodies
+
+`POST /voice/webhook` supports:
+- `application/x-www-form-urlencoded` (exposed to the compat as `params` + raw `bodyText`)
+- `application/json` (exposed to the compat as parsed `body` + raw `bodyText`)
+
+If a JSON body is empty, it is treated as `{}`. If JSON parsing fails, the request is still processed and the raw `bodyText` is passed through so the compat can validate/reject it.
+
 ### Public base URL / proxies
 
 `/voice/webhook` needs to generate a public `WS /voice/media` URL for the telephony provider to connect to.

--- a/extensions/voice/internal/server.ts
+++ b/extensions/voice/internal/server.ts
@@ -774,15 +774,28 @@ export async function createVoiceServerRegistration(ctx: {
 
           const compat = await providerPlugins.getCompat(voiceProvider);
           const params: Record<string, string> = {};
-          if (method === 'POST') {
-            const contentType = String(req.headers?.['content-type'] ?? '').toLowerCase();
-            if (contentType.includes('application/x-www-form-urlencoded')) {
-              const rawBody = await readTextBody(req, { maxBytes: maxRequestBytes, timeoutMs: bodyReadTimeoutMs });
-              if (rawBody) {
-                const form = new URLSearchParams(rawBody);
-                for (const [k, v] of form.entries()) {
-                  params[String(k)] = String(v);
-                }
+          let webhookBodyText: string | undefined;
+          let webhookBody: any | undefined;
+	          if (method === 'POST') {
+	            const contentType = String(req.headers?.['content-type'] ?? '').toLowerCase();
+	            if (contentType.includes('application/x-www-form-urlencoded')) {
+	              webhookBodyText = await readTextBody(req, { maxBytes: maxRequestBytes, timeoutMs: bodyReadTimeoutMs });
+	              if (webhookBodyText) {
+	                const form = new URLSearchParams(webhookBodyText);
+	                for (const [k, v] of form.entries()) {
+	                  params[String(k)] = String(v);
+	                }
+	              }
+	            } else if (contentType.includes('application/json') || contentType.includes('+json')) {
+	              const bodyText = await readTextBody(req, { maxBytes: maxRequestBytes, timeoutMs: bodyReadTimeoutMs });
+	              webhookBodyText = bodyText;
+	              const raw = bodyText.trim();
+	              if (!raw) {
+	                webhookBody = {};
+	              } else {
+	                try {
+	                  webhookBody = JSON.parse(raw);
+                } catch {}
               }
             }
           }
@@ -810,7 +823,22 @@ export async function createVoiceServerRegistration(ctx: {
               }
 
               try {
-                await validateWebhookRequest({ req, method, url: publicUrl, params, callConfigId, callConfig, voiceProvider, providerDefaults });
+                await validateWebhookRequest({
+                  req,
+                  method,
+                  url: publicUrl,
+                  params,
+                  ...(webhookBody !== undefined ? { body: webhookBody } : {}),
+                  ...(webhookBodyText !== undefined ? { bodyText: webhookBodyText } : {}),
+                  callConfigId,
+                  callConfig,
+                  voiceProvider,
+                  providerDefaults,
+                  store,
+                  logger,
+                  events: { emit: (event: any) => emitCallEvent(callConfigId, event) },
+                  metrics
+                });
               } catch (error: any) {
                 metrics.compatError('webhook_validate', voiceProvider);
                 const statusCode = Number(error?.statusCode ?? 500);
@@ -831,7 +859,20 @@ export async function createVoiceServerRegistration(ctx: {
 
             const response = await (async () => {
               try {
-                return await compat.createWebhookResponse({ req, callConfigId, callConfig, voiceProvider, mediaWsUrl, params });
+                return await compat.createWebhookResponse({
+                  req,
+                  callConfigId,
+                  callConfig,
+                  voiceProvider,
+                  mediaWsUrl,
+                  params,
+                  ...(webhookBody !== undefined ? { body: webhookBody } : {}),
+                  ...(webhookBodyText !== undefined ? { bodyText: webhookBodyText } : {}),
+                  store,
+                  logger,
+                  events: { emit: (event: any) => emitCallEvent(callConfigId, event) },
+                  metrics
+                });
               } catch (error: any) {
                 metrics.compatError('webhook_response', voiceProvider);
                 throw error;
@@ -839,12 +880,12 @@ export async function createVoiceServerRegistration(ctx: {
             })();
             const status = Number(response?.status ?? 200);
             const headers = (response?.headers && typeof response.headers === 'object') ? response.headers : {};
-            const body = String(response?.body ?? '');
+            const responseBody = String(response?.body ?? '');
 
             safeLog(logger, 'info', 'voice.webhook.response', { callConfigId, voiceProvider, status, ...(requestId ? { requestId } : {}) });
 
             res.writeHead(status, headers);
-            res.end(body);
+            res.end(responseBody);
             return true;
           } catch (error: any) {
             const statusCode = Number(error?.statusCode ?? 500);

--- a/extensions/voice/tests/integration/voice-webhook-media.test.ts
+++ b/extensions/voice/tests/integration/voice-webhook-media.test.ts
@@ -98,6 +98,44 @@ async function waitForMessage(messages: any[], predicate: (m: any) => boolean, t
   throw new Error('Timed out waiting for WS message');
 }
 
+async function readNextSseEvent(res: Response, timeoutMs = 1000): Promise<any> {
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const reader = res.body?.getReader();
+  if (!reader) throw new Error('Expected SSE body');
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    const idx = buffer.indexOf('\n\n');
+    if (idx < 0) continue;
+
+    const raw = buffer.slice(0, idx);
+    buffer = buffer.slice(idx + 2);
+
+    const lines = raw.split('\n').map(l => l.replace(/\r$/, ''));
+    let eventName: string | undefined;
+    const dataLines: string[] = [];
+    for (const line of lines) {
+      if (!line || line.startsWith(':')) continue;
+      if (line.startsWith('event:')) {
+        eventName = line.slice('event:'.length).trim();
+        continue;
+      }
+      if (line.startsWith('data:')) {
+        dataLines.push(line.slice('data:'.length).trim());
+      }
+    }
+    const dataText = dataLines.join('\n');
+    return { event: eventName, data: dataText ? JSON.parse(dataText) : null };
+  }
+
+  throw new Error('Timed out waiting for SSE event');
+}
+
 async function startHarness(options: { store: any; providerPlugins?: any; logging?: any; httpConfig?: any; preUpgradeHandlers?: any[] }) {
   let handleHttp: any = async () => false;
   const server = http.createServer((req, res) => {
@@ -827,6 +865,67 @@ describe('extensions/voice: webhook + media wiring', () => {
       ws.close();
       await closePromise;
     } finally {
+      await harness.close();
+    }
+  });
+
+  test('end-to-end: /voice/webhook accepts application/json and can emit SSE events', async () => {
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_webhook_json_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'test'
+      },
+      { ttlSeconds: 60 }
+    );
+
+    const providerPlugins = {
+      getCompat: jest.fn(async () => ({
+        validateWebhookRequest: jest.fn(async () => {}),
+        createWebhookResponse: jest.fn(async (options: any) => {
+          expect(options.params).toEqual({});
+          expect(options.body).toEqual({ message: { type: 'status-update', status: 'queued' } });
+          expect(typeof options.bodyText).toBe('string');
+          expect(options.bodyText).toContain('status-update');
+          options.events?.emit?.({ type: 'user_transcript.final', text: 'hello from webhook' });
+          return { status: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ok: true }) };
+        })
+      }))
+    };
+
+    const harness = await startHarness({
+      store,
+      providerPlugins,
+      httpConfig: { auth: { enabled: true, apiKeys: ['k1'] } }
+    });
+
+    let eventsRes: Response | undefined;
+    try {
+      const webhookRes = await fetch(new URL('/voice/webhook?callConfigId=cfg_webhook_json_1', harness.baseUrl), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-signature': 'ok' },
+        body: JSON.stringify({ message: { type: 'status-update', status: 'queued' } })
+      });
+      expect(webhookRes.status).toBe(200);
+
+      eventsRes = await fetch(new URL('/voice/calls/cfg_webhook_json_1/events', harness.baseUrl), {
+        method: 'GET',
+        headers: { Authorization: 'Bearer k1' }
+      });
+      expect(eventsRes.status).toBe(200);
+
+      const first = await readNextSseEvent(eventsRes, 1000);
+      expect(first.data?.event?.type ?? first.event).toBe('user_transcript.final');
+      expect(first.data?.event?.text ?? first.data?.event?.textDelta ?? '').toContain('hello from webhook');
+    } finally {
+      try { await eventsRes?.body?.cancel(); } catch {}
       await harness.close();
     }
   });

--- a/extensions/voice/tests/unit/voice-server.http.test.ts
+++ b/extensions/voice/tests/unit/voice-server.http.test.ts
@@ -1236,7 +1236,7 @@ describe('extensions/voice: server http handlers', () => {
       expect(createWebhookResponse).toHaveBeenCalledTimes(1);
     });
 
-    test('/voice/webhook (POST) reads body but does not parse params for non-form content-type', async () => {
+  test('/voice/webhook (POST) reads body but does not parse params for non-form content-type', async () => {
       process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = 'secret';
 
     const store = createInMemoryVoiceCallConfigStore();
@@ -1286,6 +1286,64 @@ describe('extensions/voice: server http handlers', () => {
     expect(String(res.writeHead.mock.calls[0][0])).toBe('200');
     expect(validateWebhookRequest).toHaveBeenCalledTimes(1);
     expect(createWebhookResponse).toHaveBeenCalledTimes(1);
+  });
+
+  test('/voice/webhook (POST) treats empty json body as {} and supports validation-side events.emit', async () => {
+    process.env.LLM_ADAPTER_VOICE_WS_TOKEN_SECRET = 'secret';
+
+    const store = createInMemoryVoiceCallConfigStore();
+    await store.putConfig(
+      {
+        version: 1,
+        callConfigId: 'cfg_1',
+        createdAtMs: 0,
+        expiresAtMs: 0,
+        to: 'to',
+        from: 'from',
+        direction: 'inbound',
+        realtimeSpec: {},
+        voiceProvider: 'test'
+      },
+      { ttlSeconds: 60 }
+    );
+
+    const eventsHub: any = {
+      emit: jest.fn(),
+      subscribe: jest.fn(() => ({ accepted: true, replay: [], unsubscribe: jest.fn() })),
+      snapshot: jest.fn(() => ({ activeCalls: 0, totalSubscribers: 0, calls: [] })),
+      close: jest.fn()
+    };
+
+    const validateWebhookRequest = jest.fn(async (options: any) => {
+      expect(options.method).toBe('POST');
+      expect(options.params).toEqual({});
+      expect(options.body).toEqual({});
+      options.events.emit({ type: 'voice.test_event' });
+    });
+    const createWebhookResponse = jest.fn(async () => ({ status: 200, headers: {}, body: 'ok' }));
+    const providerPlugins = { getCompat: jest.fn(async () => ({ validateWebhookRequest, createWebhookResponse })) };
+
+    const reg = await createVoiceServerRegistration({
+      server: {} as any,
+      registry: {},
+      pluginsPath: './plugins',
+      upgradeRouter: {} as any,
+      store,
+      providerPlugins: providerPlugins as any,
+      eventsHub
+    } as any);
+
+    const res = createMockRes();
+    const req = Object.assign(Readable.from(['']), {
+      url: '/voice/webhook?callConfigId=cfg_1',
+      method: 'POST',
+      headers: { host: 'localhost', 'content-type': 'application/json' },
+      socket: {}
+    }) as any;
+
+    await expect(reg.handleHttp(req, res)).resolves.toBe(true);
+    expect(String(res.writeHead.mock.calls[0][0])).toBe('200');
+    expect(eventsHub.emit).toHaveBeenCalledWith('cfg_1', { type: 'voice.test_event' });
   });
 
   test('/voice/webhook (POST) tolerates missing req.headers when reading body for validation', async () => {

--- a/plugins/realtime-compat/vapi/README.md
+++ b/plugins/realtime-compat/vapi/README.md
@@ -25,11 +25,40 @@ Provider manifest:
 
 This compat reads provider-agnostic `spec.settings` values (aliases in parentheses):
 
+### Core model/voice
+
 - `modelProvider` (`model_provider`): underlying model provider (default from provider metadata)
 - `wsHandshakeTimeoutMs` (`ws_handshake_timeout_ms`): WS handshake timeout for connecting to `transport.websocketCallUrl` (default from provider metadata; `0` disables explicit timeout)
 - `voiceProvider` (`voice_provider`): underlying voice provider (default from provider metadata)
 - `voice`: underlying voice id/name (default from provider metadata)
 - `temperature`: clamped to `[0,2]` when provided
+- `maxOutputTokens` (`maxTokens`, `max_output_tokens`): forwarded to `assistant.model.maxTokens` (Vapi validates)
+- `emotionRecognitionEnabled` (`emotion_recognition_enabled`): forwarded to `assistant.model.emotionRecognitionEnabled`
+- `backgroundSound` (`background_sound`): forwarded to `assistant.backgroundSound`
+- `speed`: forwarded to `assistant.voice.speed` (Vapi validates per voice provider)
+- `inputMinCharacters` (`input_min_characters`): forwarded to `assistant.voice.chunkPlan.minCharacters`
+
+### Turn detection / latency tuning
+
+- `startSpeakingWaitSeconds` (`start_speaking_wait_seconds`): forwarded to `assistant.startSpeakingPlan.waitSeconds`
+- `startSpeakingSmartEndpointingEnabled` (`smartEndpointingEnabled`, `smart_endpointing_enabled`): forwarded to `assistant.startSpeakingPlan.smartEndpointingEnabled` (deprecated in Vapi; still supported)
+- `transcriptionEndpointingOnPunctuationSeconds` (`transcription_endpointing_on_punctuation_seconds`): forwarded to `assistant.startSpeakingPlan.transcriptionEndpointingPlan.onPunctuationSeconds`
+- `transcriptionEndpointingOnNoPunctuationSeconds` (`transcription_endpointing_on_no_punctuation_seconds`): forwarded to `assistant.startSpeakingPlan.transcriptionEndpointingPlan.onNoPunctuationSeconds`
+- `transcriptionEndpointingOnNumberSeconds` (`transcription_endpointing_on_number_seconds`): forwarded to `assistant.startSpeakingPlan.transcriptionEndpointingPlan.onNumberSeconds`
+- `stopSpeakingNumWords` (`stop_speaking_num_words`): forwarded to `assistant.stopSpeakingPlan.numWords`
+- `stopSpeakingVoiceSeconds` (`stop_speaking_voice_seconds`): forwarded to `assistant.stopSpeakingPlan.voiceSeconds`
+- `stopSpeakingBackoffSeconds` (`stop_speaking_backoff_seconds`): forwarded to `assistant.stopSpeakingPlan.backoffSeconds`
+
+### Transcriber (Deepgram Flux EOT)
+
+Only applied when `transcription.enabled` is set and the resolved Vapi transcriber provider is `deepgram`:
+
+- `transcriberEagerEotThreshold` (`transcriber_eager_eot_threshold`): forwarded to `assistant.transcriber.eagerEotThreshold`
+- `transcriberEotThreshold` (`transcriber_eot_threshold`): forwarded to `assistant.transcriber.eotThreshold`
+- `transcriberEotTimeoutMs` (`transcriber_eot_timeout_ms`): forwarded to `assistant.transcriber.eotTimeoutMs`
+
+### Transport / tooling / control URL polling
+
 - `keepaliveEnabled` (`keepalive_enabled`): whether to stream silence keepalive frames (default from provider metadata)
 - `keepaliveIntervalMs` (`keepalive_interval_ms`): keepalive interval in ms (default from provider metadata; clamped to `>= 50ms`)
 - `toolFallbackDelayMs` (`tool_fallback_delay_ms`): delay before the tool-result `say` fallback is triggered (`0` disables; default `5000`)

--- a/plugins/realtime-compat/vapi/internal/session.ts
+++ b/plugins/realtime-compat/vapi/internal/session.ts
@@ -74,11 +74,27 @@ const PROVIDER_AUDIO_BASE: VapiTransportAudioFormatBase = {
 
 const VAPI_SESSION_SETTINGS_DEFINITIONS = {
   temperature: { type: 'number' },
+  maxOutputTokens: { type: 'number', aliases: ['maxTokens', 'max_output_tokens'] },
   voice: { type: 'string' },
+  speed: { type: 'number' },
+  inputMinCharacters: { type: 'number', aliases: ['input_min_characters'] },
+  backgroundSound: { type: 'string', aliases: ['background_sound'] },
   modelProvider: { type: 'string', aliases: ['model_provider'] },
   voiceProvider: { type: 'string', aliases: ['voice_provider'] },
+  emotionRecognitionEnabled: { type: 'boolean', aliases: ['emotion_recognition_enabled'] },
   transcriberProvider: { type: 'string', aliases: ['transcriber_provider'] },
   transcriberModel: { type: 'string', aliases: ['transcriber_model'] },
+  transcriberEagerEotThreshold: { type: 'number', aliases: ['transcriber_eager_eot_threshold'] },
+  transcriberEotThreshold: { type: 'number', aliases: ['transcriber_eot_threshold'] },
+  transcriberEotTimeoutMs: { type: 'number', aliases: ['transcriber_eot_timeout_ms'] },
+  startSpeakingWaitSeconds: { type: 'number', aliases: ['start_speaking_wait_seconds'] },
+  startSpeakingSmartEndpointingEnabled: { type: 'boolean', aliases: ['smartEndpointingEnabled', 'smart_endpointing_enabled'] },
+  transcriptionEndpointingOnPunctuationSeconds: { type: 'number', aliases: ['transcription_endpointing_on_punctuation_seconds'] },
+  transcriptionEndpointingOnNoPunctuationSeconds: { type: 'number', aliases: ['transcription_endpointing_on_no_punctuation_seconds'] },
+  transcriptionEndpointingOnNumberSeconds: { type: 'number', aliases: ['transcription_endpointing_on_number_seconds'] },
+  stopSpeakingNumWords: { type: 'number', aliases: ['stop_speaking_num_words'] },
+  stopSpeakingVoiceSeconds: { type: 'number', aliases: ['stop_speaking_voice_seconds'] },
+  stopSpeakingBackoffSeconds: { type: 'number', aliases: ['stop_speaking_backoff_seconds'] },
   keepaliveEnabled: { type: 'boolean', aliases: ['keepalive_enabled'] },
   keepaliveIntervalMs: { type: 'int', aliases: ['keepalive_interval_ms'] },
   wsHandshakeTimeoutMs: { type: 'int', aliases: ['ws_handshake_timeout_ms'] },
@@ -414,7 +430,7 @@ export async function createVapiRealtimeCompatSession(
     String(settings.voiceProvider ?? (provider.metadata as any)?.defaultVoiceProvider ?? modelProvider).trim() || modelProvider;
   const voice = String(settings.voice ?? (provider.metadata as any)?.defaultVoice ?? 'alloy').trim() || 'alloy';
   const temp = settings.temperature === undefined || settings.temperature === null ? NaN : Number(settings.temperature);
-  const temperature = Number.isFinite(temp) ? Math.max(0, Math.min(2, temp)) : undefined;
+  const temperature = Number.isFinite(temp) ? temp : undefined;
 
   const keepaliveFromProvider = (provider.metadata as any)?.keepalive;
   const controlUrlFromProvider = (provider.metadata as any)?.controlUrl;
@@ -485,6 +501,76 @@ export async function createVapiRealtimeCompatSession(
     audioFormat: providerAudio
   });
 
+  if (settings.backgroundSound !== undefined) {
+    (body.assistant as any).backgroundSound = settings.backgroundSound;
+  }
+
+  if (settings.maxOutputTokens !== undefined) {
+    (body.assistant as any).model.maxTokens = settings.maxOutputTokens;
+  }
+  if (settings.emotionRecognitionEnabled !== undefined) {
+    (body.assistant as any).model.emotionRecognitionEnabled = settings.emotionRecognitionEnabled;
+  }
+
+  if (settings.speed !== undefined) {
+    (body.assistant as any).voice.speed = settings.speed;
+  }
+  if (settings.inputMinCharacters !== undefined) {
+    const voiceObj = (body.assistant as any).voice;
+    const chunkPlan = ensureJsonObject(voiceObj.chunkPlan);
+    voiceObj.chunkPlan = { ...chunkPlan, minCharacters: settings.inputMinCharacters };
+  }
+
+  const startSpeakingPlan: any = {};
+  let hasStartSpeakingPlan = false;
+  if (settings.startSpeakingWaitSeconds !== undefined) {
+    startSpeakingPlan.waitSeconds = settings.startSpeakingWaitSeconds;
+    hasStartSpeakingPlan = true;
+  }
+  if (settings.startSpeakingSmartEndpointingEnabled !== undefined) {
+    startSpeakingPlan.smartEndpointingEnabled = settings.startSpeakingSmartEndpointingEnabled;
+    hasStartSpeakingPlan = true;
+  }
+  const transcriptionEndpointingPlan: any = {};
+  let hasEndpointingPlan = false;
+  if (settings.transcriptionEndpointingOnPunctuationSeconds !== undefined) {
+    transcriptionEndpointingPlan.onPunctuationSeconds = settings.transcriptionEndpointingOnPunctuationSeconds;
+    hasEndpointingPlan = true;
+  }
+  if (settings.transcriptionEndpointingOnNoPunctuationSeconds !== undefined) {
+    transcriptionEndpointingPlan.onNoPunctuationSeconds = settings.transcriptionEndpointingOnNoPunctuationSeconds;
+    hasEndpointingPlan = true;
+  }
+  if (settings.transcriptionEndpointingOnNumberSeconds !== undefined) {
+    transcriptionEndpointingPlan.onNumberSeconds = settings.transcriptionEndpointingOnNumberSeconds;
+    hasEndpointingPlan = true;
+  }
+  if (hasEndpointingPlan) {
+    startSpeakingPlan.transcriptionEndpointingPlan = transcriptionEndpointingPlan;
+    hasStartSpeakingPlan = true;
+  }
+  if (hasStartSpeakingPlan) {
+    (body.assistant as any).startSpeakingPlan = startSpeakingPlan;
+  }
+
+  const stopSpeakingPlan: any = {};
+  let hasStopSpeakingPlan = false;
+  if (settings.stopSpeakingNumWords !== undefined) {
+    stopSpeakingPlan.numWords = settings.stopSpeakingNumWords;
+    hasStopSpeakingPlan = true;
+  }
+  if (settings.stopSpeakingVoiceSeconds !== undefined) {
+    stopSpeakingPlan.voiceSeconds = settings.stopSpeakingVoiceSeconds;
+    hasStopSpeakingPlan = true;
+  }
+  if (settings.stopSpeakingBackoffSeconds !== undefined) {
+    stopSpeakingPlan.backoffSeconds = settings.stopSpeakingBackoffSeconds;
+    hasStopSpeakingPlan = true;
+  }
+  if (hasStopSpeakingPlan) {
+    (body.assistant as any).stopSpeakingPlan = stopSpeakingPlan;
+  }
+
   if (spec.transcription?.enabled) {
     (body.assistant as any).artifactPlan = {
       transcriptPlan: { enabled: true }
@@ -495,6 +581,18 @@ export async function createVapiRealtimeCompatSession(
       language: String(spec.transcription?.language ?? 'en'),
       smartFormat: true
     };
+
+    if (String(transcriberProvider).trim().toLowerCase() === 'deepgram') {
+      if (settings.transcriberEagerEotThreshold !== undefined) {
+        (body.assistant as any).transcriber.eagerEotThreshold = settings.transcriberEagerEotThreshold;
+      }
+      if (settings.transcriberEotThreshold !== undefined) {
+        (body.assistant as any).transcriber.eotThreshold = settings.transcriberEotThreshold;
+      }
+      if (settings.transcriberEotTimeoutMs !== undefined) {
+        (body.assistant as any).transcriber.eotTimeoutMs = settings.transcriberEotTimeoutMs;
+      }
+    }
   }
 
   const { callId, websocketCallUrl } = await createVapiWebsocketCall({

--- a/plugins/voice-compat/vapi/README.md
+++ b/plugins/voice-compat/vapi/README.md
@@ -1,0 +1,60 @@
+# `plugins/voice-compat/vapi`
+
+Vapi voice provider compat consumed by the Voice extension.
+
+## Scope
+
+- Implements outbound phone calls via Vapi `POST /call`.
+- Receives Vapi Server URL webhooks at the adapter’s `POST /voice/webhook?callConfigId=...` endpoint.
+- Emits provider-agnostic call events into the Voice extension event hub (SSE via `GET /voice/calls/:callConfigId/events`).
+
+## Configuration
+
+This compat reads provider defaults from `plugins/voice-providers/vapi.json`.
+
+Required:
+- `defaults.apiKey`
+- `defaults.webhookAuth` (webhook authentication config; see below)
+
+Optional:
+- `defaults.apiBaseUrl` (default: `https://api.vapi.ai`)
+- `defaults.controlUrlPollMs` / `defaults.controlUrlMaxWaitMs` (used by `endCall()` to poll for `monitor.controlUrl`)
+
+## Call creation mapping
+
+For `POST /voice/calls` with `voiceProvider: "vapi"`:
+- `from` → Vapi `phoneNumberId`
+- `to` → Vapi `customer.number`
+- `callConfig.systemPrompt` → `assistant.model.messages` (system)
+- `callConfig.realtimeSpec.provider` **must** be `"vapi"`
+- `callConfig.realtimeSpec.settings.modelProvider` → `assistant.model.provider` (selects the upstream model provider used by Vapi)
+- `callConfig.realtimeSpec.model` → `assistant.model.model` (upstream model name, as expected by the selected Vapi model provider)
+- `callConfig.realtimeSpec.settings.temperature` → `assistant.model.temperature` (passed through; not clamped)
+- `callConfig.realtimeSpec.settings.voiceProvider` → `assistant.voice.provider`
+- `callConfig.realtimeSpec.settings.voice` → `assistant.voice.voiceId`
+- `callConfig.realtimeSpec.settings.speed` → `assistant.voice.speed`
+- `callConfig.realtimeSpec.transcription.*` (or `settings.transcriberProvider` / `settings.transcriberModel`) → `assistant.transcriber.*`
+
+Notes:
+- `assistantFirstTurn.delayMs` is not supported; it must be `0` or omitted.
+- Only bearer webhook auth is supported for outbound call creation (to set `assistant.server.headers.Authorization`).
+
+## Webhook security
+
+By default, Vapi Server URL webhooks are authenticated using `Authorization: Bearer <token>` matching:
+- `defaults.webhookAuth.type = "bearer"`
+- `defaults.webhookAuth.token`
+
+Optionally, this compat also supports HMAC signatures for `validateWebhookRequest()` when:
+- `defaults.webhookAuth.type = "hmac"`
+- `defaults.webhookAuth.secretKey` + `defaults.webhookAuth.algorithm`
+
+Additional HMAC settings supported:
+- `signatureHeader` (default: `x-signature`)
+- `timestampHeader` (default: `x-timestamp`)
+- `signaturePrefix` (default: empty; e.g. `sha256=`)
+- `signatureEncoding` (`hex` default; or `base64`)
+- `secretIsBase64` (default: `false`)
+- `includeTimestamp` (default: `true`)
+- `payloadFormat` (default: `{timestamp}.{body}`; supports `{body}`, `{timestamp}`, `{method}`, `{url}`, `{svix-id}`)
+- `toleranceSeconds` (default: `300`; `0` disables tolerance checks)

--- a/plugins/voice-compat/vapi/index.ts
+++ b/plugins/voice-compat/vapi/index.ts
@@ -1,0 +1,539 @@
+import crypto from 'crypto';
+import type http from 'http';
+
+import { ProviderExecutionError } from '../../../kernel/index.js';
+import { makeHttpError } from '../../../modules/shared/index.js';
+
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(String(a));
+  const bufB = Buffer.from(String(b));
+  if (bufA.length !== bufB.length) {
+    // keep timing roughly consistent
+    crypto.timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return crypto.timingSafeEqual(bufA, bufB);
+}
+
+function makeProviderConfigError(message: string): Error {
+  return makeHttpError({ message, statusCode: 500, code: 'provider_config_error' });
+}
+
+function makeUnauthorizedError(message: string): Error {
+  return makeHttpError({ message, statusCode: 401, code: 'unauthorized' });
+}
+
+function readFirstHeader(req: http.IncomingMessage, name: string): string {
+  const raw = (req.headers as any)?.[String(name).toLowerCase()];
+  const value =
+    typeof raw === 'string'
+      ? raw
+      : Array.isArray(raw)
+        ? String(raw[0] ?? '')
+        : '';
+  return value.trim();
+}
+
+function parseBearerToken(value: string): string {
+  const raw = String(value).trim();
+  if (!raw) return '';
+  const match = /^bearer\s+(.+)$/i.exec(raw);
+  if (!match) return '';
+  return String(match[1]).trim();
+}
+
+function normalizePlainObject(value: any): Record<string, any> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, any>;
+}
+
+function readSettingString(settings: any, name: string, aliases: string[] = []): string | undefined {
+  const s = normalizePlainObject(settings);
+  const candidates = [name, ...aliases];
+  for (const key of candidates) {
+    const raw = s[key];
+    if (raw === undefined || raw === null) continue;
+    const trimmed = String(raw).trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+function readSettingNumber(settings: any, name: string, aliases: string[] = []): number | undefined {
+  const raw = readSettingString(settings, name, aliases);
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return undefined;
+  return n;
+}
+
+function toWebhookUrlFromMediaWsUrl(options: { mediaWsUrl: string; callConfigId: string }): string {
+  const callConfigId = String(options.callConfigId).trim();
+  const mediaWsUrl = String(options.mediaWsUrl).trim();
+  if (!callConfigId || !mediaWsUrl) return '';
+
+  try {
+    const url = new URL(mediaWsUrl);
+    url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
+    url.pathname = '/voice/webhook';
+    url.search = '';
+    url.searchParams.set('callConfigId', callConfigId);
+    return url.toString();
+  } catch {
+    return '';
+  }
+}
+
+type WebhookAuthBearer = { type: 'bearer'; token: string };
+type WebhookAuthHmac = {
+  type: 'hmac';
+  secretKey: string;
+  algorithm: 'sha256' | 'sha512' | 'sha1';
+  signatureHeader: string;
+  timestampHeader: string;
+  signaturePrefix: string;
+  includeTimestamp: boolean;
+  payloadFormat: string;
+  signatureEncoding: 'hex' | 'base64';
+  secretIsBase64: boolean;
+  toleranceSeconds: number;
+};
+
+function parseWebhookAuth(providerDefaults: any): WebhookAuthBearer | WebhookAuthHmac {
+  const defaults = normalizePlainObject(providerDefaults);
+  const auth = normalizePlainObject(defaults.webhookAuth);
+  const type = String(auth.type ?? 'bearer').trim().toLowerCase();
+
+  if (type === 'hmac') {
+    const secretKey = String(auth.secretKey ?? '').trim();
+    const algorithmRaw = String(auth.algorithm ?? '').trim().toLowerCase();
+    const algorithm = algorithmRaw === 'sha512' ? 'sha512' : algorithmRaw === 'sha1' ? 'sha1' : 'sha256';
+    if (!secretKey) {
+      throw makeProviderConfigError('Missing defaults.webhookAuth.secretKey');
+    }
+    if (!algorithmRaw) {
+      throw makeProviderConfigError('Missing defaults.webhookAuth.algorithm');
+    }
+
+    const signatureHeader = String(auth.signatureHeader ?? 'x-signature').trim() || 'x-signature';
+    const timestampHeader = String(auth.timestampHeader ?? 'x-timestamp').trim() || 'x-timestamp';
+    const signaturePrefix = String(auth.signaturePrefix ?? '').trim();
+    const includeTimestamp = auth.includeTimestamp === undefined ? true : Boolean(auth.includeTimestamp);
+    const payloadFormat = String(auth.payloadFormat ?? '{timestamp}.{body}');
+    const signatureEncodingRaw = String(auth.signatureEncoding ?? 'hex').trim().toLowerCase();
+    const signatureEncoding = signatureEncodingRaw === 'base64' ? 'base64' : 'hex';
+    const secretIsBase64 = Boolean(auth.secretIsBase64);
+    const toleranceSecondsRaw = auth.toleranceSeconds;
+    const toleranceSeconds =
+      toleranceSecondsRaw === undefined || toleranceSecondsRaw === null || toleranceSecondsRaw === ''
+        ? 300
+        : Number(toleranceSecondsRaw);
+    const toleranceSecondsNormalized = Number.isFinite(toleranceSeconds) && toleranceSeconds >= 0 ? Math.floor(toleranceSeconds) : 300;
+
+    return {
+      type: 'hmac',
+      secretKey,
+      algorithm,
+      signatureHeader,
+      timestampHeader,
+      signaturePrefix,
+      includeTimestamp,
+      payloadFormat,
+      signatureEncoding,
+      secretIsBase64,
+      toleranceSeconds: toleranceSecondsNormalized
+    };
+  }
+
+  const token = String(auth.token ?? '').trim();
+  if (!token) {
+    throw makeProviderConfigError('Missing defaults.webhookAuth.token');
+  }
+  return { type: 'bearer', token };
+}
+
+function resolveSecretBytes(auth: WebhookAuthHmac): Buffer {
+  return auth.secretIsBase64
+    ? Buffer.from(auth.secretKey, 'base64')
+    : Buffer.from(auth.secretKey, 'utf8');
+}
+
+function buildHmacPayload(options: { format: string; bodyText: string; timestamp: string; method: string; url: string; messageId: string }): string {
+  return String(options.format)
+    .replaceAll('{body}', options.bodyText)
+    .replaceAll('{timestamp}', options.timestamp)
+    .replaceAll('{method}', options.method)
+    .replaceAll('{url}', options.url)
+    .replaceAll('{svix-id}', options.messageId);
+}
+
+function computeHmacSignature(options: { auth: WebhookAuthHmac; payload: string }): string {
+  const key = resolveSecretBytes(options.auth);
+  const digest = crypto.createHmac(options.auth.algorithm, key).update(options.payload, 'utf8').digest();
+  return options.auth.signatureEncoding === 'base64' ? digest.toString('base64') : digest.toString('hex');
+}
+
+function coerceRealtimeSpec(value: any): any {
+  const spec = normalizePlainObject(value);
+  return spec;
+}
+
+function resolveModel(spec: any): string {
+  const model = String(spec.model ?? '').trim();
+  if (model) return model;
+  return 'gpt-4o-mini';
+}
+
+function resolveTranscriber(spec: any, settings: any): { provider: string; model: string } {
+  const transcription = normalizePlainObject(spec.transcription);
+  const provider = String(transcription.provider ?? readSettingString(settings, 'transcriberProvider', ['transcriber_provider']) ?? 'deepgram').trim() || 'deepgram';
+  const model = String(transcription.model ?? readSettingString(settings, 'transcriberModel', ['transcriber_model']) ?? 'nova-2').trim() || 'nova-2';
+  return { provider, model };
+}
+
+export default class VapiVoiceCompat {
+  async validateWebhookRequest(options: {
+    req: http.IncomingMessage;
+    method?: string;
+    url?: string;
+    bodyText?: string;
+    providerDefaults?: any;
+  }): Promise<void> {
+    const req = options.req;
+    const auth = parseWebhookAuth(options.providerDefaults);
+
+    if (auth.type === 'bearer') {
+      const header = readFirstHeader(req, 'authorization');
+      const provided = parseBearerToken(header);
+      if (!provided) {
+        throw makeUnauthorizedError('Unauthorized: missing Authorization bearer token');
+      }
+      if (!safeEqual(provided, auth.token)) {
+        throw makeUnauthorizedError('Unauthorized: invalid Authorization bearer token');
+      }
+      return;
+    }
+
+    const signatureHeaderValue = readFirstHeader(req, auth.signatureHeader);
+    const timestampHeaderValue = readFirstHeader(req, auth.timestampHeader);
+    const signatureRaw = signatureHeaderValue.trim();
+    if (!signatureRaw) {
+      throw makeUnauthorizedError('Unauthorized: missing signature');
+    }
+
+    const signature = auth.signaturePrefix && signatureRaw.startsWith(auth.signaturePrefix)
+      ? signatureRaw.slice(auth.signaturePrefix.length)
+      : signatureRaw;
+
+    const timestamp = auth.includeTimestamp ? timestampHeaderValue.trim() : '';
+    if (auth.includeTimestamp && !timestamp) {
+      throw makeUnauthorizedError('Unauthorized: missing timestamp');
+    }
+
+    if (auth.includeTimestamp && auth.toleranceSeconds > 0) {
+      const n = Number(timestamp);
+      if (Number.isFinite(n)) {
+        const now = Date.now();
+        const tsMs = n > 1e12 ? n : n * 1000;
+        const diffSeconds = Math.abs(now - tsMs) / 1000;
+        if (diffSeconds > auth.toleranceSeconds) {
+          throw makeUnauthorizedError('Unauthorized: webhook timestamp outside tolerance');
+        }
+      }
+    }
+
+    const bodyText = String(options.bodyText ?? '');
+    const method = String(options.method ?? req.method ?? 'POST').toUpperCase();
+    const url = String(options.url ?? '').trim();
+    const messageId = readFirstHeader(req, 'svix-id');
+
+    const payload = buildHmacPayload({
+      format: auth.payloadFormat,
+      bodyText,
+      timestamp,
+      method,
+      url,
+      messageId
+    });
+    const expected = computeHmacSignature({ auth, payload });
+
+    if (!safeEqual(signature, expected)) {
+      throw makeUnauthorizedError('Unauthorized: invalid signature');
+    }
+  }
+
+  async createOutboundCall(options: {
+    to: string;
+    from: string;
+    callConfigId: string;
+    callConfig?: any;
+    voiceProvider: string;
+    mediaWsUrl: string;
+    providerDefaults?: any;
+  }): Promise<{ providerCallId: string }> {
+    const to = String(options.to ?? '').trim();
+    const from = String(options.from ?? '').trim();
+    const callConfigId = String(options.callConfigId ?? '').trim();
+    if (!to || !from || !callConfigId) {
+      throw makeHttpError({ message: 'Missing required fields for outbound call', statusCode: 400, code: 'validation_error' });
+    }
+
+    const defaults = normalizePlainObject(options.providerDefaults);
+    const apiKey = String(defaults.apiKey ?? '').trim();
+    const apiBaseUrlRaw = String(defaults.apiBaseUrl ?? 'https://api.vapi.ai').trim();
+    const apiBaseUrl = apiBaseUrlRaw ? apiBaseUrlRaw.replace(/\/+$/g, '') : 'https://api.vapi.ai';
+    if (!apiKey) {
+      throw makeProviderConfigError('Missing required provider credentials');
+    }
+
+    const callConfig = normalizePlainObject(options.callConfig);
+    const realtimeSpec = coerceRealtimeSpec(callConfig.realtimeSpec);
+    const provider = String(realtimeSpec.provider ?? '').trim();
+    if (provider !== 'vapi') {
+      throw makeHttpError({ message: 'Unsupported realtimeSpec.provider for vapi voice calls', statusCode: 400, code: 'validation_error' });
+    }
+
+    const settings = normalizePlainObject(realtimeSpec.settings);
+
+    const modelProvider = readSettingString(settings, 'modelProvider', ['model_provider']) ?? 'openai';
+    const model = resolveModel(realtimeSpec);
+    const voiceProvider = readSettingString(settings, 'voiceProvider', ['voice_provider']) ?? 'openai';
+    const voice = readSettingString(settings, 'voice') ?? 'alloy';
+    const temperature = readSettingNumber(settings, 'temperature');
+    const speed = readSettingNumber(settings, 'speed');
+    const transcriber = resolveTranscriber(realtimeSpec, settings);
+
+    const messages: any[] = [];
+    const systemPrompt = String(callConfig.systemPrompt ?? '').trim();
+    if (systemPrompt) {
+      messages.push({ role: 'system', content: systemPrompt });
+    }
+
+    const assistantFirstTurn = normalizePlainObject(callConfig.assistantFirstTurn);
+    const assistantFirstTurnEnabled = Boolean(assistantFirstTurn.enabled);
+    let assistantFirstTurnActive = false;
+    if (assistantFirstTurnEnabled) {
+      const prompt = String(assistantFirstTurn.prompt ?? '').trim();
+      const missingPromptBehavior = String(assistantFirstTurn.missingPromptBehavior ?? 'reject').trim().toLowerCase();
+      if (!prompt) {
+        if (missingPromptBehavior === 'skip') {
+          // ignore
+        } else {
+          throw makeHttpError({ message: 'Missing assistantFirstTurn.prompt', statusCode: 400, code: 'validation_error' });
+        }
+      } else {
+        const roleRaw = String(assistantFirstTurn.role ?? 'user').trim().toLowerCase();
+        const role = roleRaw === 'system' ? 'system' : 'user';
+
+        const delayMsRaw = assistantFirstTurn.delayMs;
+        const delayMs = delayMsRaw === undefined || delayMsRaw === null || delayMsRaw === '' ? 0 : Number(delayMsRaw);
+        if (!Number.isFinite(delayMs) || delayMs < 0) {
+          throw makeHttpError({ message: 'Invalid assistantFirstTurn.delayMs', statusCode: 400, code: 'validation_error' });
+        }
+        if (delayMs > 0) {
+          throw makeHttpError({ message: 'assistantFirstTurn.delayMs is not supported for vapi voice calls', statusCode: 400, code: 'validation_error' });
+        }
+
+        messages.push({ role, content: prompt });
+        assistantFirstTurnActive = true;
+      }
+    }
+
+    const webhookUrl = toWebhookUrlFromMediaWsUrl({ mediaWsUrl: options.mediaWsUrl, callConfigId });
+    if (!webhookUrl) {
+      throw makeProviderConfigError('Failed to derive /voice/webhook URL from mediaWsUrl');
+    }
+
+    const webhookAuth = parseWebhookAuth(options.providerDefaults);
+    if (webhookAuth.type !== 'bearer') {
+      throw makeProviderConfigError('Only bearer webhookAuth is supported for createOutboundCall');
+    }
+
+    const assistant: any = {
+      ...(assistantFirstTurnActive ? { firstMessageMode: 'assistant-speaks-first-with-model-generated-message' } : { firstMessageMode: 'assistant-waits-for-user' }),
+      modelOutputInMessagesEnabled: true,
+      serverMessages: ['status-update', 'speech-update', 'transcript', 'end-of-call-report'],
+      server: {
+        url: webhookUrl,
+        headers: { Authorization: `Bearer ${webhookAuth.token}` }
+      },
+      model: {
+        provider: modelProvider,
+        model,
+        ...(messages.length > 0 ? { messages } : {}),
+        ...(temperature !== undefined ? { temperature } : {})
+      },
+      transcriber: {
+        provider: transcriber.provider,
+        model: transcriber.model
+      },
+      voice: {
+        provider: voiceProvider,
+        voiceId: voice,
+        ...(speed !== undefined ? { speed } : {})
+      }
+    };
+
+    const url = `${apiBaseUrl}/call`;
+    let res: any;
+    try {
+      res = await fetch(url, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          phoneNumberId: from,
+          customer: { number: to },
+          assistant
+        })
+      });
+    } catch (err: any) {
+      const detail = err?.message ? `: ${String(err.message).slice(0, 200)}` : '';
+      throw new ProviderExecutionError('vapi', `Outbound call create failed${detail}`, 502);
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      const suffix = text ? `: ${text.slice(0, 500)}` : '';
+      throw new ProviderExecutionError('vapi', `Outbound call create failed (${res.status})${suffix}`, res.status, res.status === 429);
+    }
+
+    const payload = await res.json().catch(() => null);
+    const providerCallId = String(payload?.id ?? '').trim();
+    if (!providerCallId) {
+      throw new ProviderExecutionError('vapi', 'Outbound call create response missing id', 502);
+    }
+
+    return { providerCallId };
+  }
+
+  async createWebhookResponse(options: { callConfigId: string; callConfig?: any; voiceProvider: string; body?: any; bodyText?: string; events?: { emit?: (event: any) => void } }): Promise<{
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+  }> {
+    const body = normalizePlainObject(options.body);
+    const message = normalizePlainObject(body.message);
+    const type = String(message.type ?? '').trim();
+
+    const call = normalizePlainObject(message.call);
+    const providerCallId = String(call.id ?? options.callConfig?.providerCallId ?? '').trim();
+    const emit = (event: any) => {
+      try {
+        options.events?.emit?.({ ...event, ...(providerCallId ? { providerCallId } : {}) });
+      } catch {}
+    };
+
+    if (type.startsWith('transcript')) {
+      const roleRaw = String(message.role ?? '').trim().toLowerCase();
+      const role = roleRaw === 'assistant' ? 'assistant' : roleRaw === 'user' ? 'user' : '';
+      const transcript = String(message.transcript ?? '').trim();
+
+      const transcriptTypeRaw = String(message.transcriptType ?? '').trim().toLowerCase();
+      const transcriptType =
+        transcriptTypeRaw === 'final' ? 'final' : transcriptTypeRaw === 'partial' ? 'partial' : type.includes('final') ? 'final' : '';
+
+      if (role && transcript && transcriptType) {
+        if (role === 'user') {
+          if (transcriptType === 'final') {
+            emit({ type: 'user_transcript.final', text: transcript });
+          } else {
+            emit({ type: 'user_transcript.delta', textDelta: transcript });
+          }
+        } else if (role === 'assistant') {
+          if (transcriptType === 'final') {
+            emit({ type: 'assistant_transcript.final', text: transcript });
+          } else {
+            emit({ type: 'assistant_transcript.delta', textDelta: transcript });
+          }
+        }
+      }
+    } else if (type === 'speech-update') {
+      const roleRaw = String(message.role ?? '').trim().toLowerCase();
+      const status = String(message.status ?? '').trim().toLowerCase();
+      const role = roleRaw === 'assistant' ? 'assistant' : roleRaw === 'user' ? 'user' : '';
+      if (role === 'user') {
+        if (status === 'started') emit({ type: 'user_speech.started' });
+        if (status === 'stopped') emit({ type: 'user_speech.stopped' });
+      } else if (role === 'assistant') {
+        if (status === 'started') emit({ type: 'voice.assistant_audio.started' });
+        if (status === 'stopped') {
+          emit({ type: 'voice.assistant_audio.ended' });
+          emit({ type: 'voice.playback.drained' });
+        }
+      }
+    } else if (type === 'status-update') {
+      const status = String(message.status ?? '').trim().toLowerCase();
+      if (status === 'in-progress') {
+        emit({ type: 'voice.call.connected' });
+      } else if (status === 'ended') {
+        const endedReason = String(message.endedReason ?? '').trim();
+        emit({ type: 'voice.call.ended', ...(endedReason ? { endedReason } : {}) });
+      }
+    } else if (type === 'end-of-call-report') {
+      const endedReason = String(message.endedReason ?? '').trim();
+      emit({ type: 'voice.call.ended', ...(endedReason ? { endedReason } : {}) });
+    }
+
+    return {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ok: true })
+    };
+  }
+
+  async endCall(options: { callConfigId: string; callConfig?: any; providerCallId: string; voiceProvider: string; providerDefaults?: any }): Promise<void> {
+    const providerCallId = String(options.providerCallId ?? options.callConfig?.providerCallId ?? '').trim();
+    if (!providerCallId) return;
+
+    const defaults = normalizePlainObject(options.providerDefaults);
+    const apiKey = String(defaults.apiKey ?? '').trim();
+    const apiBaseUrlRaw = String(defaults.apiBaseUrl ?? 'https://api.vapi.ai').trim();
+    const apiBaseUrl = apiBaseUrlRaw ? apiBaseUrlRaw.replace(/\/+$/g, '') : 'https://api.vapi.ai';
+    if (!apiKey) {
+      throw makeProviderConfigError('Missing required provider credentials');
+    }
+
+    const callUrl = `${apiBaseUrl}/call/${encodeURIComponent(providerCallId)}`;
+    const pollMsRaw = defaults.controlUrlPollMs ?? 500;
+    const maxWaitMsRaw = defaults.controlUrlMaxWaitMs ?? 20000;
+    const pollMs = Math.max(100, Math.floor(Number.isFinite(Number(pollMsRaw)) ? Number(pollMsRaw) : 500));
+    const maxWaitMs = Math.max(pollMs, Math.floor(Number.isFinite(Number(maxWaitMsRaw)) ? Number(maxWaitMsRaw) : 20000));
+
+    const deadline = Date.now() + maxWaitMs;
+    let controlUrl = '';
+    let lastErr: any;
+
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetch(callUrl, { method: 'GET', headers: { Authorization: `Bearer ${apiKey}` } });
+        if (!res.ok) {
+          const text = await res.text().catch(() => '');
+          throw new Error(`Vapi call get failed (${res.status}): ${text || res.statusText}`);
+        }
+        const json = await res.json().catch(() => ({}));
+        const monitor = normalizePlainObject((json as any)?.monitor);
+        controlUrl = String(monitor.controlUrl ?? '').trim();
+        if (controlUrl) break;
+      } catch (err: any) {
+        lastErr = err;
+      }
+
+      await new Promise<void>(resolve => setTimeout(resolve, pollMs));
+    }
+
+    if (!controlUrl) {
+      const detail = lastErr?.message ? `: ${String(lastErr.message).slice(0, 200)}` : '';
+      throw new ProviderExecutionError('vapi', `Vapi controlUrl unavailable${detail}`, 502);
+    }
+
+    const res = await fetch(controlUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ type: 'end-call' }) });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new ProviderExecutionError('vapi', `Vapi control failed (${res.status}): ${text || res.statusText}`, res.status, res.status === 429);
+    }
+  }
+
+  async handleMediaConnection(options: { ws: any }) {
+    try { options.ws?.close?.(); } catch {}
+  }
+}

--- a/plugins/voice-compat/vapi/tests/unit/vapi-voice-compat.test.ts
+++ b/plugins/voice-compat/vapi/tests/unit/vapi-voice-compat.test.ts
@@ -1,0 +1,1223 @@
+import crypto from 'crypto';
+import { jest } from '@jest/globals';
+
+import VapiVoiceCompat from '../../index.ts';
+
+type FakeFetchResponse = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json?: () => Promise<any>;
+  text?: () => Promise<string>;
+};
+
+function installFetch(mock: (url: string, init: any) => Promise<FakeFetchResponse>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: any, init: any) => mock(String(url), init)) as any;
+  return { restore: () => { globalThis.fetch = original; } };
+}
+
+function hmac(options: { algorithm: 'sha256' | 'sha512' | 'sha1'; key: string | Buffer; payload: string; encoding: 'hex' | 'base64' }): string {
+  return crypto.createHmac(options.algorithm, options.key).update(options.payload, 'utf8').digest(options.encoding);
+}
+
+describe('plugins/voice-compat/vapi', () => {
+  test('validateWebhookRequest: bearer token auth', async () => {
+    const compat = new VapiVoiceCompat();
+
+    // type omitted to cover bearer default
+    const providerDefaults = { webhookAuth: { token: 'tok_1' } };
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: {} } as any,
+        method: 'POST',
+        url: 'https://example.test/voice/webhook?callConfigId=cfg_1',
+        providerDefaults
+      })
+    ).rejects.toMatchObject({ statusCode: 401, code: 'unauthorized' });
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { authorization: 'Bearer nope' } } as any,
+        method: 'POST',
+        url: 'https://example.test/voice/webhook?callConfigId=cfg_1',
+        providerDefaults
+      })
+    ).rejects.toMatchObject({ statusCode: 401, code: 'unauthorized' });
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { authorization: ['Bearer tok_1'] } } as any,
+        method: 'POST',
+        url: 'https://example.test/voice/webhook?callConfigId=cfg_1',
+        providerDefaults
+      })
+    ).resolves.toBeUndefined();
+
+    // empty arrays should be treated as missing
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { authorization: [] } } as any,
+        method: 'POST',
+        url: 'https://example.test/voice/webhook?callConfigId=cfg_1',
+        providerDefaults
+      })
+    ).rejects.toMatchObject({ statusCode: 401, code: 'unauthorized' });
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { authorization: 'Basic abc' } } as any,
+        method: 'POST',
+        url: 'https://example.test/voice/webhook?callConfigId=cfg_1',
+        providerDefaults
+      })
+    ).rejects.toMatchObject({ statusCode: 401, code: 'unauthorized' });
+  });
+
+  test('validateWebhookRequest: bearer token config must include token', async () => {
+    const compat = new VapiVoiceCompat();
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { authorization: 'Bearer tok' } } as any,
+        method: 'POST',
+        url: 'https://example.test/voice/webhook?callConfigId=cfg_1',
+        providerDefaults: { webhookAuth: { type: 'bearer', token: '' } }
+      })
+    ).rejects.toMatchObject({ statusCode: 500, code: 'provider_config_error' });
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { authorization: 'Bearer tok' } } as any,
+        method: 'POST',
+        url: 'https://example.test/voice/webhook?callConfigId=cfg_1',
+        providerDefaults: { webhookAuth: { type: 'bearer' } }
+      })
+    ).rejects.toMatchObject({ statusCode: 500, code: 'provider_config_error' });
+  });
+
+  test('validateWebhookRequest: hmac auth requires secretKey + algorithm', async () => {
+    const compat = new VapiVoiceCompat();
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: {} } as any,
+        method: 'POST',
+        url: 'https://example.test/voice/webhook?callConfigId=cfg_1',
+        providerDefaults: { webhookAuth: { type: 'hmac', algorithm: 'sha256' } }
+      })
+    ).rejects.toMatchObject({ statusCode: 500, code: 'provider_config_error' });
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: {} } as any,
+        method: 'POST',
+        url: 'https://example.test/voice/webhook?callConfigId=cfg_1',
+        providerDefaults: { webhookAuth: { type: 'hmac', secretKey: 'secret_1' } }
+      })
+    ).rejects.toMatchObject({ statusCode: 500, code: 'provider_config_error' });
+  });
+
+  test('validateWebhookRequest: hmac auth (timestamp + body)', async () => {
+    const compat = new VapiVoiceCompat();
+
+    const providerDefaults = {
+      webhookAuth: {
+        type: 'hmac',
+        secretKey: 'secret_1',
+        algorithm: 'sha256',
+        signatureHeader: 'x-signature',
+        timestampHeader: 'x-timestamp',
+        signatureEncoding: 'hex',
+        includeTimestamp: true,
+        payloadFormat: '{timestamp}.{body}'
+      }
+    };
+
+    const bodyText = JSON.stringify({ message: { type: 'status-update', status: 'queued' } });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const payload = `${timestamp}.${bodyText}`;
+    const signature = hmac({ algorithm: 'sha256', key: 'secret_1', payload, encoding: 'hex' });
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: {
+          headers: {
+            'x-signature': signature,
+            'x-timestamp': timestamp
+          }
+        } as any,
+        method: 'POST',
+        url: 'https://example.test/voice/webhook?callConfigId=cfg_1',
+        bodyText,
+        providerDefaults
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  test('validateWebhookRequest: hmac supports signaturePrefix + base64 signatureEncoding + base64 secrets', async () => {
+    const compat = new VapiVoiceCompat();
+
+    const secretBytes = Buffer.from('secret_2', 'utf8');
+    const secretKey = secretBytes.toString('base64');
+    const providerDefaults = {
+      webhookAuth: {
+        type: 'hmac',
+        secretKey,
+        secretIsBase64: true,
+        algorithm: 'sha512',
+        signatureHeader: 'x-signature',
+        timestampHeader: 'x-timestamp',
+        signatureEncoding: 'base64',
+        signaturePrefix: 'sha512=',
+        includeTimestamp: true,
+        // cover non-numeric timestamp tolerance bypass
+        payloadFormat: '{timestamp}.{body}.{method}.{url}.{svix-id}',
+        toleranceSeconds: 'nope'
+      }
+    };
+
+    const bodyText = JSON.stringify({ message: { type: 'status-update', status: 'queued' } });
+    const timestamp = 'abc';
+    const url = 'https://example.test/voice/webhook?callConfigId=cfg_1';
+    const payload = `${timestamp}.${bodyText}.POST.${url}.m1`;
+    const signature = hmac({ algorithm: 'sha512', key: secretBytes, payload, encoding: 'base64' });
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { 'x-signature': `sha512=${signature}`, 'x-timestamp': timestamp, 'svix-id': 'm1' } } as any,
+        method: 'POST',
+        url,
+        bodyText,
+        providerDefaults
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  test('validateWebhookRequest: hmac can default headers and fill missing body/method/url', async () => {
+    const compat = new VapiVoiceCompat();
+
+    const providerDefaults = {
+      webhookAuth: {
+        type: 'hmac',
+        secretKey: 'secret_5',
+        algorithm: 'sha256',
+        // ensure fallback to defaults when trimmed to empty
+        signatureHeader: '  ',
+        timestampHeader: '  ',
+        signatureEncoding: 'hex',
+        includeTimestamp: true,
+        // cover body/method/url defaults + svix-id default
+        payloadFormat: '{timestamp}.{body}.{method}.{url}.{svix-id}',
+        toleranceSeconds: 0
+      }
+    };
+
+    const timestamp = 'abc';
+    const bodyText = '';
+    const url = '';
+
+    // omit options.method so it falls back to req.method
+    const methodFromReq = 'PUT';
+    const payload1 = `${timestamp}.${bodyText}.${methodFromReq}.${url}.`;
+    const signature1 = hmac({ algorithm: 'sha256', key: 'secret_5', payload: payload1, encoding: 'hex' });
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { method: methodFromReq, headers: { 'x-signature': signature1, 'x-timestamp': timestamp } } as any,
+        providerDefaults
+      } as any)
+    ).resolves.toBeUndefined();
+
+    // omit req.method too so method defaults to POST
+    const payload2 = `${timestamp}.${bodyText}.POST.${url}.`;
+    const signature2 = hmac({ algorithm: 'sha256', key: 'secret_5', payload: payload2, encoding: 'hex' });
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { 'x-signature': signature2, 'x-timestamp': timestamp } } as any,
+        providerDefaults
+      } as any)
+    ).resolves.toBeUndefined();
+  });
+
+  test('validateWebhookRequest: hmac rejects missing signature/timestamp and invalid signatures + timestamps', async () => {
+    const compat = new VapiVoiceCompat();
+    const url = 'https://example.test/voice/webhook?callConfigId=cfg_1';
+    const bodyText = '{}';
+
+    const providerDefaults = {
+      webhookAuth: {
+        type: 'hmac',
+        secretKey: 'secret_3',
+        algorithm: 'sha1',
+        signatureHeader: 'x-signature',
+        timestampHeader: 'x-timestamp',
+        signatureEncoding: 'hex',
+        includeTimestamp: true,
+        payloadFormat: '{timestamp}.{body}',
+        toleranceSeconds: 1
+      }
+    };
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { 'x-timestamp': '1' } } as any,
+        method: 'POST',
+        url,
+        bodyText,
+        providerDefaults
+      })
+    ).rejects.toMatchObject({ statusCode: 401, code: 'unauthorized' });
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { 'x-signature': 'x' } } as any,
+        method: 'POST',
+        url,
+        bodyText,
+        providerDefaults
+      })
+    ).rejects.toMatchObject({ statusCode: 401, code: 'unauthorized' });
+
+    // too old timestamp triggers tolerance error
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { 'x-signature': 'x', 'x-timestamp': '1' } } as any,
+        method: 'POST',
+        url,
+        bodyText,
+        providerDefaults
+      })
+    ).rejects.toMatchObject({ statusCode: 401, code: 'unauthorized' });
+
+    // invalid signature
+    const timestamp = String(Date.now());
+    const payload = `${timestamp}.${bodyText}`;
+    const signature = hmac({ algorithm: 'sha1', key: 'secret_3', payload, encoding: 'hex' });
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { 'x-signature': `${signature}0`, 'x-timestamp': timestamp } } as any,
+        method: 'POST',
+        url,
+        bodyText,
+        providerDefaults
+      })
+    ).rejects.toMatchObject({ statusCode: 401, code: 'unauthorized' });
+  });
+
+  test('validateWebhookRequest: hmac can ignore timestamps when includeTimestamp=false', async () => {
+    const compat = new VapiVoiceCompat();
+
+    const providerDefaults = {
+      webhookAuth: {
+        type: 'hmac',
+        secretKey: 'secret_4',
+        algorithm: 'sha256',
+        signatureHeader: 'x-signature',
+        includeTimestamp: false,
+        payloadFormat: '{body}',
+        signatureEncoding: 'hex'
+      }
+    };
+
+    const bodyText = JSON.stringify({ ok: true });
+    const signature = hmac({ algorithm: 'sha256', key: 'secret_4', payload: bodyText, encoding: 'hex' });
+
+    await expect(
+      compat.validateWebhookRequest({
+        req: { headers: { 'x-signature': signature } } as any,
+        method: 'POST',
+        url: 'https://example.test/voice/webhook?callConfigId=cfg_1',
+        bodyText,
+        providerDefaults
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  test('createOutboundCall: validates inputs, provider defaults, and webhook url', async () => {
+    const compat = new VapiVoiceCompat();
+
+    await expect(
+      compat.createOutboundCall({ to: '', from: 'x', callConfigId: 'cfg_1' } as any)
+    ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
+
+    await expect(
+      compat.createOutboundCall({ to: undefined, from: 'x', callConfigId: 'cfg_1' } as any)
+    ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
+
+    await expect(
+      compat.createOutboundCall({ to: 'to', from: undefined, callConfigId: 'cfg_1' } as any)
+    ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
+
+    await expect(
+      compat.createOutboundCall({ to: 'to', from: 'from', callConfigId: undefined } as any)
+    ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
+
+    await expect(
+      compat.createOutboundCall({
+        to: 'to',
+        from: 'from',
+        callConfigId: 'cfg_1',
+        callConfig: { realtimeSpec: { provider: 'vapi', model: 'model_x' } },
+        mediaWsUrl: '',
+        providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 500, code: 'provider_config_error' });
+
+    await expect(
+      compat.createOutboundCall({
+        to: 'to',
+        from: 'from',
+        callConfigId: 'cfg_1',
+        callConfig: { realtimeSpec: { provider: 'vapi', model: 'model_x' } },
+        mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+        providerDefaults: { apiKey: '', webhookAuth: { type: 'bearer', token: 't' } }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 500, code: 'provider_config_error' });
+
+    await expect(
+      compat.createOutboundCall({
+        to: 'to',
+        from: 'from',
+        callConfigId: 'cfg_1',
+        callConfig: { realtimeSpec: { provider: 'nope', model: 'model_x' } },
+        mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+        providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
+
+    await expect(
+      compat.createOutboundCall({
+        to: 'to',
+        from: 'from',
+        callConfigId: 'cfg_1',
+        callConfig: { realtimeSpec: { provider: 'vapi', model: 'model_x' } },
+        mediaWsUrl: 'not a url',
+        providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 500, code: 'provider_config_error' });
+
+    await expect(
+      compat.createOutboundCall({
+        to: 'to',
+        from: 'from',
+        callConfigId: 'cfg_1',
+        callConfig: { realtimeSpec: { provider: 'vapi', model: 'model_x' } },
+        mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+        providerDefaults: { apiKey: 'k', webhookAuth: { type: 'hmac', secretKey: 's', algorithm: 'sha256' } }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 500, code: 'provider_config_error' });
+
+    await expect(
+      compat.createOutboundCall({
+        to: 'to',
+        from: 'from',
+        callConfigId: 'cfg_1',
+        callConfig: { realtimeSpec: { provider: 'vapi', model: 'model_x' } },
+        mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+        providerDefaults: { apiKey: undefined, webhookAuth: { type: 'bearer', token: 't' } }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 500, code: 'provider_config_error' });
+
+    await expect(
+      compat.createOutboundCall({
+        to: 'to',
+        from: 'from',
+        callConfigId: 'cfg_1',
+        callConfig: { realtimeSpec: { model: 'model_x' } },
+        mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+        providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
+  });
+
+  test('createOutboundCall: assistantFirstTurn validation (prompt + delayMs)', async () => {
+    const compat = new VapiVoiceCompat();
+
+    const fetchMock = installFetch(async () => ({
+      ok: true,
+      status: 201,
+      statusText: 'Created',
+      json: async () => ({ id: 'call_1' })
+    }));
+
+    try {
+      await expect(
+        compat.createOutboundCall({
+          to: 'to',
+          from: 'from',
+          callConfigId: 'cfg_1',
+          callConfig: {
+            assistantFirstTurn: { enabled: true, missingPromptBehavior: 'reject' },
+            realtimeSpec: { provider: 'vapi', model: 'model_x' }
+          },
+          mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+          providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+        } as any)
+      ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
+
+      await expect(
+        compat.createOutboundCall({
+          to: 'to',
+          from: 'from',
+          callConfigId: 'cfg_1',
+          callConfig: {
+            assistantFirstTurn: { enabled: true, prompt: 'hi', delayMs: 'nope' },
+            realtimeSpec: { provider: 'vapi', model: 'model_x' }
+          },
+          mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+          providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+        } as any)
+      ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
+
+      await expect(
+        compat.createOutboundCall({
+          to: 'to',
+          from: 'from',
+          callConfigId: 'cfg_1',
+          callConfig: {
+            assistantFirstTurn: { enabled: true, prompt: 'hi', delayMs: 10 },
+            realtimeSpec: { provider: 'vapi', model: 'model_x' }
+          },
+          mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+          providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+        } as any)
+      ).rejects.toMatchObject({ statusCode: 400, code: 'validation_error' });
+
+      const ok = await compat.createOutboundCall({
+        to: 'to',
+        from: 'from',
+        callConfigId: 'cfg_1',
+        callConfig: {
+          assistantFirstTurn: { enabled: true, missingPromptBehavior: 'skip' },
+          realtimeSpec: { provider: 'vapi' }
+        },
+        mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+        providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+      } as any);
+      expect(ok.providerCallId).toBe('call_1');
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  test('createOutboundCall: surfaces fetch failures and provider errors', async () => {
+    const compat = new VapiVoiceCompat();
+
+    const fetchThrow = installFetch(async () => {
+      throw new Error('network');
+    });
+    try {
+      await expect(
+        compat.createOutboundCall({
+          to: 'to',
+          from: 'from',
+          callConfigId: 'cfg_1',
+          callConfig: { realtimeSpec: { provider: 'vapi' } },
+          mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+          providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+    } finally {
+      fetchThrow.restore();
+    }
+
+    const fetchThrowNoMessage = installFetch(async () => {
+      throw { nope: true };
+    });
+    try {
+      await expect(
+        compat.createOutboundCall({
+          to: 'to',
+          from: 'from',
+          callConfigId: 'cfg_1',
+          callConfig: { realtimeSpec: { provider: 'vapi' } },
+          mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+          providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+    } finally {
+      fetchThrowNoMessage.restore();
+    }
+
+    const fetchBad = installFetch(async () => ({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () => 'bad'
+    }));
+    try {
+      await expect(
+        compat.createOutboundCall({
+          to: 'to',
+          from: 'from',
+          callConfigId: 'cfg_1',
+          callConfig: { realtimeSpec: { provider: 'vapi' } },
+          mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+          providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+    } finally {
+      fetchBad.restore();
+    }
+
+    const fetchBadTextThrows = installFetch(async () => ({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () => { throw new Error('boom'); }
+    }));
+    try {
+      await expect(
+        compat.createOutboundCall({
+          to: 'to',
+          from: 'from',
+          callConfigId: 'cfg_1',
+          callConfig: { realtimeSpec: { provider: 'vapi' } },
+          mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+          providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+    } finally {
+      fetchBadTextThrows.restore();
+    }
+
+    const fetchNoId = installFetch(async (_url, init) => {
+      const body = JSON.parse(init.body);
+      expect(body.assistant.model.model).toBe('gpt-4o-mini');
+      expect(body.assistant.model.temperature).toBeUndefined();
+      return { ok: true, status: 201, statusText: 'Created', json: async () => ({}) };
+    });
+    try {
+      await expect(
+        compat.createOutboundCall({
+          to: 'to',
+          from: 'from',
+          callConfigId: 'cfg_1',
+          callConfig: { realtimeSpec: { provider: 'vapi', settings: { temperature: 'nope' } } },
+          mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+          providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+    } finally {
+      fetchNoId.restore();
+    }
+
+    const fetchJsonThrows = installFetch(async () => ({
+      ok: true,
+      status: 201,
+      statusText: 'Created',
+      json: async () => { throw new Error('boom'); }
+    }));
+    try {
+      await expect(
+        compat.createOutboundCall({
+          to: 'to',
+          from: 'from',
+          callConfigId: 'cfg_1',
+          callConfig: { realtimeSpec: { provider: 'vapi' } },
+          mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+          providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+    } finally {
+      fetchJsonThrows.restore();
+    }
+  });
+
+  test('createOutboundCall: shapes Vapi call create request and uses /voice/webhook server url', async () => {
+    const fetchMock = installFetch(async (url, init) => {
+      const method = String(init?.method ?? 'GET').toUpperCase();
+      expect(method).toBe('POST');
+      expect(url).toBe('https://vapi.test/call');
+      expect(init.headers.Authorization).toBe('Bearer api_key');
+
+      const body = JSON.parse(init.body);
+      expect(body.phoneNumberId).toBe('pn_1');
+      expect(body.customer.number).toBe('+15550001111');
+
+      expect(body.assistant.model.provider).toBe('google');
+      expect(body.assistant.model.model).toBe('model_x');
+      expect(body.assistant.firstMessageMode).toBe('assistant-speaks-first-with-model-generated-message');
+      expect(Array.isArray(body.assistant.model.messages)).toBe(true);
+      expect(body.assistant.model.messages[0]?.role).toBe('system');
+      expect(body.assistant.model.messages[1]?.role).toBe('user');
+      expect(String(body.assistant.model.messages[1]?.content)).toContain('Say hi');
+      expect(body.assistant.voice.provider).toBe('openai');
+      expect(body.assistant.voice.voiceId).toBe('alloy');
+      expect(body.assistant.voice.speed).toBe(1.1);
+
+      expect(body.assistant.server.url).toBe('http://example.test/voice/webhook?callConfigId=cfg_1');
+      expect(body.assistant.server.headers.Authorization).toBe('Bearer webhook_tok');
+      expect(Array.isArray(body.assistant.serverMessages)).toBe(true);
+      expect(body.assistant.serverMessages).toContain('status-update');
+      expect(body.assistant.serverMessages).toContain('transcript');
+
+      return {
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        json: async () => ({ id: 'call_1' })
+      };
+    });
+
+    try {
+      const compat = new VapiVoiceCompat();
+      const res = await compat.createOutboundCall({
+        to: '+15550001111',
+        from: 'pn_1',
+        callConfigId: 'cfg_1',
+        callConfig: {
+          systemPrompt: 'You are helpful.',
+          assistantFirstTurn: { enabled: true, prompt: 'Say hi.', role: 'user', delayMs: 0, missingPromptBehavior: 'reject' },
+          realtimeSpec: { provider: 'vapi', model: 'model_x', settings: { modelProvider: 'google', voice: 'alloy', speed: 1.1 } }
+        },
+        voiceProvider: 'vapi',
+        mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+        providerDefaults: {
+          apiKey: 'api_key',
+          apiBaseUrl: 'https://vapi.test',
+          webhookAuth: { type: 'bearer', token: 'webhook_tok' }
+        }
+      } as any);
+
+      expect(res.providerCallId).toBe('call_1');
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  test('createOutboundCall: defaults transcriber when transcription values are blank', async () => {
+    const fetchMock = installFetch(async (_url, init) => {
+      const body = JSON.parse(init.body);
+      expect(body.assistant.transcriber.provider).toBe('deepgram');
+      expect(body.assistant.transcriber.model).toBe('nova-2');
+      return { ok: true, status: 201, statusText: 'Created', json: async () => ({ id: 'call_blank_transcriber' }) };
+    });
+
+    try {
+      const compat = new VapiVoiceCompat();
+      const res = await compat.createOutboundCall({
+        to: 'to',
+        from: 'from',
+        callConfigId: 'cfg_1',
+        callConfig: {
+          realtimeSpec: { provider: 'vapi', transcription: { provider: '  ', model: '  ' } }
+        },
+        voiceProvider: 'vapi',
+        mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+        providerDefaults: { apiKey: 'k', webhookAuth: { type: 'bearer', token: 't' } }
+      } as any);
+
+      expect(res.providerCallId).toBe('call_blank_transcriber');
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  test('createOutboundCall: defaults apiBaseUrl when empty', async () => {
+    const fetchMock = installFetch(async (url) => {
+      expect(url).toBe('https://api.vapi.ai/call');
+      return { ok: true, status: 201, statusText: 'Created', json: async () => ({ id: 'call_default_base' }) };
+    });
+
+    try {
+      const compat = new VapiVoiceCompat();
+      const res = await compat.createOutboundCall({
+        to: 'to',
+        from: 'from',
+        callConfigId: 'cfg_1',
+        callConfig: { realtimeSpec: { provider: 'vapi' } },
+        voiceProvider: 'vapi',
+        mediaWsUrl: 'ws://example.test/voice/media?token=abc',
+        providerDefaults: { apiKey: 'k', apiBaseUrl: '', webhookAuth: { type: 'bearer', token: 't' } }
+      } as any);
+
+      expect(res.providerCallId).toBe('call_default_base');
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  test('createOutboundCall: supports wss media urls + temperature and transcriber overrides', async () => {
+    const fetchMock = installFetch(async (url, init) => {
+      expect(url).toBe('https://vapi.test/call');
+
+      const body = JSON.parse(init.body);
+      expect(body.assistant.server.url).toBe('https://example.test/voice/webhook?callConfigId=cfg_1');
+      expect(body.assistant.model.temperature).toBe(0.9);
+      expect(body.assistant.transcriber.provider).toBe('transcriber_x');
+      expect(body.assistant.transcriber.model).toBe('transcriber_model_x');
+      expect(body.assistant.model.messages[0]?.role).toBe('system');
+
+      return { ok: true, status: 201, statusText: 'Created', json: async () => ({ id: 'call_2' }) };
+    });
+
+    try {
+      const compat = new VapiVoiceCompat();
+      const res = await compat.createOutboundCall({
+        to: '+15550001111',
+        from: 'pn_1',
+        callConfigId: 'cfg_1',
+        callConfig: {
+          assistantFirstTurn: { enabled: true, prompt: 'Hi', role: 'system' },
+          realtimeSpec: {
+            provider: 'vapi',
+            model: 'model_x',
+            transcription: { provider: 'transcriber_x', model: 'transcriber_model_x' },
+            settings: { temperature: 0.9 }
+          }
+        },
+        voiceProvider: 'vapi',
+        mediaWsUrl: 'wss://example.test/voice/media?token=abc',
+        providerDefaults: {
+          apiKey: 'api_key',
+          apiBaseUrl: 'https://vapi.test',
+          webhookAuth: { type: 'bearer', token: 'webhook_tok' }
+        }
+      } as any);
+
+      expect(res.providerCallId).toBe('call_2');
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  test('createWebhookResponse: maps transcript + speech/status updates to normalized events', async () => {
+    const compat = new VapiVoiceCompat();
+
+    const emitted: any[] = [];
+    const emitThrowsOnce = jest.fn((evt: any) => {
+      emitted.push(evt);
+      throw new Error('boom');
+    });
+
+    const res1 = await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'transcript', role: 'user', transcriptType: 'final', transcript: 'hello', call: { id: 'call_1' } } },
+      events: { emit: emitThrowsOnce }
+    } as any);
+    expect(res1.status).toBe(200);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'transcript', role: 'assistant', transcriptType: 'partial', transcript: 'hi', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: {},
+      voiceProvider: 'vapi',
+      body: { message: { type: 'transcript[transcriptType=\"final\"]', role: 'user', transcript: 'finalish' } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'transcript', role: 'user', transcriptType: 'partial', transcript: 'he', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'speech-update', role: 'user', status: 'started', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'speech-update', role: 'user', status: 'stopped', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'speech-update', role: 'assistant', status: 'started', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'speech-update', role: 'assistant', status: 'stopped', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'status-update', status: 'in-progress', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'status-update', status: 'ended', endedReason: 'x', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'status-update', status: 'ended', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'end-of-call-report', endedReason: 'y', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'transcript', role: 'assistant', transcriptType: 'final', transcript: 'bye', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    // unknown/invalid transcript role/type should no-op
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'transcript', role: 'nope', transcriptType: 'final', transcript: 'skip', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    // missing or invalid fields should no-op
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: {},
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'transcript' } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'speech-update' } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'status-update' } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    await compat.createWebhookResponse({
+      callConfigId: 'cfg_1',
+      callConfig: { providerCallId: 'call_1' },
+      voiceProvider: 'vapi',
+      body: { message: { type: 'end-of-call-report', call: { id: 'call_1' } } },
+      events: { emit: (evt: any) => emitted.push(evt) }
+    } as any);
+
+    expect(emitted.some(e => e?.type === 'user_transcript.final' && String(e?.text).includes('hello'))).toBe(true);
+    expect(emitted.some(e => e?.type === 'assistant_transcript.delta')).toBe(true);
+    expect(emitted.some(e => e?.type === 'assistant_transcript.final' && String(e?.text).includes('bye'))).toBe(true);
+    expect(emitted.some(e => e?.type === 'user_transcript.final' && String(e?.text).includes('finalish'))).toBe(true);
+    expect(emitted.some(e => e?.type === 'user_transcript.delta')).toBe(true);
+    expect(emitted.some(e => e?.type === 'user_speech.started')).toBe(true);
+    expect(emitted.some(e => e?.type === 'user_speech.stopped')).toBe(true);
+    expect(emitted.some(e => e?.type === 'voice.assistant_audio.started')).toBe(true);
+    expect(emitted.some(e => e?.type === 'voice.assistant_audio.ended')).toBe(true);
+    expect(emitted.some(e => e?.type === 'voice.playback.drained')).toBe(true);
+    expect(emitted.some(e => e?.type === 'voice.call.connected')).toBe(true);
+    expect(emitted.some(e => e?.type === 'voice.call.ended' && e?.endedReason === 'x')).toBe(true);
+  });
+
+  test('endCall: posts end-call to monitor.controlUrl', async () => {
+    const calls: Array<{ url: string; init: any }> = [];
+    const fetchMock = installFetch(async (url, init) => {
+      calls.push({ url, init });
+      const method = String(init?.method ?? 'GET').toUpperCase();
+
+      if (method === 'GET' && url === 'https://vapi.test/call/call_1') {
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({ id: 'call_1', monitor: { controlUrl: 'https://vapi.test/control' } })
+        };
+      }
+
+      if (method === 'POST' && url === 'https://vapi.test/control') {
+        expect(init.headers['Content-Type']).toBe('application/json');
+        expect(JSON.parse(init.body)).toEqual({ type: 'end-call' });
+        return { ok: true, status: 200, statusText: 'OK', json: async () => ({ ok: true }) };
+      }
+
+      return { ok: false, status: 500, statusText: 'unexpected', text: async () => 'unexpected' };
+    });
+
+    try {
+      const compat = new VapiVoiceCompat();
+      await compat.endCall({
+        callConfigId: 'cfg_1',
+        callConfig: { providerCallId: 'call_1' },
+        providerCallId: 'call_1',
+        voiceProvider: 'vapi',
+        providerDefaults: { apiKey: 'api_key', apiBaseUrl: 'https://vapi.test' }
+      } as any);
+
+      expect(calls.some(c => c.url === 'https://vapi.test/control')).toBe(true);
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  test('endCall: noops when providerCallId missing', async () => {
+    const compat = new VapiVoiceCompat();
+    const fetchSpy = jest.fn(async () => ({ ok: false, status: 500, statusText: 'unexpected', text: async () => 'unexpected' }));
+    const fetchMock = installFetch(fetchSpy);
+    try {
+      await compat.endCall({ callConfigId: 'cfg_1', providerCallId: '', voiceProvider: 'vapi' } as any);
+      await compat.endCall({ callConfigId: 'cfg_1', providerCallId: undefined, voiceProvider: 'vapi' } as any);
+      expect(fetchSpy).toHaveBeenCalledTimes(0);
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  test('endCall: uses callConfig.providerCallId when providerCallId is missing', async () => {
+    const compat = new VapiVoiceCompat();
+
+    const fetchSpy = jest.fn(async (url: string, init: any) => {
+      const method = String(init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET' && url === 'https://vapi.test/call/call_1') {
+        return { ok: true, status: 200, statusText: 'OK', json: async () => ({ id: 'call_1', monitor: { controlUrl: 'https://vapi.test/control' } }) };
+      }
+      if (method === 'POST' && url === 'https://vapi.test/control') {
+        return { ok: true, status: 200, statusText: 'OK', json: async () => ({ ok: true }) };
+      }
+      return { ok: false, status: 500, statusText: 'unexpected', text: async () => 'unexpected' };
+    });
+
+    const fetchMock = installFetch(fetchSpy);
+    try {
+      await compat.endCall({
+        callConfigId: 'cfg_1',
+        callConfig: { providerCallId: 'call_1' },
+        providerCallId: undefined,
+        voiceProvider: 'vapi',
+        providerDefaults: { apiKey: 'api_key', apiBaseUrl: 'https://vapi.test' }
+      } as any);
+
+      expect(fetchSpy).toHaveBeenCalled();
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  test('endCall: defaults apiBaseUrl and handles provider GET/control errors with empty bodies', async () => {
+    const compat = new VapiVoiceCompat();
+
+    // cover apiKey missing (undefined), poll/maxWait non-numeric defaults, GET text() throwing, and POST text() throwing
+    await expect(
+      compat.endCall({ callConfigId: 'cfg_1', providerCallId: 'call_1', voiceProvider: 'vapi', providerDefaults: {} } as any)
+    ).rejects.toMatchObject({ statusCode: 500, code: 'provider_config_error' });
+
+    const fetchMock = installFetch(async (url, init) => {
+      const method = String(init?.method ?? 'GET').toUpperCase();
+
+      if (method === 'GET' && url === 'https://api.vapi.ai/call/call_poll') {
+        return { ok: true, status: 200, statusText: 'OK', json: async () => ({ id: 'call_poll', monitor: { controlUrl: 'https://api.vapi.ai/control' } }) };
+      }
+
+      if (method === 'GET' && url === 'https://api.vapi.ai/call/call_get_err') {
+        return { ok: false, status: 500, statusText: 'Boom', text: async () => { throw new Error('boom'); } };
+      }
+
+      if (method === 'GET' && url === 'https://api.vapi.ai/call/call_get_json_throw') {
+        return { ok: true, status: 200, statusText: 'OK', json: async () => { throw new Error('boom'); } };
+      }
+
+      if (method === 'POST' && url === 'https://api.vapi.ai/control') {
+        return { ok: false, status: 500, statusText: 'Boom', text: async () => { throw new Error('boom'); } };
+      }
+
+      return { ok: false, status: 500, statusText: 'unexpected', text: async () => 'unexpected' };
+    });
+
+    try {
+      await expect(
+        compat.endCall({
+          callConfigId: 'cfg_1',
+          providerCallId: 'call_poll',
+          voiceProvider: 'vapi',
+          providerDefaults: { apiKey: 'api_key', apiBaseUrl: '', controlUrlMaxWaitMs: 'nope', controlUrlPollMs: 'nope' }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+
+      await expect(
+        compat.endCall({
+          callConfigId: 'cfg_1',
+          providerCallId: 'call_get_err',
+          voiceProvider: 'vapi',
+          providerDefaults: { apiKey: 'api_key', apiBaseUrl: '', controlUrlMaxWaitMs: 100, controlUrlPollMs: 100 }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+
+      await expect(
+        compat.endCall({
+          callConfigId: 'cfg_1',
+          providerCallId: 'call_get_json_throw',
+          voiceProvider: 'vapi',
+          providerDefaults: { apiKey: 'api_key', apiBaseUrl: '', controlUrlMaxWaitMs: 100, controlUrlPollMs: 100 }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  test('endCall: validates provider defaults and surfaces provider errors', async () => {
+    const compat = new VapiVoiceCompat();
+
+    await expect(
+      compat.endCall({ callConfigId: 'cfg_1', providerCallId: 'call_1', voiceProvider: 'vapi', providerDefaults: { apiKey: '' } } as any)
+    ).rejects.toMatchObject({ statusCode: 500, code: 'provider_config_error' });
+
+    const fetchMock = installFetch(async (url, init) => {
+      const method = String(init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET' && url === 'https://vapi.test/call/call_1') {
+        return { ok: true, status: 200, statusText: 'OK', json: async () => ({ id: 'call_1' }) };
+      }
+      return { ok: false, status: 400, statusText: 'Bad', text: async () => 'bad' };
+    });
+
+    try {
+      await expect(
+        compat.endCall({
+          callConfigId: 'cfg_1',
+          providerCallId: 'call_1',
+          voiceProvider: 'vapi',
+          providerDefaults: { apiKey: 'api_key', apiBaseUrl: 'https://vapi.test', controlUrlMaxWaitMs: 100, controlUrlPollMs: 100 }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  test('endCall: throws when controlUrl cannot be resolved, and when controlUrl rejects', async () => {
+    const compat = new VapiVoiceCompat();
+
+    const fetchNoControl = installFetch(async (url, init) => {
+      const method = String(init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET' && url === 'https://vapi.test/call/call_1') {
+        return { ok: true, status: 200, statusText: 'OK', json: async () => ({ id: 'call_1', monitor: {} }) };
+      }
+      return { ok: false, status: 500, statusText: 'unexpected', text: async () => 'unexpected' };
+    });
+    try {
+      await expect(
+        compat.endCall({
+          callConfigId: 'cfg_1',
+          providerCallId: 'call_1',
+          voiceProvider: 'vapi',
+          providerDefaults: { apiKey: 'api_key', apiBaseUrl: 'https://vapi.test', controlUrlMaxWaitMs: 100, controlUrlPollMs: 100 }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+    } finally {
+      fetchNoControl.restore();
+    }
+
+    const fetchControlRejects = installFetch(async (url, init) => {
+      const method = String(init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET' && url === 'https://vapi.test/call/call_1') {
+        return { ok: true, status: 200, statusText: 'OK', json: async () => ({ id: 'call_1', monitor: { controlUrl: 'https://vapi.test/control' } }) };
+      }
+      if (method === 'POST' && url === 'https://vapi.test/control') {
+        return { ok: false, status: 500, statusText: 'Boom', text: async () => 'nope' };
+      }
+      return { ok: false, status: 500, statusText: 'unexpected', text: async () => 'unexpected' };
+    });
+    try {
+      await expect(
+        compat.endCall({
+          callConfigId: 'cfg_1',
+          providerCallId: 'call_1',
+          voiceProvider: 'vapi',
+          providerDefaults: { apiKey: 'api_key', apiBaseUrl: 'https://vapi.test' }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+    } finally {
+      fetchControlRejects.restore();
+    }
+  });
+
+  test('endCall: includes provider GET failures in controlUrl unavailable error', async () => {
+    const compat = new VapiVoiceCompat();
+
+    const fetchMock = installFetch(async (url, init) => {
+      const method = String(init?.method ?? 'GET').toUpperCase();
+      if (method === 'GET' && url === 'https://vapi.test/call/call_1') {
+        return { ok: false, status: 500, statusText: 'Boom', text: async () => 'nope' };
+      }
+      return { ok: false, status: 500, statusText: 'unexpected', text: async () => 'unexpected' };
+    });
+
+    try {
+      await expect(
+        compat.endCall({
+          callConfigId: 'cfg_1',
+          providerCallId: 'call_1',
+          voiceProvider: 'vapi',
+          providerDefaults: { apiKey: 'api_key', apiBaseUrl: 'https://vapi.test', controlUrlMaxWaitMs: 100, controlUrlPollMs: 100 }
+        } as any)
+      ).rejects.toBeInstanceOf(Error);
+    } finally {
+      fetchMock.restore();
+    }
+  });
+
+  test('handleMediaConnection: closes ws (swallows errors)', async () => {
+    const compat = new VapiVoiceCompat();
+
+    const ws1 = { close: jest.fn() };
+    await compat.handleMediaConnection({ ws: ws1 } as any);
+    expect(ws1.close).toHaveBeenCalledTimes(1);
+
+    const ws2 = { close: jest.fn(() => { throw new Error('boom'); }) };
+    await compat.handleMediaConnection({ ws: ws2 } as any);
+    expect(ws2.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/voice-providers/vapi.json
+++ b/plugins/voice-providers/vapi.json
@@ -1,0 +1,15 @@
+{
+  "id": "vapi",
+  "kind": "vapi",
+  "defaults": {
+    "apiKey": "${VAPI_API_KEY?}",
+    "apiBaseUrl": "https://api.vapi.ai",
+    "webhookAuth": {
+      "type": "bearer",
+      "token": "${VAPI_WEBHOOK_TOKEN?}"
+    },
+    "controlUrlPollMs": 500,
+    "controlUrlMaxWaitMs": 20000
+  }
+}
+

--- a/tests/live/test-files/30-realtime-manual-core.live.test.ts
+++ b/tests/live/test-files/30-realtime-manual-core.live.test.ts
@@ -39,10 +39,8 @@ if (filteredRealtimeTestRuns.length === 0) {
   for (const runCfg of filteredRealtimeTestRuns) {
     describeLive(`${TEST_FILE} — ${runCfg.name}`, () => {
       test('manual commit: history is visible and earlier turns persist', async () => {
-        const pick = () => WORD_TOKENS[Math.floor(Math.random() * WORD_TOKENS.length)]!;
-        const tokenHistory = pick();
-        let tokenTurn = pick();
-        while (tokenTurn === tokenHistory) tokenTurn = pick();
+        const tokenHistory = WORD_TOKENS[0]!;
+        const tokenTurn = WORD_TOKENS[1]!;
 
         const result = await runRealtimeScenario({
           pluginsPath,
@@ -104,19 +102,27 @@ if (filteredRealtimeTestRuns.length === 0) {
 
         expect(result.code).toBe(0);
         const events = result.envelopes.filter(e => e.type === 'event').map(e => (e as any).event);
+        const normalizeMessage = (raw: any) => String(raw ?? '').trim();
         const toolCall = findToolCallEnd(events, 'test.echo');
         expect(toolCall).toBeTruthy();
         expect(
-          events.some(e => e?.type === 'tool_call.end' && String(e?.arguments?.message ?? '') === `HISTORY=${tokenHistory}`)
+          events.some(e => e?.type === 'tool_call.end' && normalizeMessage(e?.arguments?.message) === `HISTORY=${tokenHistory}`)
         ).toBe(true);
         expect(
-          events.some(e => e?.type === 'tool_call.end' && String(e?.arguments?.message ?? '') === 'STORED')
+          events.some(e => e?.type === 'tool_call.end' && normalizeMessage(e?.arguments?.message) === 'STORED')
         ).toBe(true);
         expect(
           events.some(
-            e =>
-              e?.type === 'tool_call.end' &&
-              String(e?.arguments?.message ?? '') === `BOTH=${tokenHistory}|${tokenTurn}`
+            e => {
+              if (e?.type !== 'tool_call.end') return false;
+              const msg = normalizeMessage(e?.arguments?.message);
+              if (!msg.startsWith('BOTH=')) return false;
+              const payload = msg.slice('BOTH='.length);
+              const parts = payload.split('|');
+              if (parts.length !== 2) return false;
+              const [historyToken, secondToken] = parts.map(p => p.trim());
+              return historyToken === tokenHistory && secondToken === tokenTurn;
+            }
           )
         ).toBe(true);
       }, 180_000);

--- a/tests/unit/realtime-compat/vapi-realtime-session.test.ts
+++ b/tests/unit/realtime-compat/vapi-realtime-session.test.ts
@@ -312,6 +312,162 @@ describe('plugins/realtime-compat/vapi — ws session', () => {
     }
   });
 
+  test('createSession: supports additional assistant/model/voice settings via spec.settings', async () => {
+    const server = await startWsServer();
+    try {
+      const fetchMock = installVapiFetchMock({
+        websocketCallUrl: server.url,
+        onCreateCall: ({ body }) => {
+          expect(body.assistant.backgroundSound).toBe('office');
+          expect(body.assistant.model.maxTokens).toBe(321);
+          expect(body.assistant.model.emotionRecognitionEnabled).toBe(true);
+          expect(body.assistant.voice.speed).toBe(1.25);
+          expect(body.assistant.voice.chunkPlan.minCharacters).toBe(42);
+        }
+      });
+      restoreFetch = fetchMock.restore;
+
+      const compat = new VapiRealtimeCompat() as any;
+      const session = await compat.createSession({
+        provider: createProvider(),
+        spec: createSpec({
+          settings: {
+            speed: 1.25,
+            inputMinCharacters: 42,
+            maxOutputTokens: 321,
+            emotionRecognitionEnabled: true,
+            backgroundSound: 'office'
+          }
+        })
+      });
+
+      const it = session.events()[Symbol.asyncIterator]();
+      await waitForEvent(it, (e: any) => e?.type === 'ready');
+      await session.close();
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('createSession: forwards invalid/out-of-range settings to Vapi (no clamping)', async () => {
+    const server = await startWsServer();
+    try {
+      const restore = installFetch(async (url, init) => {
+        const method = String(init?.method ?? 'GET').toUpperCase();
+
+        if (method === 'POST' && url === 'https://vapi.test/call') {
+          const body = JSON.parse(init.body);
+          expect(body.assistant.voice.speed).toBe(999);
+          return {
+            ok: false,
+            status: 400,
+            statusText: 'Bad Request',
+            text: async () => 'invalid voice.speed'
+          };
+        }
+
+        throw new Error(`Unexpected fetch: ${method} ${url}`);
+      });
+      restoreFetch = restore;
+
+      const compat = new VapiRealtimeCompat() as any;
+      await expect(
+        compat.createSession({
+          provider: createProvider(),
+          spec: createSpec({ settings: { speed: 999 } })
+        })
+      ).rejects.toThrow('Vapi call create failed (400): invalid voice.speed');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('createSession: supports Vapi turn detection settings via spec.settings', async () => {
+    const server = await startWsServer();
+    try {
+      const fetchMock = installVapiFetchMock({
+        websocketCallUrl: server.url,
+        onCreateCall: ({ body }) => {
+          expect(body.assistant.startSpeakingPlan.waitSeconds).toBe(0.25);
+          expect(body.assistant.startSpeakingPlan.smartEndpointingEnabled).toBe(true);
+          expect(body.assistant.startSpeakingPlan.transcriptionEndpointingPlan.onPunctuationSeconds).toBe(0.11);
+          expect(body.assistant.startSpeakingPlan.transcriptionEndpointingPlan.onNoPunctuationSeconds).toBe(0.22);
+          expect(body.assistant.startSpeakingPlan.transcriptionEndpointingPlan.onNumberSeconds).toBe(0.33);
+
+          expect(body.assistant.stopSpeakingPlan.numWords).toBe(0);
+          expect(body.assistant.stopSpeakingPlan.voiceSeconds).toBe(0.2);
+          expect(body.assistant.stopSpeakingPlan.backoffSeconds).toBe(1);
+
+          expect(body.assistant.transcriber.eagerEotThreshold).toBe(0.3);
+          expect(body.assistant.transcriber.eotThreshold).toBe(0.7);
+          expect(body.assistant.transcriber.eotTimeoutMs).toBe(5000);
+        }
+      });
+      restoreFetch = fetchMock.restore;
+
+      const compat = new VapiRealtimeCompat() as any;
+      const session = await compat.createSession({
+        provider: createProvider(),
+        spec: createSpec({
+          settings: {
+            startSpeakingWaitSeconds: 0.25,
+            startSpeakingSmartEndpointingEnabled: true,
+            transcriptionEndpointingOnPunctuationSeconds: 0.11,
+            transcriptionEndpointingOnNoPunctuationSeconds: 0.22,
+            transcriptionEndpointingOnNumberSeconds: 0.33,
+            stopSpeakingNumWords: 0,
+            stopSpeakingVoiceSeconds: 0.2,
+            stopSpeakingBackoffSeconds: 1,
+            transcriberEagerEotThreshold: 0.3,
+            transcriberEotThreshold: 0.7,
+            transcriberEotTimeoutMs: 5000
+          }
+        })
+      });
+
+      const it = session.events()[Symbol.asyncIterator]();
+      await waitForEvent(it, (e: any) => e?.type === 'ready');
+      await session.close();
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('createSession: does not attach Deepgram EOT settings for non-deepgram transcribers', async () => {
+    const server = await startWsServer();
+    try {
+      const fetchMock = installVapiFetchMock({
+        websocketCallUrl: server.url,
+        onCreateCall: ({ body }) => {
+          expect(body.assistant.transcriber.provider).toBe('assemblyai');
+          expect(body.assistant.transcriber.eagerEotThreshold).toBeUndefined();
+          expect(body.assistant.transcriber.eotThreshold).toBeUndefined();
+          expect(body.assistant.transcriber.eotTimeoutMs).toBeUndefined();
+        }
+      });
+      restoreFetch = fetchMock.restore;
+
+      const compat = new VapiRealtimeCompat() as any;
+      const session = await compat.createSession({
+        provider: createProvider(),
+        spec: createSpec({
+          transcription: { enabled: true, provider: 'assemblyai' },
+          settings: {
+            transcriberEagerEotThreshold: 0.3,
+            transcriberEotThreshold: 0.7,
+            transcriberEotTimeoutMs: 5000
+          }
+        })
+      });
+
+      const it = session.events()[Symbol.asyncIterator]();
+      await waitForEvent(it, (e: any) => e?.type === 'ready');
+      await session.close();
+    } finally {
+      await server.close();
+    }
+  });
+
   test('createSession: validates modelProvider against provider metadata whitelist', async () => {
     const server = await startWsServer();
     try {
@@ -2814,7 +2970,7 @@ describe('plugins/realtime-compat/vapi — ws session', () => {
         onCreateCall: ({ init, body }) => {
           expect(init.headers['Content-Type']).toBe('application/json; charset=utf-8');
           expect(body.assistant.model.messages).toBeUndefined();
-          expect(body.assistant.model.temperature).toBe(2);
+          expect(body.assistant.model.temperature).toBe(999);
           expect(body.assistant.model.tools).toBeUndefined();
         }
       });


### PR DESCRIPTION
Implements Vapi voice provider support and tightens the Voice webhook path while keeping universal inputs + provider-side validation.

Changes
- Voice: `POST /voice/webhook` supports `application/json` and passes `body`/`bodyText` through to compat; webhook handlers can emit SSE events via `events.emit`.
- Voice: add `plugins/voice-providers/vapi.json` + `plugins/voice-compat/vapi` (outbound call creation via Vapi `POST /call`, webhook validation, event mapping, end-call via `monitor.controlUrl`).
- Realtime (Vapi): remove temperature clamping so Vapi rejects invalid values (no adapter-side gatekeeping).
- Live: stabilize realtime manual-commit history assertion (deterministic tokens + tolerant parsing).

Validation
- `npm run test:extensions:voice` (100% coverage)
- `npm test` (100% coverage)
- `npm run test:live:openrouter -- --transport=both`
- `npm run test:live:realtime -- --transport=both`
