### PR TITLE
Issue #1167: per-model provider extras via llmPriority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,8 +82,10 @@ plugins/processes/**
 !plugins/processes/
 !plugins/processes/test.echo.json
 !plugins/processes/test.random.json
+!plugins/processes/test.random.by-id.json
 !plugins/processes/test.control.json
 !plugins/processes/test.control.nonterminal.json
+!plugins/processes/test.control.explicit.json
 
 # tools
 plugins/tools/**

--- a/README-CLI.md
+++ b/README-CLI.md
@@ -543,7 +543,7 @@ The specification for LLM calls (`run` and `stream` commands).
     {
       "provider": "example-llm",
       "model": "example-model",
-      "settings": {}  // Optional per-provider settings override
+      "settings": {}  // Optional per-entry overrides (including provider extras)
     },
     {
       "provider": "example-llm-2",

--- a/README-SERVER.md
+++ b/README-SERVER.md
@@ -511,7 +511,7 @@ curl http://127.0.0.1:3000/embeddings/run \
     {
       "provider": "example-llm",
       "model": "example-model",
-      "settings": {}  // Optional per-provider override
+      "settings": {}  // Optional per-entry overrides (including provider extras)
     }
   ],
 

--- a/README.md
+++ b/README.md
@@ -411,6 +411,16 @@ interface LLMCallSpec {
 }
 ```
 
+### LLMPriorityItem
+
+```typescript
+interface LLMPriorityItem {
+  provider: string;
+  model: string;
+  settings?: Partial<LLMCallSettings>; // Optional per-entry overrides (including provider extras)
+}
+```
+
 ### UnifiedTool
 
 ```typescript

--- a/kernel/internal/types/internal/settings.ts
+++ b/kernel/internal/types/internal/settings.ts
@@ -67,6 +67,6 @@ export const PROVIDER_SETTING_KEYS = [
 export interface LLMPriorityItem {
   provider: string;
   model: string;
-  /** Optional per-provider settings that override global settings via deep merge */
+  /** Optional per-entry overrides (including provider extras) that override global settings via deep merge */
   settings?: Partial<LLMCallSettings>;
 }

--- a/modules/llm/internal/llm-coordinator/internal/run-nonstream.ts
+++ b/modules/llm/internal/llm-coordinator/internal/run-nonstream.ts
@@ -45,7 +45,7 @@ export async function runNonStream(options: {
     toolNameMap: Record<string, string>
   ) => Promise<LLMResponse>;
 }): Promise<LLMResponse> {
-  const { runtime, provider, providerExtras } = partitionSettings(options.spec.settings);
+  const { runtime, provider } = partitionSettings(options.spec.settings);
   await options.applyRuntimeEnvironment(runtime);
 
   const executionSpec: LLMCallSpec = {
@@ -110,6 +110,7 @@ export async function runNonStream(options: {
   const sequence = options.spec.llmPriority.map(item => {
     // Merge per-provider settings with global settings
     const mergedSettings = mergeProviderSettings(executionSpec.settings, item.settings);
+    const { providerExtras } = partitionSettings(mergedSettings);
 
     return {
       provider: item.provider,

--- a/plugins/processes/test.control.explicit.json
+++ b/plugins/processes/test.control.explicit.json
@@ -1,0 +1,13 @@
+{
+  "id": "test-control-explicit",
+  "match": {
+    "type": "exact",
+    "pattern": "test.control"
+  },
+  "invoke": {
+    "kind": "module",
+    "module": "../dist/plugins/modules/test-control/index.js",
+    "function": "handle"
+  },
+  "timeoutMs": 1000
+}

--- a/plugins/processes/test.random.by-id.json
+++ b/plugins/processes/test.random.by-id.json
@@ -1,0 +1,13 @@
+{
+  "id": "test-random-by-id",
+  "match": {
+    "type": "exact",
+    "pattern": "test.random"
+  },
+  "invoke": {
+    "kind": "module",
+    "module": "../dist/plugins/modules/test-random/index.js",
+    "function": "handle"
+  },
+  "timeoutMs": 5000
+}

--- a/plugins/tools/test.random.json
+++ b/plugins/tools/test.random.json
@@ -2,6 +2,7 @@
   "id": "test-tool-random",
   "name": "test.random",
   "description": "Generate a random number or unique identifier for testing purposes",
+  "processRouteId": "test-random-by-id",
   "parametersJsonSchema": {
     "type": "object",
     "properties": {

--- a/tests/integration/coordinator/coordinator.test.ts
+++ b/tests/integration/coordinator/coordinator.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { jest } from '@jest/globals';
 import { PluginRegistry } from '@/kernel/index.ts';
 import { LLMCoordinator } from '@/modules/llm/index.ts';
-import { Role, LLMResponse, LLMCallSettings } from '@/kernel/index.ts';
+import { Role, LLMResponse, LLMCallSettings, ProviderExecutionError } from '@/kernel/index.ts';
 import { LLMManager } from '@/modules/llm/index.ts';
 import { normalizeFlag } from '@/modules/shared/index.ts';
 import { ROOT_DIR, resolveFixture } from '@tests/helpers/paths.ts';
@@ -452,6 +452,130 @@ describe('coordinator/coordinator integration', () => {
       expect(secondCallSettings.temperature).toBe(0.2);
       expect(firstCallSettings.maxTokens).toBe(500);
       expect(secondCallSettings.maxTokens).toBe(500);
+
+      await coordinator.close();
+    });
+
+    test('per-priority provider extras apply per fallback attempt', async () => {
+      const coordinator = await createCoordinator();
+
+      const callProviderMock = jest
+        .spyOn(LLMManager.prototype, 'callProvider')
+        .mockImplementationOnce(async () => {
+          throw new ProviderExecutionError('test-openai', 'rate limit', 429, true);
+        })
+        .mockResolvedValueOnce({
+          provider: 'test-openai',
+          model: 'ok-model',
+          role: Role.ASSISTANT,
+          finishReason: 'stop',
+          content: [{ type: 'text', text: 'ok' }]
+        } as LLMResponse);
+
+      const spec = {
+        messages: [
+          { role: Role.USER, content: [{ type: 'text', text: 'test' }] }
+        ],
+        llmPriority: [
+          {
+            provider: 'test-openai',
+            model: 'blocked-model',
+            settings: { sharedExtra: 'first', extraTag: 'one' }
+          },
+          {
+            provider: 'test-openai',
+            model: 'ok-model',
+            settings: { sharedExtra: 'second', extraTag: 'two' }
+          }
+        ],
+        rateLimitRetryDelays: [],
+        settings: {
+          temperature: 0,
+          sharedExtra: 'global'
+        }
+      };
+
+      await coordinator.run(spec as any);
+
+      expect(callProviderMock).toHaveBeenCalledTimes(2);
+
+      const firstCallExtras = callProviderMock.mock.calls[0][6] as Record<string, any>;
+      const secondCallExtras = callProviderMock.mock.calls[1][6] as Record<string, any>;
+
+      expect(firstCallExtras).toEqual({ sharedExtra: 'first', extraTag: 'one' });
+      expect(secondCallExtras).toEqual({ sharedExtra: 'second', extraTag: 'two' });
+
+      await coordinator.close();
+    });
+
+    test('per-priority provider extras propagate into tool loop follow-up calls', async () => {
+      const coordinator = await createCoordinator();
+      const responses: LLMResponse[] = [
+        {
+          provider: 'test-openai',
+          model: 'stub-model',
+          role: Role.ASSISTANT,
+          content: [],
+          toolCalls: [
+            { id: 'call-1', name: 'echo.text', arguments: { text: 'hello' } }
+          ]
+        },
+        {
+          provider: 'test-openai',
+          model: 'stub-model',
+          role: Role.ASSISTANT,
+          finishReason: 'stop',
+          content: [{ type: 'text', text: 'done' }]
+        }
+      ];
+
+      const callProviderMock = jest
+        .spyOn(LLMManager.prototype, 'callProvider')
+        .mockImplementation(async () => {
+          if (!responses.length) {
+            throw new Error('unexpected call');
+          }
+          return responses.shift()!;
+        });
+
+      const spec = {
+        messages: [
+          { role: Role.USER, content: [{ type: 'text', text: 'use tool' }] }
+        ],
+        llmPriority: [
+          {
+            provider: 'test-openai',
+            model: 'stub-model',
+            settings: {
+              extraTag: 'toolcase',
+              globalExtraObject: { b: 2 }
+            }
+          }
+        ],
+        settings: {
+          temperature: 0,
+          globalExtraObject: { a: 1 },
+          maxToolIterations: 2,
+          toolFinalPromptEnabled: false
+        },
+        functionToolNames: ['echo.text']
+      };
+
+      await coordinator.run(spec as any);
+
+      expect(callProviderMock).toHaveBeenCalledTimes(2);
+
+      const firstCallExtras = callProviderMock.mock.calls[0][6] as Record<string, any>;
+      const secondCallExtras = callProviderMock.mock.calls[1][6] as Record<string, any>;
+
+      expect(firstCallExtras).toEqual({
+        extraTag: 'toolcase',
+        globalExtraObject: { a: 1, b: 2 }
+      });
+      expect(secondCallExtras).toEqual({
+        extraTag: 'toolcase',
+        globalExtraObject: { a: 1, b: 2 }
+      });
 
       await coordinator.close();
     });


### PR DESCRIPTION
Implements per-llmPriority provider extras for non-stream fallbacks and tool follow-ups.

- Fix: recompute provider extras per llmPriority entry after merging settings
- Tests: coordinator integration tests for fallback + tool loop propagation
- Docs: clarify llmPriority[].settings supports provider extras overrides

Closes #1167