### PR TITLE
Issue #1259 fix telemetry arg consistency and observability fallback defaults

### DIFF
--- a/modules/llm/internal/llm-manager/internal/observability.ts
+++ b/modules/llm/internal/llm-manager/internal/observability.ts
@@ -13,7 +13,8 @@ import {
   filterContentForObservability,
   filterMessagesForObservability,
   logObservabilityEvent,
-  monotonicElapsedMs
+  monotonicElapsedMs,
+  resolveObservabilityCaptureSettings
 } from '../../../../shared/index.js';
 
 /**
@@ -35,8 +36,7 @@ export function recordObservabilityRequest(
   if (!context.observability) return null;
 
   try {
-    const captureMessages = context.observability.captureMessages ?? 'full';
-    const captureRequestPayload = context.observability.captureRequestPayload ?? true;
+    const { captureMessages, captureRequestPayload } = resolveObservabilityCaptureSettings(context.observability);
 
     const event = {
       traceId: context.observability.traceId,
@@ -79,9 +79,7 @@ export function recordObservabilityResponse(
   if (!context.observability) return null;
 
   try {
-    const captureMessages = context.observability.captureMessages ?? 'full';
-    const captureToolArgs = context.observability.captureToolArgs ?? false;
-    const captureRawResponse = context.observability.captureRawResponse ?? true;
+    const { captureMessages, captureToolArgs, captureRawResponse } = resolveObservabilityCaptureSettings(context.observability);
 
     const endTimeMs = Date.now();
     const durationMs = monotonicElapsedMs(startTimeMonoNs);

--- a/modules/llm/internal/stream-coordinator-observability.ts
+++ b/modules/llm/internal/stream-coordinator-observability.ts
@@ -6,7 +6,11 @@ import type {
 } from '../../../kernel/index.js';
 
 import { deriveObservabilityModel, logObservabilityEvent, monotonicElapsedMs } from '../../shared/index.js';
-import { filterContentForObservability, filterMessagesForObservability } from '../../shared/index.js';
+import {
+  filterContentForObservability,
+  filterMessagesForObservability,
+  resolveObservabilityCaptureSettings
+} from '../../shared/index.js';
 import { redactJsonCredentials } from '../../security/index.js';
 
 export function recordStreamLlmRequestObservability(options: {
@@ -22,7 +26,7 @@ export function recordStreamLlmRequestObservability(options: {
   settings: any;
 }): void {
   try {
-    const captureMessages = options.observability.captureMessages ?? 'full';
+    const { captureMessages } = resolveObservabilityCaptureSettings(options.observability);
 
     const event = {
       traceId: options.observability.traceId,
@@ -74,8 +78,7 @@ export function recordStreamLlmResponseObservability(options: {
   usage?: UsageStats;
 }): void {
   try {
-    const captureMessages = options.observability.captureMessages ?? 'full';
-    const captureToolArgs = options.observability.captureToolArgs ?? false;
+    const { captureMessages, captureToolArgs } = resolveObservabilityCaptureSettings(options.observability);
     const observabilityModel = deriveObservabilityModel({
       provider: options.provider,
       model: options.model,

--- a/modules/realtime/internal/realtime-session/internal/observability-tracker.ts
+++ b/modules/realtime/internal/realtime-session/internal/observability-tracker.ts
@@ -13,7 +13,8 @@ import {
   filterMessagesForObservability,
   logObservabilityEvent,
   monotonicElapsedMs,
-  monotonicNowNs
+  monotonicNowNs,
+  resolveObservabilityCaptureSettings
 } from '../../../../shared/index.js';
 
 export class RealtimeObservabilityTracker {
@@ -69,7 +70,7 @@ export class RealtimeObservabilityTracker {
     const generationId = randomUUID();
     const timestampMs = Date.now();
     const startTimeMonoNs = monotonicNowNs();
-    const captureMessages = (obs.captureMessages ?? 'full') as any;
+    const { captureMessages } = resolveObservabilityCaptureSettings(obs);
 
     const requestEvent = {
       traceId,
@@ -113,8 +114,7 @@ export class RealtimeObservabilityTracker {
 
     const timestampMs = Date.now();
     const durationMs = monotonicElapsedMs(pending.startTimeMonoNs);
-    const captureMessages = (obs.captureMessages ?? 'full') as any;
-    const captureToolArgs = Boolean(obs.captureToolArgs);
+    const { captureMessages, captureToolArgs } = resolveObservabilityCaptureSettings(obs);
 
     const responseEvent: any = {
       traceId: pending.traceId,

--- a/modules/shared/index.ts
+++ b/modules/shared/index.ts
@@ -6,6 +6,8 @@ export { deriveObservabilityModel } from './internal/derive-observability-model.
 
 export type { ObservabilityCaptureMessagesMode } from './internal/observability-capture.js';
 export { filterMessagesForObservability, filterContentForObservability } from './internal/observability-capture.js';
+export type { ResolvedObservabilityCaptureSettings } from './internal/observability-compat.js';
+export { resolveObservabilityCaptureSettings } from './internal/observability-compat.js';
 
 export type { Deferred } from './internal/deferred.js';
 export { createDeferred } from './internal/deferred.js';

--- a/modules/shared/internal/observability-compat.ts
+++ b/modules/shared/internal/observability-compat.ts
@@ -1,0 +1,34 @@
+import type { ObservabilityContext } from '../../../kernel/index.js';
+import { normalizeFlag } from './normalize-flag.js';
+
+export type ResolvedObservabilityCaptureSettings = {
+  captureMessages: 'none' | 'text' | 'full';
+  captureToolArgs: boolean;
+  captureRequestPayload: boolean;
+  captureRawResponse: boolean;
+};
+
+const OBSERVABILITY_CAPTURE_DEFAULTS: ResolvedObservabilityCaptureSettings = {
+  captureMessages: 'none',
+  captureToolArgs: false,
+  captureRequestPayload: false,
+  captureRawResponse: false
+};
+
+function normalizeCaptureMessages(value: unknown): 'none' | 'text' | 'full' {
+  if (typeof value !== 'string') return OBSERVABILITY_CAPTURE_DEFAULTS.captureMessages;
+  const mode = value.trim().toLowerCase();
+  if (mode === 'none' || mode === 'text' || mode === 'full') return mode;
+  return OBSERVABILITY_CAPTURE_DEFAULTS.captureMessages;
+}
+
+export function resolveObservabilityCaptureSettings(
+  observability: Partial<ObservabilityContext> | undefined
+): ResolvedObservabilityCaptureSettings {
+  return {
+    captureMessages: normalizeCaptureMessages(observability?.captureMessages),
+    captureToolArgs: normalizeFlag(observability?.captureToolArgs, OBSERVABILITY_CAPTURE_DEFAULTS.captureToolArgs),
+    captureRequestPayload: normalizeFlag(observability?.captureRequestPayload, OBSERVABILITY_CAPTURE_DEFAULTS.captureRequestPayload),
+    captureRawResponse: normalizeFlag(observability?.captureRawResponse, OBSERVABILITY_CAPTURE_DEFAULTS.captureRawResponse)
+  };
+}

--- a/modules/tools/internal/tool-loop/internal/nonstream-execute.ts
+++ b/modules/tools/internal/tool-loop/internal/nonstream-execute.ts
@@ -176,9 +176,9 @@ export async function executeNonStreamToolCallsRound(options: {
 
     options.logger.info('Invoking tool', logPayload);
     const startTimeMonoNs = monotonicNowNs();
+    const invocationToolCall = stripCallArgTerminalFlag(toolCall, options.toolByName);
 
     try {
-      const invocationToolCall = stripCallArgTerminalFlag(toolCall, options.toolByName);
       const invocationResult = await options.invokeTool(
         targetToolName,
         invocationToolCall,
@@ -242,7 +242,7 @@ export async function executeNonStreamToolCallsRound(options: {
         toolName: targetToolName,
         timestampMs,
         durationMs: monotonicElapsedMs(startTimeMonoNs),
-        args: (toolCall as any)?.arguments ?? (toolCall as any)?.args,
+        args: (invocationToolCall as any)?.arguments ?? (invocationToolCall as any)?.args,
         result: {
           error: 'tool_execution_failed',
           message: error?.message ?? String(error),

--- a/modules/tools/internal/tool-loop/internal/observability.ts
+++ b/modules/tools/internal/tool-loop/internal/observability.ts
@@ -6,7 +6,12 @@ import type {
 } from '../../../../../kernel/index.js';
 
 import { redactJsonCredentials } from '../../../../security/index.js';
-import { safeJsonStringify, safeJsonValue, truncateUtf8Bytes } from '../../../../shared/index.js';
+import {
+  resolveObservabilityCaptureSettings,
+  safeJsonStringify,
+  safeJsonValue,
+  truncateUtf8Bytes
+} from '../../../../shared/index.js';
 
 function readTrimmedString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -60,8 +65,7 @@ export function recordToolExecutionObservability(options: {
   if (!obs) return;
 
   try {
-    const captureMessages = obs.captureMessages ?? 'full';
-    const captureToolArgs = obs.captureToolArgs ?? false;
+    const { captureMessages, captureToolArgs } = resolveObservabilityCaptureSettings(obs);
 
     const maxJsonBytes = typeof obs.maxJsonBytes === 'number' ? obs.maxJsonBytes : 8192;
     const maxOutputTextBytes = typeof obs.maxOutputTextBytes === 'number' ? obs.maxOutputTextBytes : 4096;

--- a/tests/unit/coordinator/stream-coordinator.observability.test.ts
+++ b/tests/unit/coordinator/stream-coordinator.observability.test.ts
@@ -188,7 +188,7 @@ describe('StreamCoordinator observability', () => {
     expect(responseArg.model).toBe('upstream-a/stub-model');
   });
 
-  test('falls back to compatibility defaults when capture fields are missing on the observability context', async () => {
+  test('falls back to restrictive shipped defaults when capture fields are missing on the observability context', async () => {
     const parseStreamChunk = () => ({
       toolEvents: [
         { type: ToolCallEventType.TOOL_CALL_START, callId: 'tool-1', name: 'echo.text' },
@@ -251,9 +251,10 @@ describe('StreamCoordinator observability', () => {
     }
 
     const requestArg = (observability.exporter.recordLLMRequest as any).mock.calls[0][0];
-    expect(requestArg.messages[0].content).toHaveLength(2);
+    expect(requestArg.messages).toEqual([]);
 
     const responseArg = (observability.exporter.recordLLMResponse as any).mock.calls[0][0];
+    expect(responseArg.content).toEqual([]);
     expect(responseArg.toolCalls).toEqual([{ id: 'tool-1', name: 'echo.text' }]);
   });
 

--- a/tests/unit/managers/llm-manager.observability.test.ts
+++ b/tests/unit/managers/llm-manager.observability.test.ts
@@ -88,6 +88,53 @@ describe('LLMManager observability', () => {
     expect(responseArg.toolCalls).toEqual([{ id: 'tc-1', name: 'test_tool' }]);
   });
 
+  test('callProvider falls back to restrictive shipped defaults when capture fields are missing', async () => {
+    const mockSDKResponse = {
+      content: [{ type: 'text', text: 'SDK response' }],
+      role: Role.ASSISTANT,
+      toolCalls: [{ id: 'tc-1', name: 'test_tool', arguments: { secret: 'abcd1234' } }],
+      raw: { token: 'abcd1234', ok: true }
+    };
+
+    const mockCompat = {
+      callSDK: jest.fn().mockResolvedValue(mockSDKResponse)
+    };
+
+    const registry = {
+      getCompatModule: jest.fn().mockReturnValue(mockCompat)
+    } as any;
+
+    const observability = createMockObservabilityContext({
+      captureMessages: undefined,
+      captureToolArgs: undefined,
+      captureRequestPayload: undefined,
+      captureRawResponse: undefined
+    });
+    const context: RunContext = { observability };
+
+    const manager = new LLMManager(registry);
+    await manager.callProvider(
+      mockProvider,
+      'test-model',
+      { temperature: 0.7 },
+      mockMessages,
+      [],
+      undefined,
+      { api_key: 'sk-abcdef1234' },
+      undefined,
+      context
+    );
+
+    const requestArg = (observability.exporter.recordLLMRequest as any).mock.calls[0][0];
+    expect(requestArg.messages).toEqual([]);
+    expect(requestArg.requestPayload).toBeUndefined();
+
+    const responseArg = (observability.exporter.recordLLMResponse as any).mock.calls[0][0];
+    expect(responseArg.content).toEqual([]);
+    expect(responseArg.rawResponse).toBeUndefined();
+    expect(responseArg.toolCalls).toEqual([{ id: 'tc-1', name: 'test_tool' }]);
+  });
+
   test('callProvider omits tool args when captureToolArgs is missing (falls back to shipped default)', async () => {
     const mockSDKResponse = {
       content: [{ type: 'text', text: 'SDK response' }],

--- a/tests/unit/modules/shared/shared.test.ts
+++ b/tests/unit/modules/shared/shared.test.ts
@@ -22,6 +22,7 @@ import {
   flattenPrimitiveStrings,
   isPlainObject,
   emitManifestOverrideWarning,
+  resolveObservabilityCaptureSettings,
   validateE164,
   type Deferred,
   type ValidateE164Result
@@ -93,6 +94,61 @@ describe('modules/shared', () => {
       expect(normalizeFlag({}, false)).toBe(true);
       expect(normalizeFlag([], false)).toBe(true);
       expect(normalizeFlag(() => {}, false)).toBe(true);
+    });
+  });
+
+  describe('resolveObservabilityCaptureSettings', () => {
+    test('returns restrictive shipped defaults when fields are missing', () => {
+      expect(resolveObservabilityCaptureSettings(undefined as any)).toEqual({
+        captureMessages: 'none',
+        captureToolArgs: false,
+        captureRequestPayload: false,
+        captureRawResponse: false
+      });
+      expect(resolveObservabilityCaptureSettings({} as any)).toEqual({
+        captureMessages: 'none',
+        captureToolArgs: false,
+        captureRequestPayload: false,
+        captureRawResponse: false
+      });
+    });
+
+    test('normalizes valid capture modes and flags', () => {
+      expect(
+        resolveObservabilityCaptureSettings({
+          captureMessages: ' text ',
+          captureToolArgs: '1' as any,
+          captureRequestPayload: 'yes' as any,
+          captureRawResponse: true as any
+        } as any)
+      ).toEqual({
+        captureMessages: 'text',
+        captureToolArgs: true,
+        captureRequestPayload: true,
+        captureRawResponse: true
+      });
+
+      expect(
+        resolveObservabilityCaptureSettings({
+          captureMessages: ' FULL '
+        } as any).captureMessages
+      ).toBe('full');
+    });
+
+    test('falls back to restrictive defaults for invalid capture values', () => {
+      expect(
+        resolveObservabilityCaptureSettings({
+          captureMessages: 'everything',
+          captureToolArgs: 'maybe' as any,
+          captureRequestPayload: '',
+          captureRawResponse: null
+        } as any)
+      ).toEqual({
+        captureMessages: 'none',
+        captureToolArgs: false,
+        captureRequestPayload: false,
+        captureRawResponse: false
+      });
     });
   });
 

--- a/tests/unit/realtime/realtime-observability-tracker.test.ts
+++ b/tests/unit/realtime/realtime-observability-tracker.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, test, jest } from '@jest/globals';
 
 import { Role } from '@/kernel/index.ts';
 import { RealtimeObservabilityTracker } from '@/modules/realtime/internal/realtime-session/internal/observability-tracker.ts';
@@ -17,5 +17,41 @@ describe('realtime/internal/realtime-session/observability-tracker', () => {
       { role: Role.SYSTEM, content: [{ type: 'text', text: 'sys' }] },
       { role: Role.USER, content: [{ type: 'text', text: 'hi' }] }
     ]);
+  });
+
+  test('falls back to restrictive shipped defaults when capture fields are missing', () => {
+    const observability = {
+      exporter: {
+        recordLLMRequest: jest.fn(),
+        recordLLMResponse: jest.fn(),
+        flush: jest.fn().mockResolvedValue(undefined)
+      },
+      baseTraceId: 'trace-123',
+      sessionId: 'session-456',
+      metadata: { correlationId: 'corr-789' }
+      // capture fields intentionally omitted.
+    } as any;
+
+    const tracker = new RealtimeObservabilityTracker({
+      spec: {
+        provider: 'test-provider',
+        model: 'test-model',
+        systemPrompt: 'sys'
+      } as any,
+      observability,
+      tools: [{ name: 'demo-tool', description: 'demo' }] as any
+    });
+
+    tracker.pushTextMessage({ role: Role.USER, text: 'hello' });
+    tracker.recordRequest();
+    tracker.recordToolCall({ id: 'call-1', name: 'demo-tool', arguments: { api_key: 'secret' } });
+    tracker.recordResponse({ content: [{ type: 'text', text: 'response' }] as any });
+
+    const requestArg = (observability.exporter.recordLLMRequest as any).mock.calls[0][0];
+    expect(requestArg.messages).toEqual([]);
+
+    const responseArg = (observability.exporter.recordLLMResponse as any).mock.calls[0][0];
+    expect(responseArg.content).toEqual([]);
+    expect(responseArg.toolCalls).toEqual([{ id: 'call-1', name: 'demo-tool' }]);
   });
 });

--- a/tests/unit/realtime/realtime-observability.test.ts
+++ b/tests/unit/realtime/realtime-observability.test.ts
@@ -491,6 +491,7 @@ describe('modules/realtime: observability (per-turn traces)', () => {
         exporter,
         baseTraceId: 'trace',
         sessionId: 'session-abc',
+        captureMessages: 'text',
         captureToolArgs: false,
         captureRequestPayload: false,
         captureRawResponse: false,

--- a/tests/unit/utils/tools/tool-loop.observability.test.ts
+++ b/tests/unit/utils/tools/tool-loop.observability.test.ts
@@ -152,8 +152,11 @@ describe('utils/tools/runToolLoop observability', () => {
     expect(event.args).toEqual({ answer: true });
   });
 
-  test('captureToolArgs missing falls back to false and omits args', () => {
-    const observability = createObservabilityContext({ captureToolArgs: undefined });
+  test('missing capture fields fall back to restrictive shipped defaults', () => {
+    const observability = createObservabilityContext({
+      captureMessages: undefined,
+      captureToolArgs: undefined
+    });
 
     recordToolExecutionObservability({
       observability,
@@ -171,6 +174,8 @@ describe('utils/tools/runToolLoop observability', () => {
 
     const event = (observability.exporter.recordToolExecution as any).mock.calls[0][0];
     expect(event.args).toBeUndefined();
+    expect(event.result).toBeUndefined();
+    expect(event.resultText).toBeUndefined();
   });
 
   test('captureMessages="full" preserves bounded structured tool result payloads under tight maxJsonBytes', () => {
@@ -217,7 +222,7 @@ describe('utils/tools/runToolLoop observability', () => {
       llmManager,
       registry: {} as any,
       messages: [{ role: Role.USER, content: [{ type: 'text', text: 'hello' }] }],
-      tools: [{ name: 'example_tool' }],
+      tools: [{ name: 'example_tool', toolCallTerminalFlag: { field: 'terminal' } }],
       toolChoice: 'auto',
       providerManifest,
       model: 'model',
@@ -237,15 +242,22 @@ describe('utils/tools/runToolLoop observability', () => {
         model: 'model',
         role: Role.ASSISTANT,
         content: [],
-        toolCalls: [{ id: 'call-1', name: 'example_tool', args: { answer: true } }]
+        toolCalls: [{ id: 'call-1', name: 'example_tool', arguments: { answer: true, terminal: true } }]
       } as any,
       invokeTool
     });
+
+    expect(invokeTool).toHaveBeenCalledWith(
+      'example_tool',
+      expect.objectContaining({ arguments: { answer: true }, args: { answer: true } }),
+      expect.any(Object)
+    );
 
     expect(observability.exporter.recordToolExecution).toHaveBeenCalledTimes(1);
     const event = (observability.exporter.recordToolExecution as any).mock.calls[0][0];
     expect(event.error).toEqual(expect.objectContaining({ message: 'boom', code: 'tool_execution_failed' }));
     expect(event.resultText).toContain('boom');
+    expect(event.args).toEqual({ answer: true });
 
     expect(observability.exporter.recordSignal).toHaveBeenCalledTimes(1);
     const signal = (observability.exporter.recordSignal as any).mock.calls[0][0];
@@ -313,6 +325,54 @@ describe('utils/tools/runToolLoop observability', () => {
     expect(observability.exporter.recordSignal).toHaveBeenCalledTimes(1);
     const signal = (observability.exporter.recordSignal as any).mock.calls[0][0];
     expect(signal).toEqual(expect.objectContaining({ level: 'warning', code: 'tool_call_budget_exhausted' }));
+  });
+
+  test('error-path tool telemetry falls back to toolCall.args when arguments is absent', async () => {
+    const llmManager: any = {
+      callProvider: jest.fn().mockResolvedValue({
+        provider: 'provider',
+        model: 'model',
+        role: Role.ASSISTANT,
+        content: []
+      }),
+      streamProvider: jest.fn()
+    };
+
+    const invokeTool = jest.fn().mockRejectedValue(new Error('boom'));
+    const observability = createObservabilityContext();
+
+    await runToolLoop({
+      mode: 'nonstream',
+      llmManager,
+      registry: {} as any,
+      messages: [{ role: Role.USER, content: [{ type: 'text', text: 'hello' }] }],
+      tools: [{ name: 'example_tool' }],
+      toolChoice: 'auto',
+      providerManifest,
+      model: 'model',
+      runtime: {
+        toolCountdownEnabled: 'false',
+        toolFinalPromptEnabled: 'false',
+        maxToolIterations: 1
+      } as any,
+      providerSettings: {},
+      providerExtras: {},
+      logger: { info: jest.fn(), warning: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+      runContext: { observability },
+      toolNameMap: { example_tool: 'example_tool' },
+      metadata: {},
+      initialResponse: {
+        provider: 'provider',
+        model: 'model',
+        role: Role.ASSISTANT,
+        content: [],
+        toolCalls: [{ id: 'call-1', name: 'example_tool', args: { answer: true } }]
+      } as any,
+      invokeTool
+    });
+
+    const event = (observability.exporter.recordToolExecution as any).mock.calls[0][0];
+    expect(event.args).toEqual({ answer: true });
   });
 
   test('nonstream loop re-reads runContext.generationId per round for tool telemetry', async () => {


### PR DESCRIPTION
## Summary
- fix nonstream tool error-path telemetry to use stripped invocation args
- add shared observability capture fallback normalization with restrictive defaults
- apply shared fallback resolution across llm/stream/realtime/tool observability recorders
- add and update unit coverage for stripped args + fallback behavior

## Validation
- npm test
- npm run test:extensions
- npm run test:live:openrouter -- --transport=both
- npm run test:live:realtime -- --transport=both
