### PR TITLE
Issue #1266 Merge Optimy parity: vectorContexts hard break, guardrails, streaming, observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,8 @@ interface LLMCallSpec {
   toolChoice?: ToolChoice;
 
   // Vector/RAG
-  vectorContext?: VectorContextConfig;
+  vectorContexts?: VectorContextConfig[];
+  vectorRequestPolicy?: Partial<VectorRequestPolicy>;
   vectorPriority?: string[];
 
   // Retry

--- a/kernel/internal/config.ts
+++ b/kernel/internal/config.ts
@@ -11,16 +11,35 @@ type EnvSubstitutionSpec =
   | { type: 'optional'; envVar: string }
   | { type: 'default'; envVar: string; defaultValue: string };
 
+function findPackageRoot(startDir: string): string {
+  let current = startDir;
+  while (current !== path.dirname(current)) {
+    const pkgPath = path.join(current, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      return current;
+    }
+    current = path.dirname(current);
+  }
+  return startDir;
+}
+
 function loadRootDotenv(): void {
   if (envLoaded) return;
-  
+
+  // Bound dotenv lookup to this package root to avoid loading a parent repo env file.
+  const packageRoot = findPackageRoot(moduleDir);
+
   let current = moduleDir;
-  while (current !== path.dirname(current)) {
+  while (true) {
     const dotenvPath = path.join(current, '.env');
     if (fs.existsSync(dotenvPath)) {
       dotenvConfig({ path: dotenvPath, override: false });
       envLoaded = true;
       return;
+    }
+
+    if (current === packageRoot) {
+      break;
     }
     current = path.dirname(current);
   }

--- a/kernel/internal/defaults.ts
+++ b/kernel/internal/defaults.ts
@@ -67,6 +67,12 @@ const FALLBACK_DEFAULTS: DefaultSettings = {
       includeSystemPrompt: 'if-in-range',
       includeAssistantMessages: true,
       messagesToInclude: 1
+    },
+    requestPolicy: {
+      maxAutoContexts: 3,
+      perContextTimeoutMs: 1500,
+      totalAutoBudgetMs: 4000,
+      maxInjectedPayloadBytes: 16384
     }
   },
   chunking: {

--- a/kernel/internal/types/internal/defaults.ts
+++ b/kernel/internal/types/internal/defaults.ts
@@ -1,4 +1,5 @@
 import type { ObservabilityTargetSpec } from '../../observability-spec-types.js';
+import type { VectorRequestPolicy } from './vector-context.js';
 
 /**
  * Retry and rate limiting default settings.
@@ -56,6 +57,7 @@ export interface VectorDefaults {
   includeVector: boolean;
   defaultCollection: string;
   queryConstruction: QueryConstructionSettings;
+  requestPolicy: VectorRequestPolicy;
 }
 
 /**

--- a/kernel/internal/types/internal/llm.ts
+++ b/kernel/internal/types/internal/llm.ts
@@ -4,7 +4,7 @@ import type { ContentPart, Message, ReasoningData, Role } from './chat.js';
 import type { JsonObject, JsonValue } from './json.js';
 import type { LLMCallSettings, LLMPriorityItem } from './settings.js';
 import type { ToolCall, ToolChoice, ToolRoutingSpec, UnifiedTool } from './tools.js';
-import type { VectorContextConfig } from './vector-context.js';
+import type { VectorContextConfig, VectorRequestPolicy } from './vector-context.js';
 
 export interface LLMCallSpec {
   systemPrompt?: string;
@@ -13,10 +13,12 @@ export interface LLMCallSpec {
   tools?: UnifiedTool[];
   mcpServers?: string[];
   vectorStores?: string[];
-  /** @deprecated Use vectorContext instead. Used for semantic tool retrieval. */
+  /** Used for semantic tool retrieval. */
   vectorPriority?: string[];
-  /** Vector context configuration for RAG capabilities */
-  vectorContext?: VectorContextConfig;
+  /** Vector context configurations for RAG capabilities. */
+  vectorContexts?: VectorContextConfig[];
+  /** Optional request-level vector guardrail overrides. */
+  vectorRequestPolicy?: Partial<VectorRequestPolicy>;
   llmPriority: LLMPriorityItem[];
   toolChoice?: ToolChoice;
   /** Optional adapter-side tool routing overrides for this call. */

--- a/kernel/internal/types/internal/vector-context.ts
+++ b/kernel/internal/types/internal/vector-context.ts
@@ -194,3 +194,28 @@ export interface VectorContextConfig {
    */
   queryConstruction?: Partial<QueryConstructionSettings>;
 }
+
+/**
+ * Request-scoped performance guardrails for auto vector context injection.
+ */
+export interface VectorRequestPolicy {
+  /**
+   * Max number of auto/both contexts to execute per request.
+   */
+  maxAutoContexts: number;
+
+  /**
+   * Timeout budget for each individual auto context retrieval.
+   */
+  perContextTimeoutMs: number;
+
+  /**
+   * Total timeout budget shared across all auto contexts in a request.
+   */
+  totalAutoBudgetMs: number;
+
+  /**
+   * Max UTF-8 bytes injected into prompt context for each auto context.
+   */
+  maxInjectedPayloadBytes: number;
+}

--- a/modules/llm/internal/llm-coordinator/index.ts
+++ b/modules/llm/internal/llm-coordinator/index.ts
@@ -27,6 +27,13 @@ import type { VectorStoreManager, VectorContextInjector } from '../../../vector/
 import { prepareMessagesWithDocuments } from './internal/prepare-messages.js';
 import { runNonStream } from './internal/run-nonstream.js';
 import { runStream } from './internal/run-stream.js';
+import { createToolCoordinatorProxy, type PendingVectorContexts } from './internal/tool-coordinator-proxy.js';
+import {
+  hasToolVectorContexts,
+  resolveAutoVectorContexts,
+  resolveVectorContexts,
+  resolveVectorRequestPolicy
+} from './internal/vector-contexts.js';
 
 export class LLMCoordinator {
   private llmManager: LLMManager;
@@ -39,10 +46,7 @@ export class LLMCoordinator {
   private logger: AdapterLogger;
   private toolCoordinatorInitialized = false;
   private activeToolSpec?: LLMCallSpec;
-  private pendingVectorContext?: {
-    config: VectorContextConfig | undefined;
-    aliasMap?: Record<string, string>;
-  };
+  private pendingVectorContexts?: PendingVectorContexts;
 
   constructor(
     private registry: PluginRegistry,
@@ -58,35 +62,23 @@ export class LLMCoordinator {
 
     // Stable proxy so tests can spy on methods without being broken by lazy initialization.
     // The real implementation is stored in `toolCoordinatorImpl` and populated on-demand.
-    this.toolCoordinator = {
-      __isToolCoordinatorProxy: true,
-      setVectorContext: (config: VectorContextConfig | undefined, _registry?: PluginRegistry, aliasMap?: Record<string, string>) => {
-        this.pendingVectorContext = { config, aliasMap };
-        this.toolCoordinatorImpl?.setVectorContext?.(config, this.registry, aliasMap);
+    this.toolCoordinator = createToolCoordinatorProxy({
+      getRegistry: () => this.registry,
+      getToolCoordinatorImpl: () => this.toolCoordinatorImpl,
+      setPendingVectorContexts: (pending) => {
+        this.pendingVectorContexts = pending;
       },
-      routeAndInvoke: async (toolName: string, callId: string, args: any, context: any) => {
-        if (!this.toolCoordinatorImpl) {
-          if (!this.activeToolSpec) {
-            throw new Error('ToolCoordinator not initialized (no active spec)');
-          }
-          await this.ensureToolCoordinator(this.activeToolSpec);
-        }
-        return this.toolCoordinatorImpl.routeAndInvoke(toolName, callId, args, context);
-      },
-      close: async () => {
-        await this.toolCoordinatorImpl?.close?.();
-      }
-    };
+      getActiveToolSpec: () => this.activeToolSpec,
+      ensureToolCoordinator: (spec) => this.ensureToolCoordinator(spec)
+    });
   }
 
   private async ensureToolCoordinator(spec: LLMCallSpec): Promise<any> {
     this.activeToolSpec = spec;
 
     if (this.toolCoordinatorInitialized) {
-      // Update vector context for new spec (may have different locks)
-      const config = this.pendingVectorContext?.config ?? spec.vectorContext;
-      const aliasMap = this.pendingVectorContext?.aliasMap;
-      this.toolCoordinatorImpl?.setVectorContext?.(config, this.registry, aliasMap);
+      const configs = this.resolveVectorContexts(spec);
+      this.toolCoordinatorImpl?.setVectorContexts?.(configs.length > 0 ? configs : undefined, this.registry);
       return this.toolCoordinator;
     }
 
@@ -101,13 +93,18 @@ export class LLMCoordinator {
 
     const processRoutes = await this.registry.getProcessRoutes();
     const { ToolCoordinator } = await import('../../../tools/index.js');
+
+    const initialConfigs = this.pendingVectorContexts?.configs ?? this.resolveVectorContexts(spec);
+    const initialAliasMaps = this.pendingVectorContexts?.aliasMaps;
+    this.pendingVectorContexts = undefined;
+
     this.toolCoordinatorImpl = new ToolCoordinator(
       processRoutes,
       this.mcpManager?.getPool(),
       {
-        vectorContext: this.pendingVectorContext?.config ?? spec.vectorContext,
+        vectorContexts: initialConfigs.length > 0 ? initialConfigs : undefined,
         registry: this.registry,
-        vectorSearchAliasMap: this.pendingVectorContext?.aliasMap
+        vectorSearchAliasMaps: initialAliasMaps
       }
     );
 
@@ -311,7 +308,9 @@ export class LLMCoordinator {
     return prepareMessagesWithDocuments(spec);
   }
 
-  private async collectTools(spec: LLMCallSpec): Promise<[UnifiedTool[], string[], Record<string, string>, Record<string, string> | undefined]> {
+  private async collectTools(
+    spec: LLMCallSpec
+  ): Promise<[UnifiedTool[], string[], Record<string, string>, Record<string, Record<string, string>> | undefined]> {
     const { collectTools } = await import('../../../tools/index.js');
     const result = await collectTools({
       spec,
@@ -319,7 +318,7 @@ export class LLMCoordinator {
       mcpManager: this.mcpManager,
       vectorManager: this.vectorManager
     });
-    return [result.tools, result.mcpServers, result.toolNameMap, result.vectorSearchAliasMap];
+    return [result.tools, result.mcpServers, result.toolNameMap, result.vectorSearchAliasMaps];
   }
 
   private ensureValidAssistantResponse(response: LLMResponse, providerId: string | undefined): void {
@@ -342,8 +341,9 @@ export class LLMCoordinator {
    * Returns true for 'auto' or 'both' modes.
    */
   private shouldInjectVectorContext(spec: LLMCallSpec): boolean {
-    const mode = spec.vectorContext?.mode;
-    return mode === 'auto' || mode === 'both';
+    const contexts = this.resolveVectorContexts(spec);
+    const policy = resolveVectorRequestPolicy(spec);
+    return resolveAutoVectorContexts(contexts, policy).length > 0;
   }
 
   /**
@@ -351,8 +351,8 @@ export class LLMCoordinator {
    * Returns true for 'tool' or 'both' modes.
    */
   private shouldCreateVectorTool(spec: LLMCallSpec): boolean {
-    const mode = spec.vectorContext?.mode;
-    return mode === 'tool' || mode === 'both';
+    const contexts = this.resolveVectorContexts(spec);
+    return hasToolVectorContexts(contexts);
   }
 
   /**
@@ -388,5 +388,9 @@ export class LLMCoordinator {
       });
     }
     return this.vectorContextInjector;
+  }
+
+  private resolveVectorContexts(spec: LLMCallSpec): VectorContextConfig[] {
+    return resolveVectorContexts(spec);
   }
 }

--- a/modules/llm/internal/llm-coordinator/internal/run-nonstream.ts
+++ b/modules/llm/internal/llm-coordinator/internal/run-nonstream.ts
@@ -16,6 +16,12 @@ import { getDefaults } from '../../../../../kernel/index.js';
 import type { LLMManager } from '../../llm-manager.js';
 import { partitionSettings, mergeProviderSettings } from '../../../../settings/index.js';
 import { withRetries } from '../../../../retry/index.js';
+import {
+  resolveAutoVectorContexts,
+  resolveVectorContexts,
+  resolveVectorRequestPolicy,
+  withTimeout
+} from './vector-contexts.js';
 
 export async function runNonStream(options: {
   spec: LLMCallSpec;
@@ -30,7 +36,7 @@ export async function runNonStream(options: {
   shouldCreateVectorTool: (spec: LLMCallSpec) => boolean;
   ensureVectorContextInjector: () => Promise<{ injectContext: (...args: any[]) => Promise<{ messages: Message[] }> }>;
   ensureToolCoordinator: (spec: LLMCallSpec) => Promise<any>;
-  collectTools: (spec: LLMCallSpec) => Promise<[UnifiedTool[], string[], Record<string, string>, Record<string, string> | undefined]>;
+  collectTools: (spec: LLMCallSpec) => Promise<[UnifiedTool[], string[], Record<string, string>, Record<string, Record<string, string>> | undefined]>;
   attachUsageCostIfNeeded: (response: LLMResponse, settings: LLMCallSettings, provider: string, model: string) => Promise<void>;
   ensureValidAssistantResponse: (response: LLMResponse, providerId: string | undefined) => void;
   handleTools: (
@@ -55,17 +61,51 @@ export async function runNonStream(options: {
     settings: provider
   };
 
+  const vectorContexts = resolveVectorContexts(options.spec);
+  const vectorPolicy = resolveVectorRequestPolicy(options.spec);
   let messages = options.prepareMessages(executionSpec);
 
   // Inject vector context if configured for auto or both mode
   if (options.shouldInjectVectorContext(options.spec)) {
+    const logger = options.getLogger().withCorrelation(options.spec.metadata?.correlationId as string);
     const injector = await options.ensureVectorContextInjector();
-    const injectionResult = await injector.injectContext(
-      messages,
-      options.spec.vectorContext!,
-      options.spec.systemPrompt
-    );
-    messages = injectionResult.messages;
+    const autoContexts = resolveAutoVectorContexts(vectorContexts, vectorPolicy);
+    const embeddingCache = new Map<string, number[]>();
+    const startedAt = Date.now();
+
+    for (const contextConfig of autoContexts) {
+      const elapsed = Date.now() - startedAt;
+      const remainingBudget = vectorPolicy.totalAutoBudgetMs - elapsed;
+      if (remainingBudget <= 0) {
+        logger.warning?.('Vector auto-injection budget exhausted; skipping remaining contexts', {
+          totalAutoBudgetMs: vectorPolicy.totalAutoBudgetMs
+        });
+        break;
+      }
+
+      const timeoutMs = Math.min(vectorPolicy.perContextTimeoutMs, remainingBudget);
+
+      try {
+        const injectionResult = await withTimeout(
+          injector.injectContext(messages, contextConfig, options.spec.systemPrompt, {
+            maxInjectedPayloadBytes: vectorPolicy.maxInjectedPayloadBytes,
+            embeddingCache
+          }),
+          timeoutMs,
+          'vector context injection'
+        );
+        messages = injectionResult.messages;
+      } catch (error: any) {
+        if (String(error?.code ?? '') === 'config_error') {
+          throw error;
+        }
+        logger.warning?.('Vector context injection skipped due to error', {
+          error: error?.message ?? String(error),
+          mode: contextConfig.mode,
+          stores: contextConfig.stores
+        });
+      }
+    }
   }
 
   // Tools are optional; avoid importing tool code unless actually needed.
@@ -79,15 +119,20 @@ export async function runNonStream(options: {
   let tools: UnifiedTool[] = [];
   let mcpServers: string[] = [];
   let toolNameMap: Record<string, string> = {};
-  let vectorSearchAliasMap: Record<string, string> | undefined;
+  let vectorSearchAliasMaps: Record<string, Record<string, string>> | undefined;
 
   if (needsTools) {
     await options.ensureToolCoordinator(executionSpec);
-    [tools, mcpServers, toolNameMap, vectorSearchAliasMap] = await options.collectTools(executionSpec);
+    [tools, mcpServers, toolNameMap, vectorSearchAliasMaps] = await options.collectTools(executionSpec);
 
     // Update vector context with alias map after collectTools generates it
-    if (vectorSearchAliasMap) {
-      options.toolCoordinator.setVectorContext(executionSpec.vectorContext, options.registry, vectorSearchAliasMap);
+    if (vectorSearchAliasMaps) {
+      const toolVectorContexts = vectorContexts.filter(ctx => ctx.mode === 'tool' || ctx.mode === 'both');
+      options.toolCoordinator.setVectorContexts(
+        toolVectorContexts.length > 0 ? toolVectorContexts : undefined,
+        options.registry,
+        vectorSearchAliasMaps
+      );
     }
 
     // Sanitize toolChoice to match sanitized tool names

--- a/modules/llm/internal/llm-coordinator/internal/run-stream.ts
+++ b/modules/llm/internal/llm-coordinator/internal/run-stream.ts
@@ -8,8 +8,17 @@ import type {
   AdapterLogger,
   ObservabilityContext
 } from '../../../../../kernel/index.js';
+import { StreamEventType } from '../../../../../kernel/index.js';
 import type { LLMManager } from '../../llm-manager.js';
 import { partitionSettings, mergeProviderSettings } from '../../../../settings/index.js';
+import {
+  resolveAutoVectorContexts,
+  resolveVectorContexts,
+  resolveVectorRequestPolicy,
+  withTimeout
+} from './vector-contexts.js';
+
+const MAX_BUFFERED_PRE_DELTA_EVENTS = 256;
 
 export async function* runStream(options: {
   spec: LLMCallSpec;
@@ -24,15 +33,12 @@ export async function* runStream(options: {
   shouldCreateVectorTool: (spec: LLMCallSpec) => boolean;
   ensureVectorContextInjector: () => Promise<{ injectContext: (...args: any[]) => Promise<{ messages: Message[] }> }>;
   ensureToolCoordinator: (spec: LLMCallSpec) => Promise<any>;
-  collectTools: (spec: LLMCallSpec) => Promise<[UnifiedTool[], string[], Record<string, string>, Record<string, string> | undefined]>;
+  collectTools: (spec: LLMCallSpec) => Promise<[UnifiedTool[], string[], Record<string, string>, Record<string, Record<string, string>> | undefined]>;
 }): AsyncGenerator<LLMStreamEvent> {
   if (!options.spec.llmPriority.length) {
     throw new Error('LLMCallSpec.llmPriority must include at least one provider');
   }
 
-  // Streaming delegates to StreamCoordinator, which re-partitions settings (runtime vs provider) and
-  // needs access to the *runtime* settings for tool loop behavior (truncation, countdown, budgets, etc).
-  // Keep the original settings on the spec and only extract runtime here for environment overrides.
   const { runtime } = partitionSettings(options.spec.settings);
   await options.applyRuntimeEnvironment(runtime);
 
@@ -41,30 +47,51 @@ export async function* runStream(options: {
     settings: options.spec.settings
   };
 
-  const providerPref = executionSpec.llmPriority[0];
+  const vectorContexts = resolveVectorContexts(options.spec);
+  const vectorPolicy = resolveVectorRequestPolicy(options.spec);
+  let messages = options.prepareMessages(executionSpec);
 
-  // Merge per-provider settings for streaming (only first provider is used)
-  const mergedSettings = mergeProviderSettings(executionSpec.settings, providerPref.settings);
-  const streamExecutionSpec: LLMCallSpec = {
-    ...executionSpec,
-    settings: mergedSettings
-  };
-
-  const providerManifest = await options.registry.getProvider(providerPref.provider);
-  let messages = options.prepareMessages(streamExecutionSpec);
-
-  // Inject vector context if configured for auto or both mode
   if (options.shouldInjectVectorContext(options.spec)) {
+    const logger = options.getLogger().withCorrelation(options.spec.metadata?.correlationId as string);
     const injector = await options.ensureVectorContextInjector();
-    const injectionResult = await injector.injectContext(
-      messages,
-      options.spec.vectorContext!,
-      options.spec.systemPrompt
-    );
-    messages = injectionResult.messages;
+    const autoContexts = resolveAutoVectorContexts(vectorContexts, vectorPolicy);
+    const embeddingCache = new Map<string, number[]>();
+    const startedAt = Date.now();
+
+    for (const contextConfig of autoContexts) {
+      const elapsed = Date.now() - startedAt;
+      const remainingBudget = vectorPolicy.totalAutoBudgetMs - elapsed;
+      if (remainingBudget <= 0) {
+        logger.warning?.('Vector auto-injection budget exhausted; skipping remaining contexts', {
+          totalAutoBudgetMs: vectorPolicy.totalAutoBudgetMs
+        });
+        break;
+      }
+
+      const timeoutMs = Math.min(vectorPolicy.perContextTimeoutMs, remainingBudget);
+      try {
+        const injectionResult = await withTimeout(
+          injector.injectContext(messages, contextConfig, options.spec.systemPrompt, {
+            maxInjectedPayloadBytes: vectorPolicy.maxInjectedPayloadBytes,
+            embeddingCache
+          }),
+          timeoutMs,
+          'vector context injection'
+        );
+        messages = injectionResult.messages;
+      } catch (error: any) {
+        if (String(error?.code ?? '') === 'config_error') {
+          throw error;
+        }
+        logger.warning?.('Vector context injection skipped due to error', {
+          error: error?.message ?? String(error),
+          mode: contextConfig.mode,
+          stores: contextConfig.stores
+        });
+      }
+    }
   }
 
-  // Tools are optional; avoid importing tool code unless actually needed.
   const needsTools = (options.spec.tools && options.spec.tools.length > 0) ||
                     (options.spec.functionToolNames && options.spec.functionToolNames.length > 0) ||
                     (options.spec.mcpServers && options.spec.mcpServers.length > 0) ||
@@ -75,56 +102,128 @@ export async function* runStream(options: {
   let tools: UnifiedTool[] = [];
   let mcpServers: string[] = [];
   let toolNameMap: Record<string, string> = {};
-  let vectorSearchAliasMap: Record<string, string> | undefined;
+  let vectorSearchAliasMaps: Record<string, Record<string, string>> | undefined;
 
   if (needsTools) {
     await options.ensureToolCoordinator(executionSpec);
-    [tools, mcpServers, toolNameMap, vectorSearchAliasMap] = await options.collectTools(executionSpec);
+    [tools, mcpServers, toolNameMap, vectorSearchAliasMaps] = await options.collectTools(executionSpec);
 
-    // Update vector context with alias map after collectTools generates it
-    if (vectorSearchAliasMap) {
-      options.toolCoordinator.setVectorContext(executionSpec.vectorContext, options.registry, vectorSearchAliasMap);
+    if (vectorSearchAliasMaps) {
+      const toolVectorContexts = vectorContexts.filter(ctx => ctx.mode === 'tool' || ctx.mode === 'both');
+      options.toolCoordinator.setVectorContexts(
+        toolVectorContexts.length > 0 ? toolVectorContexts : undefined,
+        options.registry,
+        vectorSearchAliasMaps
+      );
     }
 
-    // Sanitize toolChoice to match sanitized tool names
     const { sanitizeToolChoice } = await import('../../../../tools/index.js');
-    streamExecutionSpec.toolChoice = sanitizeToolChoice(streamExecutionSpec.toolChoice);
+    executionSpec.toolChoice = sanitizeToolChoice(executionSpec.toolChoice);
   }
 
   const runLogger = options.getLogger().withCorrelation(options.spec.metadata?.correlationId as string);
-  runLogger.info('Streaming call started', {
-    provider: providerManifest.id,
-    model: providerPref.model,
-    tools: tools.map(t => t.name),
-    mcpServers
-  });
-
-  // Create observability context if enabled (lazy-loads observability module)
   const observability = await options.createObservabilityContext(options.spec, runtime);
 
-  // Delegate streaming to StreamCoordinator
   const streamCoordinator = new (await import('../../stream-coordinator.js')).StreamCoordinator(
     options.registry,
     options.llmManager,
     options.toolCoordinator
   );
 
-  const context = {
-    provider: providerManifest.id,
-    model: providerPref.model,
-    tools,
-    mcpServers,
-    toolNameMap: new Map<string, string>(Object.entries(toolNameMap)),
-    logger: runLogger,
-    metadata: options.spec.metadata,
-    observability
-  };
+  let emittedUserDelta = false;
+  let bufferOverflowLogged = false;
+  let buffered: LLMStreamEvent[] = [];
+  let lastError: any;
 
-  yield* streamCoordinator.coordinateStream(
-    streamExecutionSpec,
-    messages,
-    tools,
-    context,
-    { requireFinishToExecute: true }
-  );
+  for (let i = 0; i < executionSpec.llmPriority.length; i += 1) {
+    const pref = executionSpec.llmPriority[i];
+    const mergedSettings = mergeProviderSettings(executionSpec.settings, pref.settings);
+    const attemptSpec: LLMCallSpec = {
+      ...executionSpec,
+      llmPriority: [{ provider: pref.provider, model: pref.model, settings: pref.settings }],
+      settings: mergedSettings
+    };
+
+    const providerManifest = await options.registry.getProvider(pref.provider);
+    runLogger.info('Streaming call started', {
+      attempt: i + 1,
+      provider: providerManifest.id,
+      model: pref.model,
+      tools: tools.map(t => t.name),
+      mcpServers,
+      hasPerProviderSettings: !!pref.settings
+    });
+
+    const context = {
+      provider: providerManifest.id,
+      model: pref.model,
+      tools,
+      mcpServers,
+      toolNameMap: new Map<string, string>(Object.entries(toolNameMap)),
+      logger: runLogger,
+      metadata: options.spec.metadata,
+      observability
+    };
+
+    try {
+      const iterator = streamCoordinator.coordinateStream(
+        attemptSpec,
+        messages,
+        tools,
+        context,
+        { requireFinishToExecute: true }
+      );
+
+      for await (const event of iterator) {
+        const isDelta = (event as any)?.type === StreamEventType.DELTA || (event as any)?.type === 'delta';
+        if (!emittedUserDelta && isDelta) {
+          emittedUserDelta = true;
+          for (const bufferedEvent of buffered) {
+            yield bufferedEvent;
+          }
+          buffered = [];
+          yield event;
+          continue;
+        }
+
+        if (!emittedUserDelta) {
+          buffered.push(event);
+          if (buffered.length > MAX_BUFFERED_PRE_DELTA_EVENTS) {
+            buffered.shift();
+            if (!bufferOverflowLogged) {
+              runLogger.warning?.('Pre-delta stream buffer reached cap; dropping oldest events', {
+                cap: MAX_BUFFERED_PRE_DELTA_EVENTS
+              });
+              bufferOverflowLogged = true;
+            }
+          }
+          continue;
+        }
+
+        yield event;
+      }
+
+      if (!emittedUserDelta && buffered.length > 0) {
+        for (const bufferedEvent of buffered) {
+          yield bufferedEvent;
+        }
+      }
+      return;
+    } catch (error: any) {
+      lastError = error;
+      if (emittedUserDelta) {
+        throw error;
+      }
+
+      buffered = [];
+      runLogger.warning?.('Streaming attempt failed before first delta; failing over', {
+        attempt: i + 1,
+        provider: providerManifest.id,
+        model: pref.model,
+        error: error?.message ?? String(error)
+      });
+    }
+  }
+
+  throw lastError ?? new Error('Streaming failed: all llmPriority attempts exhausted');
 }

--- a/modules/llm/internal/llm-coordinator/internal/tool-coordinator-proxy.ts
+++ b/modules/llm/internal/llm-coordinator/internal/tool-coordinator-proxy.ts
@@ -1,0 +1,45 @@
+import type { LLMCallSpec, PluginRegistry, VectorContextConfig } from '../../../../../kernel/index.js';
+
+export interface PendingVectorContexts {
+  configs: VectorContextConfig[] | undefined;
+  aliasMaps?: Record<string, Record<string, string>>;
+}
+
+export function createToolCoordinatorProxy(options: {
+  getRegistry: () => PluginRegistry;
+  getToolCoordinatorImpl: () => any;
+  setPendingVectorContexts: (pending: PendingVectorContexts | undefined) => void;
+  getActiveToolSpec: () => LLMCallSpec | undefined;
+  ensureToolCoordinator: (spec: LLMCallSpec) => Promise<any>;
+}): any {
+  return {
+    __isToolCoordinatorProxy: true,
+    setVectorContexts: (
+      configs: VectorContextConfig[] | undefined,
+      _registry?: PluginRegistry,
+      aliasMaps?: Record<string, Record<string, string>>
+    ) => {
+      const impl = options.getToolCoordinatorImpl();
+      if (!impl) {
+        options.setPendingVectorContexts({ configs, aliasMaps });
+        return;
+      }
+      impl.setVectorContexts?.(configs, options.getRegistry(), aliasMaps);
+    },
+    routeAndInvoke: async (toolName: string, callId: string, args: any, context: any) => {
+      let impl = options.getToolCoordinatorImpl();
+      if (!impl) {
+        const activeSpec = options.getActiveToolSpec();
+        if (!activeSpec) {
+          throw new Error('ToolCoordinator not initialized (no active spec)');
+        }
+        await options.ensureToolCoordinator(activeSpec);
+        impl = options.getToolCoordinatorImpl();
+      }
+      return impl.routeAndInvoke(toolName, callId, args, context);
+    },
+    close: async () => {
+      await options.getToolCoordinatorImpl()?.close?.();
+    }
+  };
+}

--- a/modules/llm/internal/llm-coordinator/internal/vector-contexts.ts
+++ b/modules/llm/internal/llm-coordinator/internal/vector-contexts.ts
@@ -1,0 +1,80 @@
+import type { LLMCallSpec, VectorContextConfig, VectorRequestPolicy } from '../../../../../kernel/index.js';
+import { getDefaults } from '../../../../../kernel/index.js';
+import { parseNonNegativeInt } from '../../../../shared/index.js';
+
+function normalizePositiveInt(value: unknown, fallback: number, min: number, max: number): number {
+  const parsed = parseNonNegativeInt(value, fallback);
+  return Math.min(max, Math.max(min, Math.floor(parsed)));
+}
+
+export function resolveVectorContexts(spec: LLMCallSpec): VectorContextConfig[] {
+  if (!Array.isArray(spec.vectorContexts) || spec.vectorContexts.length < 1) {
+    return [];
+  }
+
+  const out: VectorContextConfig[] = [];
+  for (const ctx of spec.vectorContexts) {
+    if (!ctx || typeof ctx !== 'object') continue;
+    if (!Array.isArray(ctx.stores) || ctx.stores.length < 1) continue;
+    out.push(ctx);
+  }
+  return out;
+}
+
+export function resolveVectorRequestPolicy(spec: LLMCallSpec): VectorRequestPolicy {
+  const defaults = getDefaults().vector.requestPolicy;
+  const override = (spec.vectorRequestPolicy && typeof spec.vectorRequestPolicy === 'object')
+    ? spec.vectorRequestPolicy
+    : {};
+
+  const maxAutoContexts = normalizePositiveInt(override.maxAutoContexts, defaults.maxAutoContexts, 0, 20);
+  const perContextTimeoutMs = normalizePositiveInt(override.perContextTimeoutMs, defaults.perContextTimeoutMs, 50, 120000);
+  const totalAutoBudgetMs = normalizePositiveInt(
+    override.totalAutoBudgetMs,
+    defaults.totalAutoBudgetMs,
+    50,
+    300000
+  );
+  const maxInjectedPayloadBytes = normalizePositiveInt(
+    override.maxInjectedPayloadBytes,
+    defaults.maxInjectedPayloadBytes,
+    64,
+    1_000_000
+  );
+
+  return {
+    maxAutoContexts,
+    perContextTimeoutMs,
+    totalAutoBudgetMs,
+    maxInjectedPayloadBytes
+  };
+}
+
+export function resolveAutoVectorContexts(
+  contexts: VectorContextConfig[],
+  policy: VectorRequestPolicy
+): VectorContextConfig[] {
+  const autoEnabled = contexts.filter(ctx => ctx.mode === 'auto' || ctx.mode === 'both');
+  if (policy.maxAutoContexts <= 0) return [];
+  return autoEnabled.slice(0, policy.maxAutoContexts);
+}
+
+export function hasToolVectorContexts(contexts: VectorContextConfig[]): boolean {
+  return contexts.some(ctx => ctx.mode === 'tool' || ctx.mode === 'both');
+}
+
+export async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return promise;
+
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+      })
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}

--- a/modules/llm/internal/llm-manager/internal/observability.ts
+++ b/modules/llm/internal/llm-manager/internal/observability.ts
@@ -47,7 +47,7 @@ export function recordObservabilityRequest(
       messages: filterMessagesForObservability(messages, captureMessages),
       sessionId: context.observability.sessionId,
       metadata: context.observability.metadata,
-      tools: tools.map(t => ({ name: t.name, description: t.description })),
+      tools: redactJsonCredentials(tools) as any,
       settings,
       ...(captureRequestPayload ? { requestPayload: redactJsonCredentials(requestPayload) } : {})
     };
@@ -80,7 +80,7 @@ export function recordObservabilityResponse(
 
   try {
     const captureMessages = context.observability.captureMessages ?? 'full';
-    const captureToolArgs = context.observability.captureToolArgs ?? false;
+    const captureToolArgs = context.observability.captureToolArgs ?? true;
     const captureRawResponse = context.observability.captureRawResponse ?? true;
 
     const endTimeMs = Date.now();

--- a/modules/llm/internal/stream-coordinator-observability.ts
+++ b/modules/llm/internal/stream-coordinator-observability.ts
@@ -33,7 +33,7 @@ export function recordStreamLlmRequestObservability(options: {
       messages: filterMessagesForObservability(options.messages, captureMessages),
       sessionId: options.observability.sessionId,
       metadata: options.observability.metadata,
-      tools: options.tools.map((t: any) => ({ name: t.name, description: t.description })),
+      tools: redactJsonCredentials(options.tools) as any,
       settings: options.settings as any
     };
 
@@ -75,7 +75,7 @@ export function recordStreamLlmResponseObservability(options: {
 }): void {
   try {
     const captureMessages = options.observability.captureMessages ?? 'full';
-    const captureToolArgs = options.observability.captureToolArgs ?? false;
+    const captureToolArgs = options.observability.captureToolArgs ?? true;
     const observabilityModel = deriveObservabilityModel({
       provider: options.provider,
       model: options.model,

--- a/modules/observability/internal/compat-helpers.ts
+++ b/modules/observability/internal/compat-helpers.ts
@@ -55,7 +55,7 @@ export function getStringArrayMetadata(metadata: unknown, key: string): string[]
 export function resolveTraceContext(options: {
   event: { sessionId?: unknown; metadata?: unknown };
   cachedSummary?: { sessionId?: unknown; correlationId?: unknown; batchId?: unknown; tags?: unknown };
-}): { sessionId?: string; traceName?: string; batchId?: string; tags?: string[] } {
+}): { sessionId?: string; traceName?: string; correlationId?: string; batchId?: string; tags?: string[] } {
   const { event, cachedSummary } = options;
   const metadata = event.metadata;
 
@@ -65,7 +65,7 @@ export function resolveTraceContext(options: {
       ? String(event.sessionId)
       : undefined;
 
-  const traceName =
+  const correlationId =
     (cachedSummary?.correlationId ? String(cachedSummary.correlationId) : undefined) ??
     readTrimmedStringProperty(metadata, 'correlationId');
 
@@ -73,9 +73,11 @@ export function resolveTraceContext(options: {
     (cachedSummary?.batchId ? String(cachedSummary.batchId) : undefined) ??
     (readTrimmedStringProperty(metadata, 'batchId') ?? sessionId);
 
+  const traceName = batchId ?? correlationId;
+
   const tags = (cachedSummary?.tags as any) ?? getStringArrayMetadata(metadata, 'tags');
 
-  return { sessionId, traceName, batchId, tags };
+  return { sessionId, traceName, correlationId, batchId, tags };
 }
 
 export function getEventIds(context?: ObservabilityCompatContext): string[] {
@@ -147,6 +149,13 @@ export function buildCachedRequestSummary(
   context?: ObservabilityCompatContext
 ): CachedRequestSummary {
   const maxBytes = resolveMaxAttributeBytes(context);
+  const jsonOptions = {
+    maxBytes,
+    maxDepth: 25,
+    maxArrayLength: 1000,
+    maxObjectKeys: 2000,
+    maxStringBytes: maxBytes
+  } as const;
   const metadata = request.metadata;
   const sessionId = request.sessionId ? String(request.sessionId) : undefined;
   const correlationId = readTrimmedStringProperty(metadata, 'correlationId');
@@ -162,8 +171,8 @@ export function buildCachedRequestSummary(
     batchId,
     tags,
     inputText: flattenPrimitiveStrings(request.messages, { maxBytes }),
-    observationInput: safeJsonStringify(buildInputJson(request), { maxBytes }),
-    modelParameters: safeJsonStringify(request.settings ?? {}, { maxBytes })
+    observationInput: safeJsonStringify(buildInputJson(request), jsonOptions),
+    modelParameters: safeJsonStringify(request.settings ?? {}, jsonOptions)
   };
 }
 
@@ -189,4 +198,3 @@ export function applyTraceUpdateToCachedRequests(
     if (nextSessionId && !summary.sessionId) summary.sessionId = nextSessionId;
   }
 }
-

--- a/modules/shared/internal/serialization.ts
+++ b/modules/shared/internal/serialization.ts
@@ -60,6 +60,11 @@ export interface SafeJsonStringifyOptions {
   maxDepth?: number;
   maxArrayLength?: number;
   maxObjectKeys?: number;
+  /**
+   * Maximum UTF-8 bytes for any single string encountered while serializing.
+   * Defaults to `min(maxBytes, 4096)` when maxBytes is set, otherwise 4096.
+   */
+  maxStringBytes?: number;
 }
 
 function boundJsonValue(
@@ -127,9 +132,13 @@ export function safeJsonStringify(value: unknown, options: SafeJsonStringifyOpti
   const maxArrayLength = clampInt(options.maxArrayLength, 50, 0, 1000);
   const maxObjectKeys = clampInt(options.maxObjectKeys, 50, 0, 2000);
 
-  const maxStringBytes = maxBytes !== null
-    ? Math.min(maxBytes, 4096)
-    : 4096;
+  const defaultMaxStringBytes = maxBytes !== null ? Math.min(maxBytes, 4096) : 4096;
+  const maxStringBytes = clampInt(
+    options.maxStringBytes,
+    defaultMaxStringBytes,
+    0,
+    maxBytes !== null ? maxBytes : 1_000_000
+  );
 
   const bounded = boundJsonValue(
     value,

--- a/modules/tools/internal/tool-coordinator/index.ts
+++ b/modules/tools/internal/tool-coordinator/index.ts
@@ -2,7 +2,6 @@ import { spawn } from 'child_process';
 import path from 'path';
 import { pathToFileURL } from 'url';
 import axios from 'axios';
-import { Minimatch } from 'minimatch';
 import { ProcessRouteManifest, VectorContextConfig, ToolExecutionError, getDefaults } from '../../../../kernel/index.js';
 import type { PluginRegistry } from '../../../../kernel/index.js';
 import type { MCPClientPool } from '../../../mcp/index.js';
@@ -10,19 +9,26 @@ import { invokeCommand as invokeCommandImpl } from './internal/invoke-command.js
 import { resolveInvokeModulePath } from './internal/resolve-invoke-module-path.js';
 import { createTimeout as createTimeoutImpl } from './internal/timeout.js';
 import type { ToolContext, ToolRouteAndInvokeContext } from './internal/types.js';
+import { compileMatcher } from './internal/matcher.js';
+import {
+  computeVectorSearchState,
+  getVectorSearchEntryForToolName,
+  translateVectorSearchArgs as translateVectorSearchArgsImpl,
+  type VectorSearchEntry
+} from './internal/vector-search.js';
+import { closeVectorRuntime, ensureVectorRuntime, type VectorRuntimeState } from './internal/vector-runtime.js';
 
 export interface ToolCoordinatorOptions {
-  vectorContext?: VectorContextConfig;
+  vectorContexts?: VectorContextConfig[];
   registry?: PluginRegistry;
-  vectorSearchAliasMap?: Record<string, string>;
+  vectorSearchAliasMaps?: Record<string, Record<string, string>>;
 }
 
 export class ToolCoordinator {
   private mcpServerIds: string[] = [];
-  private vectorContext?: VectorContextConfig;
   private registry?: PluginRegistry;
-  private vectorToolName: string = 'vector_search';
-  private vectorSearchAliasMap?: Record<string, string>;
+  private vectorContextsByToolName = new Map<string, VectorSearchEntry>();
+  private vectorRuntime: VectorRuntimeState = {};
   private warnedInvokeModuleCwdFallback = new Set<string>();
   private routesById = new Map<string, ProcessRouteManifest>();
   private compiledRoutes: Array<{ route: ProcessRouteManifest; match: (toolName: string) => boolean }> = [];
@@ -37,17 +43,16 @@ export class ToolCoordinator {
       this.mcpServerIds = mcpPool.getServerIds();
     }
 
-    if (options?.vectorContext) {
-      this.vectorContext = options.vectorContext;
-      this.vectorToolName = options.vectorContext.toolName ?? 'vector_search';
-    }
     this.registry = options?.registry;
-    this.vectorSearchAliasMap = options?.vectorSearchAliasMap;
+    if (options?.vectorContexts && options.vectorContexts.length > 0) {
+      this.setVectorContexts(options.vectorContexts, this.registry, options.vectorSearchAliasMaps);
+    }
+
     this.routesById = new Map(routes.map(route => [route.id, route]));
-    this.compiledRoutes = routes.map((route) => ({ route, match: this.compileMatcher(route.match) }));
+    this.compiledRoutes = routes.map((route) => ({ route, match: compileMatcher(route.match) }));
     this.compiledToolIdRoutes = routes
       .filter(route => !!route.matchToolId)
-      .map(route => ({ route, match: this.compileMatcher(route.matchToolId!) }));
+      .map(route => ({ route, match: compileMatcher(route.matchToolId!) }));
   }
 
   protected createTimeout(
@@ -60,52 +65,20 @@ export class ToolCoordinator {
     return createTimeoutImpl(seconds, options);
   }
 
-  private compileMatcher(match: { type: string; pattern: any }): (value: string) => boolean {
-    const matchType = match.type;
-    const pattern = match.pattern;
-    switch (matchType) {
-      case 'exact':
-        return (value: string) => value === pattern;
-      case 'prefix':
-        return (value: string) => value.startsWith(pattern);
-      case 'regex': {
-        try {
-          const regex = new RegExp(pattern);
-          return (value: string) => regex.test(value);
-        } catch (error: any) {
-          return () => {
-            throw error;
-          };
-        }
-      }
-      case 'glob': {
-        try {
-          const matcher = new Minimatch(pattern);
-          return (value: string) => matcher.match(value);
-        } catch (error: any) {
-          return () => {
-            throw error;
-          };
-        }
-      }
-      default:
-        return () => false;
-    }
-  }
-
-  setVectorContext(
-    config: VectorContextConfig | undefined,
+  setVectorContexts(
+    configs: VectorContextConfig[] | undefined,
     registry?: PluginRegistry,
-    aliasMap?: Record<string, string>
+    aliasMaps?: Record<string, Record<string, string>>
   ): void {
-    this.vectorContext = config;
-    if (config) {
-      this.vectorToolName = config.toolName ?? 'vector_search';
-    }
     if (registry) {
       this.registry = registry;
     }
-    this.vectorSearchAliasMap = aliasMap;
+
+    this.vectorContextsByToolName = computeVectorSearchState(configs, aliasMaps);
+  }
+
+  private isVectorSearchTool(toolName: string): boolean {
+    return !!this.getVectorSearchEntry(toolName);
   }
 
   async routeAndInvoke(
@@ -114,13 +87,16 @@ export class ToolCoordinator {
     args: any,
     context: ToolRouteAndInvokeContext
   ): Promise<any> {
-    if (this.isVectorSearchTool(toolName)) {
-      return this.invokeVectorSearch(toolName, callId, args, context);
+    const vectorEntry = this.getVectorSearchEntry(toolName);
+    if (vectorEntry) {
+      return this.invokeVectorSearch(toolName, callId, args, context, vectorEntry);
     }
+
     const route = this.selectRoute(toolName, { processRouteId: context.processRouteId, toolId: context.toolId });
     if (!route) {
       throw new ToolExecutionError(`No matching process route for tool '${toolName}'`);
     }
+
     const ctx: ToolContext = {
       toolName,
       callId,
@@ -150,7 +126,6 @@ export class ToolCoordinator {
 
     const timeoutMs = route.timeoutMs ?? getDefaults().tools.timeoutMs;
     const timeoutSeconds = timeoutMs / 1000;
-
     const timeoutCancel = new AbortController();
     const invokeAbort = new AbortController();
 
@@ -171,47 +146,40 @@ export class ToolCoordinator {
     }
   }
 
-  private isVectorSearchTool(toolName: string): boolean {
-    if (!this.vectorContext) return false;
-    const mode = this.vectorContext.mode;
-    if (mode !== 'tool' && mode !== 'both') return false;
-    return toolName === this.vectorToolName;
+  private getVectorSearchEntry(toolName: string): VectorSearchEntry | undefined {
+    return getVectorSearchEntryForToolName({
+      toolName,
+      byToolName: this.vectorContextsByToolName
+    });
   }
 
-  private translateVectorSearchArgs(args: Record<string, any>): Record<string, any> {
-    if (!this.vectorSearchAliasMap) {
-      return args;
-    }
-
-    const translated: Record<string, any> = {};
-    for (const [key, value] of Object.entries(args)) {
-      const canonicalName = this.vectorSearchAliasMap[key] ?? key;
-      translated[canonicalName] = value;
-    }
-    return translated;
+  private translateVectorSearchArgs(args: Record<string, any>, aliasMap?: Record<string, string>): Record<string, any> {
+    return translateVectorSearchArgsImpl(args, aliasMap);
   }
 
   private async invokeVectorSearch(
     toolName: string,
     callId: string,
     args: any,
-    context: ToolRouteAndInvokeContext
+    context: ToolRouteAndInvokeContext,
+    entry: VectorSearchEntry
   ): Promise<any> {
-    if (!this.vectorContext || !this.registry) {
+    if (!this.registry) {
       throw new ToolExecutionError('Vector search not configured');
     }
 
-    const translatedArgs = this.translateVectorSearchArgs(args);
+    const translatedArgs = this.translateVectorSearchArgs(args, entry.aliasMap);
 
     context.logger?.info('Invoking built-in vector_search handler', {
       toolName,
       callId,
-      hasLocks: !!this.vectorContext.locks,
-      lockedParams: Object.keys(this.vectorContext.locks ?? {}),
-      hasAliasMap: !!this.vectorSearchAliasMap
+      hasLocks: !!entry.config.locks,
+      lockedParams: Object.keys(entry.config.locks ?? {}),
+      hasAliasMap: !!entry.aliasMap
     });
 
     const { executeVectorSearch, formatVectorSearchResults } = await import('../../../vector/index.js');
+    const runtime = await ensureVectorRuntime(this.vectorRuntime, this.registry);
 
     const result = await executeVectorSearch(
       {
@@ -223,13 +191,15 @@ export class ToolCoordinator {
         scoreThreshold: translatedArgs.scoreThreshold
       },
       {
-        vectorConfig: this.vectorContext,
+        vectorConfig: entry.config,
         registry: this.registry,
-        logger: context.logger
+        logger: context.logger,
+        embeddingManager: runtime.embeddingManager,
+        vectorManager: runtime.vectorManager
       }
     );
 
-    const formattedResult = formatVectorSearchResults(result, this.vectorContext);
+    const formattedResult = formatVectorSearchResults(result, entry.config);
     return { result: formattedResult };
   }
 
@@ -242,6 +212,7 @@ export class ToolCoordinator {
       }
       return routed;
     }
+
     const toolId = options?.toolId;
     if (toolId) {
       const routedById = this.routesById.get(toolId);
@@ -254,6 +225,7 @@ export class ToolCoordinator {
         }
       }
     }
+
     for (const compiled of this.compiledRoutes) {
       if (compiled.match(toolName)) {
         return compiled.route;
@@ -287,17 +259,13 @@ export class ToolCoordinator {
       case 'command':
         return this.invokeCommand(route, ctx, options);
       case 'mcp':
-        return this.invokeMcp(route, ctx, options);
+        return this.invokeMcp(route, ctx);
       default:
         throw new ToolExecutionError(`Unsupported invoke kind '${route.invoke.kind}'`);
     }
   }
 
-  private async invokeModule(
-    route: ProcessRouteManifest,
-    ctx: ToolContext,
-    options: { signal?: AbortSignal }
-  ): Promise<any> {
+  private async invokeModule(route: ProcessRouteManifest, ctx: ToolContext, options: { signal?: AbortSignal }): Promise<any> {
     if (!route.invoke.module) {
       throw new ToolExecutionError('Module route missing module field');
     }
@@ -315,11 +283,7 @@ export class ToolCoordinator {
     return { result: invocation };
   }
 
-  private async invokeHttp(
-    route: ProcessRouteManifest,
-    ctx: ToolContext,
-    options: { signal?: AbortSignal }
-  ): Promise<any> {
+  private async invokeHttp(route: ProcessRouteManifest, ctx: ToolContext, options: { signal?: AbortSignal }): Promise<any> {
     if (!route.invoke.url) {
       throw new ToolExecutionError('HTTP route missing url');
     }
@@ -335,11 +299,7 @@ export class ToolCoordinator {
     return response.data || { result: null };
   }
 
-  private async invokeCommand(
-    route: ProcessRouteManifest,
-    ctx: ToolContext,
-    options: { signal?: AbortSignal }
-  ): Promise<any> {
+  private async invokeCommand(route: ProcessRouteManifest, ctx: ToolContext, options: { signal?: AbortSignal }): Promise<any> {
     if (!route.invoke.command) {
       throw new ToolExecutionError('Command route missing command');
     }
@@ -352,11 +312,7 @@ export class ToolCoordinator {
     });
   }
 
-  private async invokeMcp(
-    route: ProcessRouteManifest,
-    ctx: ToolContext,
-    _options: { signal?: AbortSignal }
-  ): Promise<any> {
+  private async invokeMcp(route: ProcessRouteManifest, ctx: ToolContext): Promise<any> {
     if (!this.mcpPool) {
       throw new ToolExecutionError('MCP route requested but no pool configured');
     }
@@ -373,11 +329,9 @@ export class ToolCoordinator {
     if (modulePath.startsWith('file:') || modulePath.startsWith('node:')) {
       return import(modulePath);
     }
-
     if (path.isAbsolute(modulePath)) {
       return import(pathToFileURL(modulePath).href);
     }
-
     return import(modulePath);
   }
 
@@ -395,6 +349,6 @@ export class ToolCoordinator {
   }
 
   async close(): Promise<void> {
-    // Cleanup if needed
+    await closeVectorRuntime(this.vectorRuntime);
   }
 }

--- a/modules/tools/internal/tool-coordinator/internal/matcher.ts
+++ b/modules/tools/internal/tool-coordinator/internal/matcher.ts
@@ -1,0 +1,34 @@
+import { Minimatch } from 'minimatch';
+
+export function compileMatcher(match: { type: string; pattern: any }): (value: string) => boolean {
+  const matchType = match.type;
+  const pattern = match.pattern;
+  switch (matchType) {
+    case 'exact':
+      return (value: string) => value === pattern;
+    case 'prefix':
+      return (value: string) => value.startsWith(pattern);
+    case 'regex': {
+      try {
+        const regex = new RegExp(pattern);
+        return (value: string) => regex.test(value);
+      } catch (error: any) {
+        return () => {
+          throw error;
+        };
+      }
+    }
+    case 'glob': {
+      try {
+        const matcher = new Minimatch(pattern);
+        return (value: string) => matcher.match(value);
+      } catch (error: any) {
+        return () => {
+          throw error;
+        };
+      }
+    }
+    default:
+      return () => false;
+  }
+}

--- a/modules/tools/internal/tool-coordinator/internal/vector-runtime.ts
+++ b/modules/tools/internal/tool-coordinator/internal/vector-runtime.ts
@@ -1,0 +1,35 @@
+import type { PluginRegistry } from '../../../../../kernel/index.js';
+
+export interface VectorRuntimeState {
+  embeddingManager?: any;
+  vectorManager?: any;
+}
+
+export async function ensureVectorRuntime(state: VectorRuntimeState, registry: PluginRegistry): Promise<VectorRuntimeState> {
+  if (!state.embeddingManager) {
+    const { EmbeddingManager } = await import('../../../../embeddings/index.js');
+    if (typeof EmbeddingManager === 'function') {
+      state.embeddingManager = new EmbeddingManager(registry as any);
+    }
+  }
+
+  if (!state.vectorManager) {
+    const { VectorStoreManager } = await import('../../../../vector/index.js');
+    if (typeof VectorStoreManager === 'function') {
+      state.vectorManager = new VectorStoreManager(
+        new Map(),
+        new Map(),
+        undefined,
+        registry
+      );
+    }
+  }
+
+  return state;
+}
+
+export async function closeVectorRuntime(state: VectorRuntimeState): Promise<void> {
+  if (state.vectorManager?.closeAll) {
+    await state.vectorManager.closeAll().catch(() => {});
+  }
+}

--- a/modules/tools/internal/tool-coordinator/internal/vector-search.ts
+++ b/modules/tools/internal/tool-coordinator/internal/vector-search.ts
@@ -1,0 +1,59 @@
+import type { VectorContextConfig } from '../../../../../kernel/index.js';
+
+export interface VectorSearchEntry {
+  config: VectorContextConfig;
+  aliasMap?: Record<string, string>;
+}
+
+export function computeVectorSearchState(
+  configs: VectorContextConfig[] | undefined,
+  aliasMaps?: Record<string, Record<string, string>>
+): Map<string, VectorSearchEntry> {
+  const byToolName = new Map<string, VectorSearchEntry>();
+
+  if (!configs || configs.length < 1) {
+    return byToolName;
+  }
+
+  for (const cfg of configs) {
+    if (!cfg || typeof cfg !== 'object') {
+      continue;
+    }
+    const toolName = cfg.toolName ?? 'vector_search';
+    byToolName.set(toolName, { config: cfg, aliasMap: aliasMaps?.[toolName] });
+  }
+
+  return byToolName;
+}
+
+export function getVectorSearchEntryForToolName(options: {
+  toolName: string;
+  byToolName: Map<string, VectorSearchEntry>;
+}): VectorSearchEntry | undefined {
+  const toolName = options.toolName;
+
+  const entry = options.byToolName.get(toolName);
+  if (!entry) {
+    return undefined;
+  }
+
+  const mode = entry.config.mode;
+  if (mode !== 'tool' && mode !== 'both') {
+    return undefined;
+  }
+
+  return entry;
+}
+
+export function translateVectorSearchArgs(args: Record<string, any>, aliasMap?: Record<string, string>): Record<string, any> {
+  if (!aliasMap) {
+    return args;
+  }
+
+  const translated: Record<string, any> = {};
+  for (const [key, value] of Object.entries(args)) {
+    const canonicalName = aliasMap[key] ?? key;
+    translated[canonicalName] = value;
+  }
+  return translated;
+}

--- a/modules/tools/internal/tool-discovery.ts
+++ b/modules/tools/internal/tool-discovery.ts
@@ -14,8 +14,7 @@ export interface ToolDiscoveryResult {
   tools: UnifiedTool[];
   mcpServers: string[];
   toolNameMap: Record<string, string>;
-  /** Maps exposed vector search param names -> canonical names for arg translation */
-  vectorSearchAliasMap?: Record<string, string>;
+  vectorSearchAliasMaps?: Record<string, Record<string, string>>;
 }
 const DISALLOWED_TERMINAL_FLAG_FIELDS = new Set(['__proto__', 'prototype', 'constructor']);
 
@@ -156,12 +155,22 @@ export async function collectTools({
     }
   }
 
-  // Create vector_search tool if vectorContext mode is 'tool' or 'both'
-  let vectorSearchAliasMap: Record<string, string> | undefined;
-  if (spec.vectorContext && shouldCreateVectorSearchTool(spec.vectorContext.mode)) {
-    const result = createVectorSearchTool(spec.vectorContext);
+  // Create vector tools when vectorContexts mode is 'tool' or 'both'
+  let vectorSearchAliasMaps: Record<string, Record<string, string>> | undefined;
+  for (const ctx of spec.vectorContexts ?? []) {
+    if (!ctx || typeof ctx !== 'object') continue;
+    if (!shouldCreateVectorSearchTool(ctx.mode)) continue;
+
+    const result = createVectorSearchTool(ctx);
+    if (toolMap.has(result.tool.name)) {
+      throw new Error(
+        `Vector search tool name '${result.tool.name}' conflicts with an existing tool. ` +
+        'Use unique vectorContexts[].toolName values.'
+      );
+    }
     toolMap.set(result.tool.name, result.tool);
-    vectorSearchAliasMap = result.aliasMap;
+    vectorSearchAliasMaps = vectorSearchAliasMaps ?? {};
+    vectorSearchAliasMaps[result.tool.name] = result.aliasMap;
   }
 
   const sanitize = sanitizeName ?? sanitizeToolName;
@@ -188,7 +197,7 @@ export async function collectTools({
     tools: sanitizedTools,
     mcpServers,
     toolNameMap,
-    vectorSearchAliasMap
+    vectorSearchAliasMaps
   };
 }
 
@@ -231,35 +240,21 @@ function isUnifiedTool(value: unknown): value is UnifiedTool {
   );
 }
 
-/**
- * Check if a vector_search tool should be created based on vectorContext mode.
- */
 export function shouldCreateVectorSearchTool(mode: string | undefined): boolean {
   return mode === 'tool' || mode === 'both';
 }
 
-/**
- * Result from creating a vector search tool, including the alias map for arg translation.
- */
 export interface VectorSearchToolResult {
-  /** The generated tool definition */
   tool: UnifiedTool;
-  /** Maps exposed parameter name -> canonical name for arg translation */
   aliasMap: Record<string, string>;
 }
 
-/**
- * Default parameter configurations for vector search tool.
- */
 interface ParamConfig {
   canonical: string;
   type: string;
   defaultDescription: (config: VectorContextConfig) => string;
-  /** Whether this param is exposed by default (without overrides) */
   defaultExpose: boolean;
-  /** Property for lock check - if locked, param is always hidden */
   lockKey?: keyof NonNullable<VectorContextConfig['locks']>;
-  /** Additional properties for the schema */
   additionalProps?: Record<string, any>;
 }
 
@@ -309,13 +304,6 @@ const PARAM_CONFIGS: ParamConfig[] = [
   }
 ];
 
-/**
- * Create a vector_search tool for LLM-driven vector store queries.
- * When locks are specified, locked parameters are omitted from the schema
- * and enforced server-side.
- *
- * Supports schema overrides for customizing parameter names and descriptions.
- */
 export function createVectorSearchTool(config: VectorContextConfig): VectorSearchToolResult {
   const toolName = config.toolName ?? 'vector_search';
   const locks = config.locks;

--- a/modules/transport/internal/spec-validator.ts
+++ b/modules/transport/internal/spec-validator.ts
@@ -143,7 +143,18 @@ const llmSpecSchema: any = {
     mcpServers: { type: 'array', items: { type: 'string' }, nullable: true },
     vectorStores: { type: 'array', items: { type: 'string' }, nullable: true },
     vectorPriority: { type: 'array', items: { type: 'string' }, nullable: true },
-    vectorContext: { type: 'object', nullable: true, additionalProperties: true },
+    vectorContexts: { type: 'array', nullable: true, items: { type: 'object', additionalProperties: true } },
+    vectorRequestPolicy: {
+      type: 'object',
+      nullable: true,
+      properties: {
+        maxAutoContexts: { type: 'number', nullable: true },
+        perContextTimeoutMs: { type: 'number', nullable: true },
+        totalAutoBudgetMs: { type: 'number', nullable: true },
+        maxInjectedPayloadBytes: { type: 'number', nullable: true }
+      },
+      additionalProperties: true
+    },
     toolChoice: {
       anyOf: [
         { type: 'string', enum: ['auto', 'none', 'required'] },
@@ -291,6 +302,22 @@ function assertTelemetryObservabilityOverridesAllowed(payload: unknown, allowlis
 }
 
 export function assertValidSpec(spec: unknown): void {
+  if (spec && typeof spec === 'object' && (spec as any).vectorContext !== undefined) {
+    const error = new Error(
+      'Spec validation failed: `vectorContext` is no longer supported. Use `vectorContexts` (array) instead.'
+    );
+    (error as any).statusCode = 400;
+    (error as any).code = 'validation_error';
+    (error as any).details = [
+      {
+        instancePath: '/vectorContext',
+        keyword: 'deprecated',
+        message: '`vectorContext` is not supported; migrate to `vectorContexts`'
+      }
+    ];
+    throw error;
+  }
+
   const ok = validateLlm(spec);
   if (ok) return;
 

--- a/modules/vector/README.md
+++ b/modules/vector/README.md
@@ -16,7 +16,6 @@ Owns vector store orchestration, RAG context injection, and the built-in vector 
 ## Public API
 - `VectorStoreManager` for vector store compat orchestration.
 - `VectorStoreCoordinator` for CLI/server vector operations.
-- `VectorContextInjector` for `vectorContext.mode: 'auto' | 'both'` injection.
+- `VectorContextInjector` for `vectorContexts[].mode: 'auto' | 'both'` injection.
 - `executeVectorSearch` + `formatVectorSearchResults` for tool execution and formatting.
 - `chunkText` / `chunkFile` for ingestion chunking helpers.
-

--- a/modules/vector/internal/embedding-priority.ts
+++ b/modules/vector/internal/embedding-priority.ts
@@ -38,7 +38,7 @@ export async function resolveEmbeddingPriority(
 
   if (defaults.length === 0) {
     const error = new Error(
-      'No embedding priority configured. Provide vectorContext.embeddingPriority or set defaultEmbeddingPriority on the vector store plugin manifest.'
+      'No embedding priority configured. Provide vectorContexts[].embeddingPriority or set defaultEmbeddingPriority on the vector store plugin manifest.'
     );
     (error as any).statusCode = 400;
     (error as any).code = 'config_error';
@@ -60,7 +60,7 @@ export async function resolveEmbeddingPriority(
     .join(', ');
 
   const error = new Error(
-    `Multiple vector stores specify different default embedding priorities (${storeList}). Provide vectorContext.embeddingPriority explicitly.`
+    `Multiple vector stores specify different default embedding priorities (${storeList}). Provide vectorContexts[].embeddingPriority explicitly.`
   );
   (error as any).statusCode = 400;
   (error as any).code = 'config_error';

--- a/modules/vector/internal/vector-context-injector.ts
+++ b/modules/vector/internal/vector-context-injector.ts
@@ -1,4 +1,3 @@
-// VectorContextInjector - handles RAG context injection for auto/both modes.
 import { getDefaults, Message, QueryConstructionSettings, resolveLoggingDeps, Role, TextContent, VectorContextConfig } from '../../../kernel/index.js';
 import type {
   AdapterLogger,
@@ -8,6 +7,7 @@ import type {
   PluginRegistry
 } from '../../../kernel/index.js';
 import { interpolate } from '../../string/index.js';
+import { truncateUtf8Bytes } from '../../shared/index.js';
 import type { EmbeddingManager } from '../../embeddings/index.js';
 import { VectorStoreManager } from './vector-store-manager.js';
 import { resolveEmbeddingPriority } from './embedding-priority.js';
@@ -26,7 +26,11 @@ export interface InjectionResult {
   retrievedResults: any[];
 }
 
-// Get defaults from config (lazy loaded)
+export interface InjectionOptions {
+  maxInjectedPayloadBytes?: number;
+  embeddingCache?: Map<string, number[]>;
+}
+
 const getVectorDefaults = () => getDefaults().vector;
 
 export class VectorContextInjector {
@@ -48,16 +52,12 @@ export class VectorContextInjector {
     this.vectorLogger = this.logging.getVectorLogger();
   }
 
-  /**
-   * Inject vector context into messages based on configuration.
-   * Returns modified messages with context pre-injected.
-   */
   async injectContext(
     messages: Message[],
     config: VectorContextConfig,
-    systemPrompt?: string
+    systemPrompt?: string,
+    options: InjectionOptions = {}
   ): Promise<InjectionResult> {
-    // Only inject for 'auto' or 'both' modes
     if (config.mode === 'tool') {
       return {
         messages,
@@ -67,7 +67,6 @@ export class VectorContextInjector {
       };
     }
 
-    // Extract query from messages based on config
     const query = this.extractQuery(messages, config);
     if (!query) {
       return {
@@ -79,7 +78,6 @@ export class VectorContextInjector {
     }
 
     try {
-      // Ensure managers are initialized
       await this.ensureManagers();
 
       const embeddingPriority = await resolveEmbeddingPriority(
@@ -87,19 +85,19 @@ export class VectorContextInjector {
         this.registry
       );
 
-      // Embed the query
-      const embeddingResult = await this.embeddingManager!.embed(query, embeddingPriority);
-      const queryVector = embeddingResult.vectors[0];
+      const embeddingCacheKey = this.buildEmbeddingCacheKey(query, embeddingPriority);
+      let queryVector = options.embeddingCache?.get(embeddingCacheKey);
+      if (!queryVector) {
+        const embeddingResult = await this.embeddingManager!.embed(query, embeddingPriority);
+        queryVector = embeddingResult.vectors[0];
+        options.embeddingCache?.set(embeddingCacheKey, queryVector);
+      }
 
-      // Query vector stores
       let results: any[] = [];
       for (const storeId of config.stores) {
         try {
           await this.ensureStoreInitialized(storeId);
 
-          // getCompat will succeed since ensureStoreInitialized succeeded for this store
-          // Both methods go through the same registry to load the compat
-          // If it somehow returns null, compat.query() will throw and be caught below
           const compat = (await this.vectorManager!.getCompat(storeId))!;
 
           const storeConfig = await this.registry.getVectorStore(storeId);
@@ -117,26 +115,21 @@ export class VectorContextInjector {
 
           results = [...results, ...storeResults];
 
-          // If we got results, stop searching
           if (results.length > 0) break;
         } catch (error) {
           this.logger.warning('Vector store query failed', {
             storeId,
             error: error instanceof Error ? error.message : String(error)
           });
-          // Continue to next store
         }
       }
 
-      // Apply score threshold
       if (config.scoreThreshold !== undefined) {
         results = results.filter(r => r.score >= config.scoreThreshold!);
       }
 
-      // Limit to topK
       results = results.slice(0, config.topK ?? getVectorDefaults().topK);
 
-      // If no results, return original messages
       if (results.length === 0) {
         return {
           messages,
@@ -146,13 +139,10 @@ export class VectorContextInjector {
         };
       }
 
-      // Format results
       const formattedContext = this.formatResults(results, config);
 
-      // Apply template
-      const contextToInject = this.applyTemplate(formattedContext, config);
+      const contextToInject = this.applyTemplate(formattedContext, config, options.maxInjectedPayloadBytes);
 
-      // Inject into messages
       const modifiedMessages = this.injectIntoMessages(
         messages,
         contextToInject,
@@ -171,12 +161,10 @@ export class VectorContextInjector {
 
       this.logger.warning('Vector context injection failed', { error: message });
 
-      // Configuration errors should surface as request failures (do not silently degrade).
       if (String(error?.code ?? '') === 'config_error') {
         throw error;
       }
 
-      // Other errors (e.g., transient store failures) degrade gracefully.
       return {
         messages,
         resultsInjected: 0,
@@ -186,16 +174,11 @@ export class VectorContextInjector {
     }
   }
 
-  /**
-   * Extract the query from messages based on configuration.
-   */
   private extractQuery(messages: Message[], config: VectorContextConfig): string {
-    // Check for override first
     if (config.overrideEmbeddingQuery && config.overrideEmbeddingQuery.trim()) {
       return config.overrideEmbeddingQuery.trim();
     }
 
-    // Get query construction settings with defaults
     const defaults = getVectorDefaults().queryConstruction;
     const settings: QueryConstructionSettings = {
       includeSystemPrompt: config.queryConstruction?.includeSystemPrompt ?? defaults.includeSystemPrompt,
@@ -203,7 +186,6 @@ export class VectorContextInjector {
       messagesToInclude: config.queryConstruction?.messagesToInclude ?? defaults.messagesToInclude
     };
 
-    // Separate system message from other messages
     let systemMessage: Message | null = null;
     let nonSystemMessages: Message[] = [];
 
@@ -215,42 +197,32 @@ export class VectorContextInjector {
       }
     }
 
-    // Determine which messages to include based on messagesToInclude
     let messagesToProcess: Message[] = [];
 
     if (settings.messagesToInclude === 0) {
-      // Include all non-system messages
       messagesToProcess = nonSystemMessages;
     } else {
-      // Include last N messages
       messagesToProcess = nonSystemMessages.slice(-settings.messagesToInclude);
     }
 
-    // Filter by role (always include user, optionally include assistant)
     messagesToProcess = messagesToProcess.filter(msg => {
       if (msg.role === Role.USER) return true;
       if (msg.role === Role.ASSISTANT && settings.includeAssistantMessages) return true;
       return false;
     });
 
-    // Determine if system prompt should be included
     let includeSystem = false;
     if (systemMessage) {
       if (settings.includeSystemPrompt === 'always') {
         includeSystem = true;
       } else if (settings.includeSystemPrompt === 'if-in-range') {
-        // Include if total messages (including system) <= messagesToInclude
-        // Or if messagesToInclude is 0 (all messages)
         const totalMessages = messages.length;
         includeSystem = settings.messagesToInclude === 0 || totalMessages <= settings.messagesToInclude;
       }
-      // 'never' means includeSystem stays false
     }
 
-    // Build the query text
     const queryParts: string[] = [];
 
-    // Add system message first if included
     if (includeSystem && systemMessage) {
       const systemText = this.extractTextFromMessage(systemMessage);
       if (systemText) {
@@ -258,7 +230,6 @@ export class VectorContextInjector {
       }
     }
 
-    // Add other messages in order
     for (const msg of messagesToProcess) {
       const text = this.extractTextFromMessage(msg);
       if (text) {
@@ -269,9 +240,6 @@ export class VectorContextInjector {
     return queryParts.join('\n').trim();
   }
 
-  /**
-   * Extract text content from a message.
-   */
   private extractTextFromMessage(message: Message): string {
     for (const part of message.content) {
       if (part.type === 'text') {
@@ -284,9 +252,6 @@ export class VectorContextInjector {
     return '';
   }
 
-  /**
-   * Format results using the configured template.
-   */
   private formatResults(results: any[], config: VectorContextConfig): string {
     const format = config.resultFormat ?? getVectorDefaults().resultFormat;
 
@@ -301,17 +266,22 @@ export class VectorContextInjector {
     return formattedLines.join('\n');
   }
 
-  /**
-   * Apply the injection template.
-   */
-  private applyTemplate(content: string, config: VectorContextConfig): string {
+  private applyTemplate(content: string, config: VectorContextConfig, maxInjectedPayloadBytes?: number): string {
     const template = config.injectTemplate ?? getVectorDefaults().injectTemplate;
-    return template.replace('{{results}}', content);
+    const rendered = template.replace('{{results}}', content);
+    if (typeof maxInjectedPayloadBytes !== 'number' || maxInjectedPayloadBytes <= 0) {
+      return rendered;
+    }
+    return truncateUtf8Bytes(rendered, maxInjectedPayloadBytes);
   }
 
-  /**
-   * Inject context into messages.
-   */
+  private buildEmbeddingCacheKey(query: string, priority: Array<{ provider: string; model?: string }>): string {
+    const normalizedPriority = priority
+      .map(item => `${String(item.provider)}:${item.model ? String(item.model) : ''}`)
+      .join('|');
+    return `${query}::${normalizedPriority}`;
+  }
+
   private injectIntoMessages(
     messages: Message[],
     context: string,
@@ -321,7 +291,6 @@ export class VectorContextInjector {
     const result = [...messages];
 
     if (injectAs === 'system') {
-      // Create or update system message at the start
       const systemContent = systemPrompt
         ? `${systemPrompt}\n\n${context}`
         : context;
@@ -331,26 +300,21 @@ export class VectorContextInjector {
         content: [{ type: 'text', text: systemContent }]
       };
 
-      // Check if there's already a system message
       if (result.length > 0 && result[0].role === Role.SYSTEM) {
-        // Append to existing system message
         const existingText = (result[0].content[0] as TextContent)?.text ?? '';
         result[0] = {
           ...result[0],
           content: [{ type: 'text', text: `${existingText}\n\n${context}` }]
         };
       } else {
-        // Insert at the beginning
         result.unshift(systemMessage);
       }
     } else {
-      // Insert as user context before the last user message
       const contextMessage: Message = {
         role: Role.USER,
         content: [{ type: 'text', text: context }]
       };
 
-      // Find the last user message and insert before it
       let lastUserIndex = -1;
       for (let i = result.length - 1; i >= 0; i--) {
         if (result[i].role === Role.USER) {
@@ -359,38 +323,28 @@ export class VectorContextInjector {
         }
       }
 
-      // Insert before the last user message
-      // Note: lastUserIndex is always >= 0 here because extractQuery() requires a user message
       result.splice(lastUserIndex, 0, contextMessage);
     }
 
     return result;
   }
 
-  /**
-   * Ensure managers are initialized.
-   */
   private async ensureManagers(): Promise<void> {
     if (!this.embeddingManager) {
       const { EmbeddingManager } = await import('../../embeddings/index.js');
-      // Pass logger to embedding manager for HTTP request logging
       this.embeddingManager = new EmbeddingManager(this.registry as any, this.embeddingLogger);
     }
     if (!this.vectorManager) {
-      // Pass logger to vector manager for operation logging
       this.vectorManager = new VectorStoreManager(
-        new Map(),  // configs - will be loaded from registry
-        new Map(),  // adapters - will be created via compat
-        undefined,  // embedder - not needed, we use EmbeddingManager directly
+        new Map(),
+        new Map(),
+        undefined,
         this.registry,
-        this.vectorLogger  // logger for vector operations
+        this.vectorLogger
       );
     }
   }
 
-  /**
-   * Ensure a vector store is initialized.
-   */
   private async ensureStoreInitialized(storeId: string): Promise<void> {
     const compat = await this.vectorManager!.getCompat(storeId);
     if (!compat) {

--- a/plugins/configs/defaults.json
+++ b/plugins/configs/defaults.json
@@ -42,6 +42,12 @@
             "includeSystemPrompt": "if-in-range",
             "includeAssistantMessages": true,
             "messagesToInclude": 1
+        },
+        "requestPolicy": {
+            "maxAutoContexts": 3,
+            "perContextTimeoutMs": 1500,
+            "totalAutoBudgetMs": 4000,
+            "maxInjectedPayloadBytes": 16384
         }
     },
     "chunking": {

--- a/plugins/modules/noop-terminal/index.ts
+++ b/plugins/modules/noop-terminal/index.ts
@@ -1,0 +1,1 @@
+export { handle } from './internal/noop-terminal.js';

--- a/plugins/modules/noop-terminal/internal/noop-terminal.ts
+++ b/plugins/modules/noop-terminal/internal/noop-terminal.ts
@@ -1,0 +1,8 @@
+interface NoopTerminalContext {
+  toolName?: string;
+  args?: unknown;
+}
+
+export async function handle(_ctx: NoopTerminalContext): Promise<{ result: { ok: true } }> {
+  return { result: { ok: true } };
+}

--- a/plugins/observability-compat/langfuse/internal/langfuse-helpers.ts
+++ b/plugins/observability-compat/langfuse/internal/langfuse-helpers.ts
@@ -37,14 +37,16 @@ export function buildCommonTraceAttributes(options: {
   traceId: string;
   sessionId?: string;
   traceName?: string;
+  correlationId?: string;
   tags?: string[];
   batchId?: string;
 }): Record<string, unknown> {
-  const { traceId, sessionId, traceName, tags, batchId } = options;
+  const { traceId, sessionId, traceName, correlationId, tags, batchId } = options;
   return {
     'llm.adapter.trace_id': String(traceId || ''),
     ...(sessionId ? { 'langfuse.session.id': sessionId, 'llm.adapter.session_id': sessionId } : {}),
-    ...(traceName ? { 'langfuse.trace.name': traceName, 'llm.adapter.correlation_id': traceName } : {}),
+    ...(traceName ? { 'langfuse.trace.name': traceName } : {}),
+    ...(correlationId ? { 'llm.adapter.correlation_id': correlationId } : {}),
     ...(tags ? { 'langfuse.trace.tags': tags } : {}),
     ...(batchId ? { 'llm.adapter.batch_id': batchId } : {})
   };

--- a/plugins/observability-compat/langfuse/internal/langfuse.ts
+++ b/plugins/observability-compat/langfuse/internal/langfuse.ts
@@ -58,6 +58,13 @@ export class LangfuseCompat implements IObservabilityCompat {
 
     const eventIds = getEventIds(context);
     const maxBytes = resolveMaxAttributeBytes(context);
+    const jsonOptions = {
+      maxBytes,
+      maxDepth: 25,
+      maxArrayLength: 1000,
+      maxObjectKeys: 2000,
+      maxStringBytes: maxBytes
+    } as const;
     const spans: OtlpSpanSpec[] = [];
     const eventIndexByEnvelopeId = new Map<string, number>();
 
@@ -75,10 +82,14 @@ export class LangfuseCompat implements IObservabilityCompat {
         const cached = this.requestCache.get(key);
         const cachedSummary = cached?.summary as any;
 
-        const { sessionId, traceName, batchId, tags } = resolveTraceContext({
+        const { sessionId, traceName, correlationId, batchId, tags } = resolveTraceContext({
           event,
           cachedSummary
         });
+        const step = typeof (event as any)?.metadata?.step === 'string'
+          ? String((event as any).metadata.step).trim()
+          : '';
+        const spanName = step || DEFAULT_SPAN_NAME;
 
         const envelopeId = getEnvelopeId(
           eventIds,
@@ -91,7 +102,7 @@ export class LangfuseCompat implements IObservabilityCompat {
         spans.push({
           traceIdHex: deriveOtlpTraceIdHex(String(event.traceId)),
           spanIdHex: deriveOtlpSpanIdHex(String(event.generationId || envelopeId)),
-          name: DEFAULT_SPAN_NAME,
+          name: spanName,
           startTimeIso: cachedSummary?.startTimeIso ? String(cachedSummary.startTimeIso) : deriveStartTimeIso(event),
           endTimeIso: eventTimestampToIso(event),
           status: event.error
@@ -102,6 +113,7 @@ export class LangfuseCompat implements IObservabilityCompat {
               traceId: String(event.traceId || ''),
               sessionId,
               traceName,
+              correlationId,
               tags,
               batchId
             }),
@@ -112,10 +124,10 @@ export class LangfuseCompat implements IObservabilityCompat {
               { maxBytes }
             ),
             'langfuse.observation.type': 'generation',
-            'langfuse.observation.input': cachedSummary?.observationInput ?? safeJsonStringify(buildInputJson(undefined), { maxBytes }),
-            'langfuse.observation.output': safeJsonStringify(buildOutputJson(event), { maxBytes }),
+            'langfuse.observation.input': cachedSummary?.observationInput ?? safeJsonStringify(buildInputJson(undefined), jsonOptions),
+            'langfuse.observation.output': safeJsonStringify(buildOutputJson(event), jsonOptions),
             'langfuse.observation.model.name': String(event.model || cachedSummary?.model || ''),
-            'langfuse.observation.model.parameters': cachedSummary?.modelParameters ?? safeJsonStringify({}, { maxBytes }),
+            'langfuse.observation.model.parameters': cachedSummary?.modelParameters ?? safeJsonStringify({}, jsonOptions),
             'langfuse.observation.usage_details': safeJsonStringify(buildLangfuseUsageDetails(event.usage), { maxBytes }),
             ...(costDetails
               ? {
@@ -138,7 +150,7 @@ export class LangfuseCompat implements IObservabilityCompat {
         const key = cacheKey(toolEvent.traceId, toolEvent.generationId);
         const cachedSummary = (this.requestCache.get(key)?.summary as any) ?? undefined;
 
-        const { sessionId, traceName, batchId, tags } = resolveTraceContext({
+        const { sessionId, traceName, correlationId, batchId, tags } = resolveTraceContext({
           event: toolEvent,
           cachedSummary
         });
@@ -170,6 +182,7 @@ export class LangfuseCompat implements IObservabilityCompat {
               traceId: String(toolEvent.traceId || ''),
               sessionId,
               traceName,
+              correlationId,
               tags,
               batchId
             }),
@@ -190,7 +203,7 @@ export class LangfuseCompat implements IObservabilityCompat {
             'langfuse.observation.level': level,
             'langfuse.observation.input': safeJsonStringify(
               { toolName: toolEvent.toolName, toolCallId: toolEvent.toolCallId, ...(toolEvent.args !== undefined ? { args: toolEvent.args } : {}) },
-              { maxBytes }
+              jsonOptions
             ),
             'langfuse.observation.output': safeJsonStringify(
               {
@@ -200,7 +213,7 @@ export class LangfuseCompat implements IObservabilityCompat {
                 ...(toolEvent.skipReason ? { skipReason: toolEvent.skipReason } : {}),
                 ...(toolEvent.error ? { error: toolEvent.error } : {})
               },
-              { maxBytes }
+              jsonOptions
             )
           },
           envelopeId
@@ -215,7 +228,7 @@ export class LangfuseCompat implements IObservabilityCompat {
         const key = cacheKey(signalEvent.traceId, signalEvent.generationId);
         const cachedSummary = (this.requestCache.get(key)?.summary as any) ?? undefined;
 
-        const { sessionId, traceName, batchId, tags } = resolveTraceContext({
+        const { sessionId, traceName, correlationId, batchId, tags } = resolveTraceContext({
           event: signalEvent,
           cachedSummary
         });
@@ -238,6 +251,7 @@ export class LangfuseCompat implements IObservabilityCompat {
               traceId: String(signalEvent.traceId || ''),
               sessionId,
               traceName,
+              correlationId,
               tags,
               batchId
             }),
@@ -254,7 +268,7 @@ export class LangfuseCompat implements IObservabilityCompat {
                 ...(signalEvent.tags ? { tags: signalEvent.tags } : {}),
                 ...(signalEvent.metadata ? { metadata: signalEvent.metadata } : {})
               },
-              { maxBytes }
+              jsonOptions
             )
           },
           envelopeId
@@ -271,7 +285,7 @@ export class LangfuseCompat implements IObservabilityCompat {
         const key = cacheKey(updateEvent.traceId, updateEvent.generationId);
         const cachedSummary = (this.requestCache.get(key)?.summary as any) ?? undefined;
 
-        const { sessionId, traceName, batchId, tags } = resolveTraceContext({
+        const { sessionId, traceName, correlationId, batchId, tags } = resolveTraceContext({
           event: updateEvent,
           cachedSummary: {
             ...(cachedSummary ?? {}),
@@ -296,12 +310,13 @@ export class LangfuseCompat implements IObservabilityCompat {
               traceId: String(updateEvent.traceId || ''),
               sessionId,
               traceName,
+              correlationId,
               tags,
               batchId
             }),
             ...(updateEvent.metadata
               ? {
-                  'langfuse.trace.metadata.payload': safeJsonStringify(updateEvent.metadata, { maxBytes })
+                  'langfuse.trace.metadata.payload': safeJsonStringify(updateEvent.metadata, jsonOptions)
                 }
               : {}),
             'langfuse.observation.type': 'event',

--- a/tests/helpers/live.ts
+++ b/tests/helpers/live.ts
@@ -24,7 +24,7 @@ export type BaseSpec = {
   tools?: any[];
   functionToolNames?: string[];
   mcpServers?: string[];
-  vectorContext?: any;
+  vectorContexts?: any[];
   observability?: any;
   metadata?: Record<string, any>;
   toolChoice?: any;

--- a/tests/integration/coordinator/coordinator.test.ts
+++ b/tests/integration/coordinator/coordinator.test.ts
@@ -607,7 +607,7 @@ describe('coordinator/coordinator integration', () => {
           }
         ],
         settings: { temperature: 0 },
-        vectorContext: {
+        vectorContexts: [{
           mode: 'tool' as const,
           stores: ['test-store'],
           embeddingPriority: [{ provider: 'openrouter', model: 'test-embed' }],
@@ -616,7 +616,7 @@ describe('coordinator/coordinator integration', () => {
               topK: { name: 'maximum_results' }
             }
           }
-        }
+        }]
       };
 
       const result = await coordinator.run(spec as any);
@@ -710,11 +710,11 @@ describe('coordinator/coordinator integration', () => {
           }
         ],
         settings: { temperature: 0 },
-        vectorContext: {
+        vectorContexts: [{
           mode: 'auto' as const,
           stores: ['test-store'],
           embeddingPriority: [{ provider: 'test-embeddings' }]
-        }
+        }]
       };
 
       await coordinator.run(spec as any);

--- a/tests/integration/lazy-loading/import-evaluation.mcp-only.test.ts
+++ b/tests/integration/lazy-loading/import-evaluation.mcp-only.test.ts
@@ -35,7 +35,7 @@ describe('integration/lazy-loading/import-evaluation (MCP-only)', () => {
       jest.unstable_mockModule('../../../modules/tools/index.js', () => ({
         ToolCoordinator: class ToolCoordinator {
           constructor(..._args: any[]) {}
-          setVectorContext() {}
+          setVectorContexts() {}
           async routeAndInvoke() {
             throw new Error('ToolCoordinator not used in MCP-only import test');
           }
@@ -46,7 +46,7 @@ describe('integration/lazy-loading/import-evaluation (MCP-only)', () => {
           tools: [],
           mcpServers: [],
           toolNameMap: {},
-          vectorSearchAliasMap: undefined
+          vectorSearchAliasMaps: undefined
         }),
         runToolLoop: async () => {
           throw new Error('runToolLoop not used in MCP-only import test');
@@ -93,4 +93,3 @@ describe('integration/lazy-loading/import-evaluation (MCP-only)', () => {
     });
   });
 });
-

--- a/tests/integration/lazy-loading/import-evaluation.tools-only.test.ts
+++ b/tests/integration/lazy-loading/import-evaluation.tools-only.test.ts
@@ -33,7 +33,7 @@ describe('integration/lazy-loading/import-evaluation (tools-only)', () => {
       jest.unstable_mockModule('../../../modules/tools/index.js', () => ({
         ToolCoordinator: class ToolCoordinator {
           constructor(..._args: any[]) {}
-          setVectorContext() {}
+          setVectorContexts() {}
           async routeAndInvoke() {
             throw new Error('ToolCoordinator not used in tools-only import test');
           }
@@ -44,7 +44,7 @@ describe('integration/lazy-loading/import-evaluation (tools-only)', () => {
           tools: spec.tools ?? [],
           mcpServers: [],
           toolNameMap: {},
-          vectorSearchAliasMap: undefined
+          vectorSearchAliasMaps: undefined
         }),
         runToolLoop: async () => {
           throw new Error('runToolLoop not used in tools-only import test');
@@ -86,4 +86,3 @@ describe('integration/lazy-loading/import-evaluation (tools-only)', () => {
     });
   });
 });
-

--- a/tests/integration/lazy-loading/import-evaluation.tools-vector-search.test.ts
+++ b/tests/integration/lazy-loading/import-evaluation.tools-vector-search.test.ts
@@ -23,7 +23,7 @@ describe('integration/lazy-loading/import-evaluation (tools vector_search invoca
         [],
         undefined,
         {
-          vectorContext: { mode: 'tool', stores: ['memory'], topK: 1 },
+          vectorContexts: [{ mode: 'tool', stores: ['memory'], topK: 1 }],
           registry: {} as any
         }
       );
@@ -44,4 +44,3 @@ describe('integration/lazy-loading/import-evaluation (tools vector_search invoca
     });
   });
 });
-

--- a/tests/integration/lazy-loading/import-evaluation.vector-context.test.ts
+++ b/tests/integration/lazy-loading/import-evaluation.vector-context.test.ts
@@ -72,11 +72,11 @@ describe('integration/lazy-loading/import-evaluation (vector context)', () => {
       await coordinator.run({
         messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
         llmPriority: [{ provider: 'stub-provider', model: 'stub-model' }],
-        vectorContext: {
+        vectorContexts: [{
           mode: 'auto',
           stores: ['memory'],
           topK: 1
-        },
+        }],
         settings: {}
       } as any);
 
@@ -87,4 +87,3 @@ describe('integration/lazy-loading/import-evaluation (vector context)', () => {
     });
   });
 });
-

--- a/tests/integration/lazy-loading/import-evaluation.vector-stream.test.ts
+++ b/tests/integration/lazy-loading/import-evaluation.vector-stream.test.ts
@@ -64,11 +64,11 @@ describe('integration/lazy-loading/import-evaluation (vector-context stream)', (
       for await (const _event of coordinator.runStream({
         messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
         llmPriority: [{ provider: 'stub-provider', model: 'stub-model' }],
-        vectorContext: {
+        vectorContexts: [{
           mode: 'auto',
           stores: ['memory'],
           topK: 1
-        },
+        }],
         settings: {}
       } as any)) {
         // exhaust stream
@@ -81,4 +81,3 @@ describe('integration/lazy-loading/import-evaluation (vector-context stream)', (
     });
   });
 });
-

--- a/tests/integration/vector/auto-inject.test.ts
+++ b/tests/integration/vector/auto-inject.test.ts
@@ -541,12 +541,12 @@ describe('integration/vector/auto-inject', () => {
     });
   });
 
-  describe('backward compatibility', () => {
-    test('vectorPriority and vectorContext are independent', async () => {
+  describe('vector configuration interoperability', () => {
+    test('vectorPriority and vectorContexts are independent', async () => {
       if (!coordinator) return;
 
       // vectorPriority is for semantic tool selection
-      // vectorContext is for RAG context injection
+      // vectorContexts is for RAG context injection
       // Both can be specified and work independently
 
       const spec: LLMCallSpec = {
@@ -554,21 +554,21 @@ describe('integration/vector/auto-inject', () => {
           { role: 'user' as Role, content: [{ type: 'text', text: 'Query' }] }
         ],
         vectorPriority: ['tool-store'],
-        vectorContext: {
+        vectorContexts: [{
           stores: ['doc-store'],
           mode: 'auto',
           topK: 5
-        },
+        }],
         llmPriority: [{ provider: 'openrouter', model: 'openai/gpt-4o-mini' }],
         settings: {}
       };
 
       // Both can be defined
       expect(spec.vectorPriority).toBeDefined();
-      expect(spec.vectorContext).toBeDefined();
+      expect(spec.vectorContexts).toBeDefined();
       // They serve different purposes
       expect(spec.vectorPriority).toContain('tool-store');
-      expect(spec.vectorContext?.stores).toContain('doc-store');
+      expect(spec.vectorContexts?.[0]?.stores).toContain('doc-store');
     });
   });
 });

--- a/tests/live/test-files/00-validation-and-plugin-loading.live.test.ts
+++ b/tests/live/test-files/00-validation-and-plugin-loading.live.test.ts
@@ -284,11 +284,11 @@ async function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<{ code: n
       messages: [{ role: 'user', content: [{ type: 'text', text: 'What is 2+2?' }] }],
       llmPriority: runCfg.llmPriority,
       settings: runCfg.settings,
-      vectorContext: {
+      vectorContexts: [{
         mode: 'auto',
         stores: ['memory'],
         topK: 1
-      }
+      }]
     };
 
     const transport = String(process.env.LLM_LIVE_TRANSPORT || '').trim().toLowerCase();
@@ -348,7 +348,7 @@ async function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<{ code: n
       messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
       llmPriority: runCfg.llmPriority,
       settings: runCfg.settings,
-      vectorContext: { mode: 'auto', stores: ['memory'], topK: 1 }
+      vectorContexts: [{ mode: 'auto', stores: ['memory'], topK: 1 }]
     };
 
     const transport = String(process.env.LLM_LIVE_TRANSPORT || '').trim().toLowerCase();

--- a/tests/live/test-files/01-llm-core.live.test.ts
+++ b/tests/live/test-files/01-llm-core.live.test.ts
@@ -54,7 +54,7 @@ function extractText(parts: ContentPart[] | undefined): string {
         // Ensure the core suite doesn't enable tools/MCP/vector implicitly.
         tools: [],
         mcpServers: [],
-        vectorContext: undefined
+        vectorContexts: undefined
       },
       traceId
     );

--- a/tests/live/test-files/18-vector-auto-inject.live.test.ts
+++ b/tests/live/test-files/18-vector-auto-inject.live.test.ts
@@ -117,7 +117,7 @@ function readOpenRouterEmbeddingProviderId(): string {
     });
   }, 60_000);
 
-  test('auto-inject (both mode) inserts retrieved context and tool is available', async () => {
+  test('auto-inject (both mode) supports two stores and falls back to the second when first is empty', async () => {
     expect(runCfg).toBeTruthy();
 
     const spec = {
@@ -142,14 +142,14 @@ function readOpenRouterEmbeddingProviderId(): string {
       ],
       llmPriority: runCfg.llmPriority,
       settings: mergeSettings(runCfg.settings, { maxTokens: 512 }),
-      vectorContext: {
+      vectorContexts: [{
         mode: 'both',
-        stores: [STORE_ID],
+        stores: ['memory', STORE_ID],
         collection,
         topK: 1,
         injectAs: 'system',
         injectTemplate: `Relevant context for ${TOKEN}:\n{{results}}`
-      }
+      }]
     };
 
     const { result, response } = await runLlmOnce({
@@ -178,7 +178,11 @@ function readOpenRouterEmbeddingProviderId(): string {
     expect(thisRun).toBeTruthy();
 
     const tools = Array.isArray((thisRun as any)?.tools) ? (thisRun as any).tools : [];
-    expect(tools.some((t: any) => t?.name === 'vector_search')).toBe(true);
+    const vectorTool = tools.find((t: any) => t?.name === 'vector_search');
+    expect(vectorTool).toBeTruthy();
+    const vectorToolDescription = String((vectorTool as any)?.description ?? '');
+    expect(vectorToolDescription).toContain('memory');
+    expect(vectorToolDescription).toContain(STORE_ID);
 
     const msgs = Array.isArray((thisRun as any)?.messages) ? (thisRun as any).messages : [];
     const systemText = msgs

--- a/tests/live/test-files/19-vector-search-locks.live.test.ts
+++ b/tests/live/test-files/19-vector-search-locks.live.test.ts
@@ -128,7 +128,7 @@ function extractTextFromMessage(msg: any): string {
         parallelToolExecution: false
       }),
       toolChoice: { type: 'single', name: 'vector_search' },
-      vectorContext: {
+      vectorContexts: [{
         // Intentionally wrong/unhelpful defaults (locks must override these).
         mode: 'tool',
         stores: ['memory', STORE_ID],
@@ -144,7 +144,7 @@ function extractTextFromMessage(msg: any): string {
           filter: { relevance: 'high' },
           scoreThreshold: 0
         }
-      }
+      }]
     };
 
     const { result, response } = await runLlmOnce({

--- a/tests/sandbox/README.md
+++ b/tests/sandbox/README.md
@@ -29,7 +29,7 @@ Flags:
   - `copyLogs` (bool, default `true`) – copy `./logs` into the sandbox run folder.  
   - `transcriptPath` (string, optional) – custom transcript location.
 - `env` (object, optional): extra environment variables for the CLI process.
-- `spec`: base `LLMCallSpec` fields (everything except `messages`, which are built per turn). Includes `systemPrompt`, `llmPriority`, `settings`, `tools`, `functionToolNames`, `mcpServers`, `vectorContext`, etc.
+- `spec`: base `LLMCallSpec` fields (everything except `messages`, which are built per turn). Includes `systemPrompt`, `llmPriority`, `settings`, `tools`, `functionToolNames`, `mcpServers`, `vectorContexts`, etc.
 - `initialMessages` (array, optional): pre-seeded history (e.g., tool results or assistant replies) before the scripted turns.
 - `turns` (array, required): ordered user turns. Each item can be a string or an object with `role` (defaults to `user`) and `content` (string or content parts).
 

--- a/tests/sandbox/internal/load-scenario.ts
+++ b/tests/sandbox/internal/load-scenario.ts
@@ -28,7 +28,7 @@ export interface LLMCallSpec {
   mcpServers?: string[];
   vectorStores?: string[];
   vectorPriority?: string[];
-  vectorContext?: any;
+  vectorContexts?: any[];
   llmPriority: any[];
   toolChoice?: any;
   rateLimitRetryDelays?: number[];

--- a/tests/sandbox/scenarios/example.yml
+++ b/tests/sandbox/scenarios/example.yml
@@ -81,28 +81,28 @@ spec:
   vectorStores: [memory]
   vectorPriority: [memory]
 
-  vectorContext:
-    stores: [memory]
-    collection: demo
-    mode: both           # auto inject + tool
-    topK: 3
-    scoreThreshold: 0.15
-    filter:
-      topic: sandbox
-    embeddingPriority:
-      - provider: test-openai
-        model: embed-model
-    injectAs: system
-    injectTemplate: "Relevant context:\\n{{results}}"
-    maxContextTokens: 512
-    resultFormat: "- {{payload.text}} (score: {{score}})"
-    toolName: vector_search
-    toolDescription: Search stored snippets
-    locks:
-      store: memory
+  vectorContexts:
+    - stores: [memory]
+      collection: demo
+      mode: both           # auto inject + tool
       topK: 3
+      scoreThreshold: 0.15
       filter:
         topic: sandbox
+      embeddingPriority:
+        - provider: test-openai
+          model: embed-model
+      injectAs: system
+      injectTemplate: "Relevant context:\\n{{results}}"
+      maxContextTokens: 512
+      resultFormat: "- {{payload.text}} (score: {{score}})"
+      toolName: vector_search
+      toolDescription: Search stored snippets
+      locks:
+        store: memory
+        topK: 3
+        filter:
+          topic: sandbox
 
   rateLimitRetryDelays: [1, 2, 5]
 

--- a/tests/unit/coordinator/run-guards.test.ts
+++ b/tests/unit/coordinator/run-guards.test.ts
@@ -12,6 +12,29 @@ function createRegistryStub() {
 }
 
 describe('LLMCoordinator guard clauses', () => {
+  function createResponse() {
+    return {
+      provider: 'stub-provider',
+      model: 'stub-model',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'ok' }],
+      finishReason: 'stop',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 }
+    } as any;
+  }
+
+  function createMockLogger() {
+    const logger: any = {
+      info: jest.fn(),
+      warning: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      withCorrelation: jest.fn()
+    };
+    logger.withCorrelation.mockReturnValue(logger);
+    return logger;
+  }
+
   test('run throws when llmPriority missing', async () => {
     const coordinator = new LLMCoordinator(createRegistryStub());
     await expect(coordinator.run({
@@ -203,10 +226,10 @@ describe('LLMCoordinator guard clauses', () => {
       messages: [{ role: 'user', content: [{ type: 'text', text: 'Query' }] }],
       llmPriority: [{ provider: 'stub-provider', model: 'stub-model' }],
       settings: {},
-      vectorContext: {
+      vectorContexts: [{
         stores: ['test-store'],
         mode: 'auto'
-      },
+      }],
       tools: [],
       functionToolNames: []
     } as any;
@@ -226,8 +249,258 @@ describe('LLMCoordinator guard clauses', () => {
 
     expect(mockInjector.injectContext).toHaveBeenCalledWith(
       expect.any(Array),
-      spec.vectorContext,
-      undefined
+      spec.vectorContexts[0],
+      undefined,
+      expect.objectContaining({
+        maxInjectedPayloadBytes: 16384,
+        embeddingCache: expect.any(Map)
+      })
+    );
+  });
+
+  test('run applies auto-injection budget and skips remaining contexts after budget is exhausted', async () => {
+    const registry = createRegistryStub();
+    registry.getProvider = jest.fn(() => ({ id: 'stub-provider', compat: 'openai' }));
+    const coordinator = new LLMCoordinator(registry);
+    const logger = createMockLogger();
+    (coordinator as any).logger = logger;
+
+    const mockInjector = {
+      injectContext: jest.fn().mockResolvedValue({ messages: [{ role: 'user', content: [{ type: 'text', text: 'Q' }] }] })
+    };
+    (coordinator as any).vectorContextInjector = mockInjector;
+    (coordinator as any).llmManager = {
+      callProvider: jest.fn().mockResolvedValue(createResponse())
+    };
+
+    const nowSpy = jest.spyOn(Date, 'now');
+    nowSpy
+      .mockReturnValueOnce(0)   // startedAt
+      .mockReturnValueOnce(0)   // first context elapsed
+      .mockReturnValueOnce(100); // second context elapsed -> budget exhausted
+
+    await coordinator.run({
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Q' }] }],
+      llmPriority: [{ provider: 'stub-provider', model: 'stub-model' }],
+      settings: {},
+      vectorContexts: [
+        { stores: ['memory-a'], mode: 'auto' },
+        { stores: ['memory-b'], mode: 'auto' }
+      ],
+      vectorRequestPolicy: {
+        totalAutoBudgetMs: 50,
+        perContextTimeoutMs: 1000,
+        maxAutoContexts: 5
+      }
+    } as any);
+
+    expect(mockInjector.injectContext).toHaveBeenCalledTimes(1);
+    expect(logger.warning).toHaveBeenCalledWith(
+      'Vector auto-injection budget exhausted; skipping remaining contexts',
+      { totalAutoBudgetMs: 50 }
+    );
+
+    nowSpy.mockRestore();
+  });
+
+  test('run rethrows config_error from vector auto-injection', async () => {
+    const registry = createRegistryStub();
+    registry.getProvider = jest.fn(() => ({ id: 'stub-provider', compat: 'openai' }));
+    const coordinator = new LLMCoordinator(registry);
+
+    const configError = Object.assign(new Error('invalid vector config'), { code: 'config_error' });
+    const mockInjector = {
+      injectContext: jest.fn().mockRejectedValue(configError)
+    };
+    (coordinator as any).vectorContextInjector = mockInjector;
+    (coordinator as any).llmManager = {
+      callProvider: jest.fn().mockResolvedValue(createResponse())
+    };
+
+    await expect(
+      coordinator.run({
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'Q' }] }],
+        llmPriority: [{ provider: 'stub-provider', model: 'stub-model' }],
+        settings: {},
+        vectorContexts: [{ stores: ['memory'], mode: 'auto' }]
+      } as any)
+    ).rejects.toBe(configError);
+  });
+
+  test('run logs non-config vector auto-injection errors and continues', async () => {
+    const registry = createRegistryStub();
+    registry.getProvider = jest.fn(() => ({ id: 'stub-provider', compat: 'openai' }));
+    const coordinator = new LLMCoordinator(registry);
+    const logger = createMockLogger();
+    (coordinator as any).logger = logger;
+
+    const mockInjector = {
+      injectContext: jest.fn().mockRejectedValue('boom-string')
+    };
+    (coordinator as any).vectorContextInjector = mockInjector;
+    (coordinator as any).llmManager = {
+      callProvider: jest.fn().mockResolvedValue(createResponse())
+    };
+
+    const result = await coordinator.run({
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Q' }] }],
+      llmPriority: [{ provider: 'stub-provider', model: 'stub-model' }],
+      settings: {},
+      vectorContexts: [{ stores: ['memory'], mode: 'auto' }]
+    } as any);
+
+    expect(result.role).toBe('assistant');
+    expect(logger.warning).toHaveBeenCalledWith(
+      'Vector context injection skipped due to error',
+      expect.objectContaining({
+        error: 'boom-string',
+        mode: 'auto',
+        stores: ['memory']
+      })
+    );
+  });
+
+  test('run updates tool coordinator with undefined tool vector contexts when alias maps exist', async () => {
+    const registry = createRegistryStub();
+    registry.getProvider = jest.fn(() => ({ id: 'stub-provider', compat: 'openai' }));
+    const coordinator = new LLMCoordinator(registry);
+
+    const setVectorContexts = jest.fn();
+    (coordinator as any).toolCoordinator = {
+      setVectorContexts,
+      routeAndInvoke: jest.fn(),
+      close: jest.fn()
+    };
+    jest.spyOn(coordinator as any, 'ensureToolCoordinator').mockResolvedValue((coordinator as any).toolCoordinator);
+    jest.spyOn(coordinator as any, 'collectTools').mockResolvedValue([
+      [],
+      [],
+      {},
+      { vector_search: { query: 'query' } }
+    ]);
+
+    (coordinator as any).llmManager = {
+      callProvider: jest.fn().mockResolvedValue(createResponse())
+    };
+
+    await coordinator.run({
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Q' }] }],
+      llmPriority: [{ provider: 'stub-provider', model: 'stub-model' }],
+      settings: {},
+      toolChoice: { type: 'single', name: 'ignored' },
+      vectorContexts: [{ stores: ['memory'], mode: 'auto' }]
+    } as any);
+
+    expect(setVectorContexts).toHaveBeenCalledWith(
+      undefined,
+      registry,
+      { vector_search: { query: 'query' } }
+    );
+  });
+
+  test('run keeps both-mode vector contexts when alias maps are applied', async () => {
+    const registry = createRegistryStub();
+    registry.getProvider = jest.fn(() => ({ id: 'stub-provider', compat: 'openai' }));
+    const coordinator = new LLMCoordinator(registry);
+
+    const setVectorContexts = jest.fn();
+    (coordinator as any).toolCoordinator = {
+      setVectorContexts,
+      routeAndInvoke: jest.fn(),
+      close: jest.fn()
+    };
+    jest.spyOn(coordinator as any, 'ensureToolCoordinator').mockResolvedValue((coordinator as any).toolCoordinator);
+    jest.spyOn(coordinator as any, 'collectTools').mockResolvedValue([
+      [],
+      [],
+      {},
+      { semantic_search: { query: 'query' } }
+    ]);
+
+    (coordinator as any).llmManager = {
+      callProvider: jest.fn().mockResolvedValue(createResponse())
+    };
+
+    await coordinator.run({
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Q' }] }],
+      llmPriority: [{ provider: 'stub-provider', model: 'stub-model' }],
+      settings: {},
+      toolChoice: { type: 'single', name: 'ignored' },
+      vectorContexts: [{ stores: ['memory'], mode: 'both', toolName: 'semantic_search' }]
+    } as any);
+
+    expect(setVectorContexts).toHaveBeenCalledWith(
+      [{ stores: ['memory'], mode: 'both', toolName: 'semantic_search' }],
+      registry,
+      { semantic_search: { query: 'query' } }
+    );
+  });
+
+  test('tool coordinator proxy stores pending vector contexts before initialization', () => {
+    const coordinator = new LLMCoordinator(createRegistryStub());
+
+    (coordinator as any).toolCoordinator.setVectorContexts(
+      [{ stores: ['memory'], mode: 'tool' }],
+      undefined,
+      { vector_search: { q: 'query' } }
+    );
+
+    expect((coordinator as any).pendingVectorContexts).toEqual({
+      configs: [{ stores: ['memory'], mode: 'tool' }],
+      aliasMaps: { vector_search: { q: 'query' } }
+    });
+  });
+
+  test('ensureToolCoordinator refresh uses undefined vector contexts when none are configured', async () => {
+    const registry = createRegistryStub();
+    const coordinator = new LLMCoordinator(registry);
+
+    const firstSpec = {
+      messages: [],
+      settings: {},
+      llmPriority: [{ provider: 'p', model: 'm' }],
+      vectorContexts: [{ stores: ['memory'], mode: 'tool' }]
+    } as any;
+
+    const secondSpec = {
+      ...firstSpec,
+      vectorContexts: []
+    } as any;
+
+    await (coordinator as any).ensureToolCoordinator(firstSpec);
+    const impl = (coordinator as any).toolCoordinatorImpl;
+    const setSpy = jest.spyOn(impl, 'setVectorContexts');
+
+    await (coordinator as any).ensureToolCoordinator(secondSpec);
+
+    expect(setSpy).toHaveBeenCalledWith(undefined, registry);
+  });
+
+  test('ensureToolCoordinator refresh passes vector contexts when they are configured', async () => {
+    const registry = createRegistryStub();
+    const coordinator = new LLMCoordinator(registry);
+
+    const firstSpec = {
+      messages: [],
+      settings: {},
+      llmPriority: [{ provider: 'p', model: 'm' }],
+      vectorContexts: []
+    } as any;
+
+    const secondSpec = {
+      ...firstSpec,
+      vectorContexts: [{ stores: ['memory'], mode: 'tool' }]
+    } as any;
+
+    await (coordinator as any).ensureToolCoordinator(firstSpec);
+    const impl = (coordinator as any).toolCoordinatorImpl;
+    const setSpy = jest.spyOn(impl, 'setVectorContexts');
+
+    await (coordinator as any).ensureToolCoordinator(secondSpec);
+
+    expect(setSpy).toHaveBeenCalledWith(
+      [{ stores: ['memory'], mode: 'tool' }],
+      registry
     );
   });
 });

--- a/tests/unit/coordinator/run-stream.test.ts
+++ b/tests/unit/coordinator/run-stream.test.ts
@@ -4,6 +4,18 @@ import { StreamEventType, Role, ToolCallEventType } from '@/kernel/index.ts';
 
 const handleChunkMock = jest.fn();
 
+function createMockLogger() {
+  const logger: any = {
+    info: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    withCorrelation: jest.fn()
+  };
+  logger.withCorrelation.mockReturnValue(logger);
+  return logger;
+}
+
 function createCoordinator({ withDetector }: { withDetector: boolean }) {
     const compatModule = {
       parseStreamChunk: jest.fn().mockImplementation(chunk => ({
@@ -364,15 +376,97 @@ describe('LLMCoordinator runStream', () => {
         messages: [{ role: Role.USER, content: [{ type: 'text', text: 'Query' }] }],
         llmPriority: [{ provider: 'openrouter', model: 'openai/gpt-4o-mini' }],
         settings: {},
-        vectorContext: {
+        vectorContexts: [{
           stores: ['test-store'],
           mode: 'auto'
-        }
+        }]
       })) {
         events.push(event);
       }
 
       expect(mockInjector.injectContext).toHaveBeenCalled();
+    });
+
+    test('runStream applies auto-injection budget and skips remaining contexts', async () => {
+      const { coordinator, mockInjector } = createCoordinatorWithVectorSupport();
+      (coordinator as any).vectorContextInjector = mockInjector;
+      const logger = createMockLogger();
+      (coordinator as any).logger = logger;
+
+      const nowSpy = jest.spyOn(Date, 'now');
+      nowSpy
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(100);
+
+      for await (const _event of coordinator.runStream({
+        messages: [{ role: Role.USER, content: [{ type: 'text', text: 'Query' }] }],
+        llmPriority: [{ provider: 'openrouter', model: 'openai/gpt-4o-mini' }],
+        settings: {},
+        vectorContexts: [
+          { stores: ['test-store-a'], mode: 'auto' },
+          { stores: ['test-store-b'], mode: 'auto' }
+        ],
+        vectorRequestPolicy: {
+          totalAutoBudgetMs: 50,
+          perContextTimeoutMs: 1000,
+          maxAutoContexts: 5
+        }
+      } as any)) {
+        // consume
+      }
+
+      expect(mockInjector.injectContext).toHaveBeenCalledTimes(1);
+      expect(logger.warning).toHaveBeenCalledWith(
+        'Vector auto-injection budget exhausted; skipping remaining contexts',
+        { totalAutoBudgetMs: 50 }
+      );
+
+      nowSpy.mockRestore();
+    });
+
+    test('runStream rethrows config_error from vector context injection', async () => {
+      const { coordinator, mockInjector } = createCoordinatorWithVectorSupport();
+      const configError = Object.assign(new Error('invalid vector config'), { code: 'config_error' });
+      mockInjector.injectContext.mockRejectedValue(configError);
+      (coordinator as any).vectorContextInjector = mockInjector;
+
+      const iterator = coordinator.runStream({
+        messages: [{ role: Role.USER, content: [{ type: 'text', text: 'Query' }] }],
+        llmPriority: [{ provider: 'openrouter', model: 'openai/gpt-4o-mini' }],
+        settings: {},
+        vectorContexts: [{ stores: ['test-store'], mode: 'auto' }]
+      } as any);
+
+      await expect(iterator.next()).rejects.toBe(configError);
+    });
+
+    test('runStream logs non-config vector injection errors and continues', async () => {
+      const { coordinator, mockInjector } = createCoordinatorWithVectorSupport();
+      const logger = createMockLogger();
+      (coordinator as any).logger = logger;
+      mockInjector.injectContext.mockRejectedValue('stream-boom');
+      (coordinator as any).vectorContextInjector = mockInjector;
+
+      const events: any[] = [];
+      for await (const event of coordinator.runStream({
+        messages: [{ role: Role.USER, content: [{ type: 'text', text: 'Query' }] }],
+        llmPriority: [{ provider: 'openrouter', model: 'openai/gpt-4o-mini' }],
+        settings: {},
+        vectorContexts: [{ stores: ['test-store'], mode: 'auto' }]
+      } as any)) {
+        events.push(event);
+      }
+
+      expect(events.some(e => e.type === 'done')).toBe(true);
+      expect(logger.warning).toHaveBeenCalledWith(
+        'Vector context injection skipped due to error',
+        expect.objectContaining({
+          error: 'stream-boom',
+          mode: 'auto',
+          stores: ['test-store']
+        })
+      );
     });
 
     test('runStream injects vector context when mode is both', async () => {
@@ -386,10 +480,10 @@ describe('LLMCoordinator runStream', () => {
         messages: [{ role: Role.USER, content: [{ type: 'text', text: 'Query' }] }],
         llmPriority: [{ provider: 'openrouter', model: 'openai/gpt-4o-mini' }],
         settings: {},
-        vectorContext: {
+        vectorContexts: [{
           stores: ['test-store'],
           mode: 'both'
-        }
+        }]
       })) {
         events.push(event);
       }
@@ -408,15 +502,105 @@ describe('LLMCoordinator runStream', () => {
         messages: [{ role: Role.USER, content: [{ type: 'text', text: 'Query' }] }],
         llmPriority: [{ provider: 'openrouter', model: 'openai/gpt-4o-mini' }],
         settings: {},
-        vectorContext: {
+        vectorContexts: [{
           stores: ['test-store'],
           mode: 'tool'
-        }
+        }]
       })) {
         events.push(event);
       }
 
       expect(mockInjector.injectContext).not.toHaveBeenCalled();
+    });
+
+    test('runStream sets undefined tool vector contexts when alias maps are returned for auto-only configs', async () => {
+      const { coordinator } = createCoordinatorWithVectorSupport();
+
+      const setVectorContexts = jest.fn();
+      (coordinator as any).toolCoordinator = {
+        setVectorContexts,
+        routeAndInvoke: jest.fn(),
+        close: jest.fn()
+      };
+      jest.spyOn(coordinator as any, 'ensureToolCoordinator').mockResolvedValue((coordinator as any).toolCoordinator);
+      jest.spyOn(coordinator as any, 'collectTools').mockResolvedValue([
+        [],
+        [],
+        {},
+        { vector_search: { query: 'query' } }
+      ]);
+
+      for await (const _event of coordinator.runStream({
+        messages: [{ role: Role.USER, content: [{ type: 'text', text: 'Query' }] }],
+        llmPriority: [{ provider: 'openrouter', model: 'openai/gpt-4o-mini' }],
+        settings: {},
+        toolChoice: { type: 'single', name: 'ignored' },
+        vectorContexts: [{ stores: ['test-store'], mode: 'auto' }],
+        vectorRequestPolicy: { maxAutoContexts: 0 }
+      } as any)) {
+        // consume
+      }
+
+      expect(setVectorContexts).toHaveBeenCalledWith(
+        undefined,
+        expect.any(Object),
+        { vector_search: { query: 'query' } }
+      );
+    });
+
+    test('runStream logs and caps pre-delta buffer before first delta', async () => {
+      const { coordinator, compatModule } = createCoordinator({ withDetector: true });
+      const logger = createMockLogger();
+      (coordinator as any).logger = logger;
+
+      let parseCount = 0;
+      compatModule.parseStreamChunk.mockImplementation(() => {
+        parseCount += 1;
+        if (parseCount <= 300) {
+          return {
+            text: undefined,
+            toolEvents: [{ type: ToolCallEventType.TOOL_CALL_START, callId: String(parseCount), name: 'tool_sanitized' }]
+          };
+        }
+        return {
+          text: 'token',
+          toolEvents: []
+        };
+      });
+
+      (coordinator as any).llmManager.streamProvider = jest.fn().mockImplementation(async function* () {
+        for (let i = 0; i < 301; i += 1) {
+          yield { chunk: i };
+        }
+      });
+
+      for await (const _event of coordinator.runStream({
+        messages: [{ role: Role.USER, content: [{ type: 'text', text: 'hi' }] }],
+        llmPriority: [{ provider: 'provider', model: 'model' }],
+        settings: {}
+      } as any)) {
+        // consume
+      }
+
+      expect(logger.warning).toHaveBeenCalledWith(
+        'Pre-delta stream buffer reached cap; dropping oldest events',
+        { cap: 256 }
+      );
+    });
+
+    test('runStream throws fallback error when attempts fail with undefined error before first delta', async () => {
+      const { coordinator } = createCoordinator({ withDetector: false });
+      (coordinator as any).llmManager.streamProvider = jest.fn().mockImplementation(async function* () {
+        throw undefined;
+      });
+
+      const iterator = coordinator.runStream({
+        messages: [{ role: Role.USER, content: [{ type: 'text', text: 'hi' }] }],
+        llmPriority: [{ provider: 'provider', model: 'model' }],
+        settings: {}
+      } as any);
+
+      await expect(iterator.next()).rejects.toThrow('Streaming failed: all llmPriority attempts exhausted');
     });
 
     test('ensureVectorContextInjector lazily initializes injector', async () => {

--- a/tests/unit/coordinator/stream-coordinator.observability.test.ts
+++ b/tests/unit/coordinator/stream-coordinator.observability.test.ts
@@ -254,7 +254,11 @@ describe('StreamCoordinator observability', () => {
     expect(requestArg.messages[0].content).toHaveLength(2);
 
     const responseArg = (observability.exporter.recordLLMResponse as any).mock.calls[0][0];
-    expect(responseArg.toolCalls).toEqual([{ id: 'tool-1', name: 'echo.text' }]);
+    expect(responseArg.toolCalls).toEqual([{
+      id: 'tool-1',
+      name: 'echo.text',
+      arguments: { a: 1, api_key: '***cret' }
+    }]);
   });
 
   test('omits tool call arguments in observability when captureToolArgs is disabled', async () => {

--- a/tests/unit/coordinator/tool-coordinator-proxy.test.ts
+++ b/tests/unit/coordinator/tool-coordinator-proxy.test.ts
@@ -19,7 +19,7 @@ describe('coordinator toolCoordinator proxy', () => {
         constructor(...args: any[]) {
           ctorSpy(...args);
         }
-        setVectorContext() {}
+        setVectorContexts() {}
         async routeAndInvoke() {
           return { result: 'ok' };
         }
@@ -35,7 +35,7 @@ describe('coordinator toolCoordinator proxy', () => {
     } as any;
 
     const coordinator = new LLMCoordinator(registry);
-    (coordinator as any).activeToolSpec = { mcpServers: [], vectorContext: undefined } as any;
+    (coordinator as any).activeToolSpec = { mcpServers: [], vectorContexts: undefined } as any;
 
     const result = await (coordinator as any).toolCoordinator.routeAndInvoke(
       't',
@@ -47,5 +47,24 @@ describe('coordinator toolCoordinator proxy', () => {
     expect(result).toEqual({ result: 'ok' });
     expect(ctorSpy).toHaveBeenCalled();
   });
-});
 
+  test('setVectorContexts stores pending configs when impl is not initialized', async () => {
+    const { createToolCoordinatorProxy } = await import('@/modules/llm/internal/llm-coordinator/internal/tool-coordinator-proxy.ts');
+
+    const setPending = jest.fn();
+    const proxy = createToolCoordinatorProxy({
+      getRegistry: () => ({}) as any,
+      getToolCoordinatorImpl: () => undefined,
+      setPendingVectorContexts: setPending,
+      getActiveToolSpec: () => undefined,
+      ensureToolCoordinator: async () => undefined
+    });
+
+    proxy.setVectorContexts([{ stores: ['memory'], mode: 'tool' }], undefined, { vector_search: { q: 'query' } });
+
+    expect(setPending).toHaveBeenCalledWith({
+      configs: [{ stores: ['memory'], mode: 'tool' }],
+      aliasMaps: { vector_search: { q: 'query' } }
+    });
+  });
+});

--- a/tests/unit/coordinator/vector-contexts.test.ts
+++ b/tests/unit/coordinator/vector-contexts.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+  hasToolVectorContexts,
+  resolveAutoVectorContexts,
+  resolveVectorContexts,
+  resolveVectorRequestPolicy,
+  withTimeout
+} from '@/modules/llm/internal/llm-coordinator/internal/vector-contexts.ts';
+
+describe('coordinator/vector-contexts helpers', () => {
+  test('resolveVectorContexts filters invalid entries and keeps valid contexts', () => {
+    const resolved = resolveVectorContexts({
+      vectorContexts: [
+        null,
+        123,
+        {},
+        { stores: [] },
+        { stores: ['memory'], mode: 'auto' }
+      ]
+    } as any);
+
+    expect(resolved).toEqual([{ stores: ['memory'], mode: 'auto' }]);
+  });
+
+  test('resolveVectorRequestPolicy clamps values and falls back for non-finite values', () => {
+    const policy = resolveVectorRequestPolicy({
+      vectorRequestPolicy: {
+        maxAutoContexts: 9999,
+        perContextTimeoutMs: Number.POSITIVE_INFINITY,
+        totalAutoBudgetMs: 1,
+        maxInjectedPayloadBytes: -1
+      }
+    } as any);
+
+    expect(policy.maxAutoContexts).toBe(20);
+    // Infinity falls back to default, then min/max bounds apply inside helper.
+    expect(policy.perContextTimeoutMs).toBeGreaterThanOrEqual(50);
+    expect(policy.totalAutoBudgetMs).toBe(50);
+    expect(policy.maxInjectedPayloadBytes).toBe(64);
+  });
+
+  test('resolveAutoVectorContexts honors maxAutoContexts including zero', () => {
+    const contexts = [
+      { stores: ['s1'], mode: 'auto' },
+      { stores: ['s2'], mode: 'both' },
+      { stores: ['s3'], mode: 'tool' }
+    ] as any[];
+
+    expect(resolveAutoVectorContexts(contexts as any, { maxAutoContexts: 0 } as any)).toEqual([]);
+    expect(resolveAutoVectorContexts(contexts as any, { maxAutoContexts: 1 } as any)).toEqual([
+      { stores: ['s1'], mode: 'auto' }
+    ]);
+  });
+
+  test('hasToolVectorContexts detects tool and both modes only', () => {
+    expect(hasToolVectorContexts([{ stores: ['s1'], mode: 'auto' }] as any)).toBe(false);
+    expect(hasToolVectorContexts([{ stores: ['s1'], mode: 'both' }] as any)).toBe(true);
+  });
+
+  test('withTimeout returns original promise for non-positive/non-finite timeout and times out otherwise', async () => {
+    await expect(withTimeout(Promise.resolve('ok'), 0, 'noop')).resolves.toBe('ok');
+    await expect(withTimeout(Promise.resolve('still-ok'), Number.POSITIVE_INFINITY, 'noop')).resolves.toBe('still-ok');
+    await expect(withTimeout(new Promise(() => {}), 1, 'vector context injection')).rejects.toThrow(
+      'vector context injection timed out after 1ms'
+    );
+  });
+});

--- a/tests/unit/managers/llm-manager.observability.test.ts
+++ b/tests/unit/managers/llm-manager.observability.test.ts
@@ -88,7 +88,7 @@ describe('LLMManager observability', () => {
     expect(responseArg.toolCalls).toEqual([{ id: 'tc-1', name: 'test_tool' }]);
   });
 
-  test('callProvider omits tool args when captureToolArgs is missing (falls back to shipped default)', async () => {
+  test('callProvider records minimally redacted tool args when captureToolArgs is missing (falls back to shipped default)', async () => {
     const mockSDKResponse = {
       content: [{ type: 'text', text: 'SDK response' }],
       role: Role.ASSISTANT,
@@ -120,7 +120,7 @@ describe('LLMManager observability', () => {
     );
 
     const responseArg = (observability.exporter.recordLLMResponse as any).mock.calls[0][0];
-    expect(responseArg.toolCalls).toEqual([{ id: 'tc-1', name: 'test_tool' }]);
+    expect(responseArg.toolCalls).toEqual([{ id: 'tc-1', name: 'test_tool', arguments: { api_key: '***1234' } }]);
   });
 
   test('callProvider records LLM request when observability is enabled', async () => {
@@ -1111,8 +1111,8 @@ describe('LLMManager observability', () => {
     expect(observability.exporter.recordLLMRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: [
-          { name: 'test_tool', description: 'A test tool' },
-          { name: 'another_tool', description: 'Another tool' }
+          { name: 'test_tool', description: 'A test tool', parameters: {} },
+          { name: 'another_tool', description: 'Another tool', parameters: {} }
         ]
       })
     );

--- a/tests/unit/plugins/modules/noop-terminal.test.ts
+++ b/tests/unit/plugins/modules/noop-terminal.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { handle } from '@/plugins/modules/noop-terminal/index.ts';
+
+describe('plugins/modules/noop-terminal', () => {
+  test('returns success payload', async () => {
+    await expect(
+      handle({
+        toolName: 'noop.terminal',
+        args: { any: 'value' }
+      } as any)
+    ).resolves.toEqual({ result: { ok: true } });
+  });
+});

--- a/tests/unit/plugins/observability-compat/langfuse.test.ts
+++ b/tests/unit/plugins/observability-compat/langfuse.test.ts
@@ -124,7 +124,7 @@ describe('LangfuseCompat (OTLP)', () => {
       expect(String(attrs['langfuse.observation.input'] || '')).toContain('Hello');
       expect(String(attrs['langfuse.observation.output'] || '')).toContain('Hello there!');
       expect(String(attrs['langfuse.observation.output'] || '')).toContain('test.echo');
-      expect(attrs['langfuse.trace.name']).toBe('corr-123');
+      expect(attrs['langfuse.trace.name']).toBe('batch-xyz');
       expect(attrs['llm.adapter.trace_id']).toBe(traceId);
       expect(attrs['llm.adapter.session_id']).toBe('session-456');
       expect(attrs['llm.adapter.correlation_id']).toBe('corr-123');
@@ -135,6 +135,23 @@ describe('LangfuseCompat (OTLP)', () => {
 
       const output = JSON.parse(String(attrs['langfuse.observation.output'] || '{}'));
       expect(output.rawResponse).toEqual(responseEvent.rawResponse);
+    });
+
+    it('uses trimmed metadata.step as the response span name when provided', () => {
+      compat.buildBatch([requestEvent], mockManifest, { eventIds: ['event-req-step'] } as any);
+
+      const steppedResponse = {
+        ...responseEvent,
+        metadata: {
+          ...(responseEvent.metadata ?? {}),
+          step: '  retrieval.phase  '
+        }
+      } as any;
+
+      const batch = compat.buildBatch([steppedResponse], mockManifest, { eventIds: ['event-resp-step'] } as any);
+      const spans = (batch.payload as any)?.spans ?? [];
+      expect(spans).toHaveLength(1);
+      expect(spans[0]?.name).toBe('retrieval.phase');
     });
 
     it('maps tool_execution events as spans with input/output and parent span linkage', () => {
@@ -168,7 +185,7 @@ describe('LangfuseCompat (OTLP)', () => {
 
       const attrs = span.attributes ?? {};
       expect(attrs['langfuse.observation.type']).toBe('span');
-      expect(attrs['langfuse.trace.name']).toBe('corr-123');
+      expect(attrs['langfuse.trace.name']).toBe('batch-xyz');
       expect(attrs['llm.adapter.tool_name']).toBe('test.echo');
       expect(attrs['llm.adapter.tool_call_id']).toBe('call-1');
 
@@ -431,13 +448,15 @@ describe('LangfuseCompat (OTLP)', () => {
       const updateBatch = compat.buildBatch([{ ...updateEvent, type: 'trace_update' } as any], mockManifest, { eventIds: ['event-update'] } as any);
       const updateSpans = (updateBatch.payload as any)?.spans ?? [];
       expect(updateSpans).toHaveLength(1);
-      expect(updateSpans[0].attributes?.['langfuse.trace.name']).toBe('corr-updated');
+      expect(updateSpans[0].attributes?.['langfuse.trace.name']).toBe('batch-xyz');
+      expect(updateSpans[0].attributes?.['llm.adapter.correlation_id']).toBe('corr-updated');
 
       const respBatch = compat.buildBatch([responseEvent], mockManifest, ctxResp);
       const spans = (respBatch.payload as any)?.spans ?? [];
       expect(spans).toHaveLength(1);
       const attrs = spans[0]?.attributes ?? {};
-      expect(attrs['langfuse.trace.name']).toBe('corr-updated');
+      expect(attrs['langfuse.trace.name']).toBe('batch-xyz');
+      expect(attrs['llm.adapter.correlation_id']).toBe('corr-updated');
       expect(attrs['langfuse.trace.tags']).toEqual(['t2', 't3']);
     });
 
@@ -768,7 +787,7 @@ describe('LangfuseCompat (OTLP)', () => {
 
       const attrs = spans[0]?.attributes ?? {};
       expect(attrs['llm.adapter.correlation_id']).toBeUndefined();
-      expect(attrs['langfuse.trace.name']).toBeUndefined();
+      expect(attrs['langfuse.trace.name']).toBe('session-456');
       expect(attrs['llm.adapter.batch_id']).toBe('session-456');
     });
 

--- a/tests/unit/plugins/observability-compat/sentry.test.ts
+++ b/tests/unit/plugins/observability-compat/sentry.test.ts
@@ -284,7 +284,7 @@ describe('SentryCompat (envelopes + OTLP traces)', () => {
       const attrs = span.attributes ?? {};
       expect(attrs['llm.adapter.trace_id']).toBe(traceId);
       expect(attrs['llm.adapter.session_id']).toBe('session-456');
-      expect(attrs['llm.adapter.correlation_id']).toBe('corr-123');
+      expect(attrs['llm.adapter.correlation_id']).toBe('batch-xyz');
       expect(attrs['llm.adapter.batch_id']).toBe('batch-xyz');
       expect(attrs['llm.adapter.provider']).toBe('provider-a');
       expect(attrs['llm.adapter.model']).toBe('model-a');
@@ -335,7 +335,7 @@ describe('SentryCompat (envelopes + OTLP traces)', () => {
 
       const respUpdated = compat.buildBatch([responseEvent], mockManifest, { eventIds: ['resp'], providerConfig: { enableOtlp: true } } as any);
       const updatedAttrs = (respUpdated.payload as any)?.spans?.[0]?.attributes ?? {};
-      expect(updatedAttrs['llm.adapter.correlation_id']).toBe('corr-updated');
+      expect(updatedAttrs['llm.adapter.correlation_id']).toBe('batch-xyz');
       expect(updatedAttrs['llm.adapter.tags']).toEqual(['updated']);
     });
 
@@ -373,7 +373,7 @@ describe('SentryCompat (envelopes + OTLP traces)', () => {
         { eventIds: ['sig'] } as any
       );
       const { payload: signalEvent } = parseEnvelope((signalBatch.payload as any).envelopes[0].body);
-      expect(signalEvent.tags['llm.adapter.correlation_id']).toBe('corr-updated');
+      expect(signalEvent.tags['llm.adapter.correlation_id']).toBe('batch-xyz');
       expect(signalEvent.tags['llm.adapter.tags']).toBe('updated');
     });
 

--- a/tests/unit/utils/server/spec-validator.test.ts
+++ b/tests/unit/utils/server/spec-validator.test.ts
@@ -21,6 +21,17 @@ describe('utils/server assertValidSpec', () => {
     expect(() => assertValidSpec({ messages: [] } as any)).toThrow(/validation/i);
   });
 
+  test('rejects deprecated vectorContext field with migration details', () => {
+    expect(() =>
+      assertValidSpec({
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+        llmPriority: [{ provider: 'p', model: 'm' }],
+        settings: {},
+        vectorContext: { stores: ['memory'], mode: 'auto' }
+      } as any)
+    ).toThrow(/vectorContext/);
+  });
+
   test('accepts toolChoice="required" string shorthand', () => {
     expect(() =>
       assertValidSpec({

--- a/tests/unit/utils/tool-coordinator.internal-helpers.test.ts
+++ b/tests/unit/utils/tool-coordinator.internal-helpers.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+  closeVectorRuntime,
+  ensureVectorRuntime
+} from '@/modules/tools/internal/tool-coordinator/internal/vector-runtime.ts';
+import {
+  computeVectorSearchState,
+  getVectorSearchEntryForToolName,
+  translateVectorSearchArgs
+} from '@/modules/tools/internal/tool-coordinator/internal/vector-search.ts';
+
+describe('utils/tool-coordinator internal helpers', () => {
+  test('ensureVectorRuntime lazily initializes managers', async () => {
+    const state: any = {};
+    const runtime = await ensureVectorRuntime(state, {} as any);
+    expect(runtime.embeddingManager).toBeDefined();
+    expect(runtime.vectorManager).toBeDefined();
+  });
+
+  test('closeVectorRuntime swallows closeAll failures', async () => {
+    const state: any = {
+      vectorManager: {
+        closeAll: async () => {
+          throw new Error('close failure');
+        }
+      }
+    };
+
+    await expect(closeVectorRuntime(state)).resolves.toBeUndefined();
+  });
+
+  test('computeVectorSearchState skips invalid configs and retains valid entries', () => {
+    const byToolName = computeVectorSearchState(
+      [null as any, { stores: ['memory'], mode: 'tool', toolName: 'semantic_search' } as any],
+      { semantic_search: { k: 'topK' } }
+    );
+
+    expect(byToolName.has('semantic_search')).toBe(true);
+    expect(byToolName.get('semantic_search')?.aliasMap).toEqual({ k: 'topK' });
+  });
+
+  test('getVectorSearchEntryForToolName only returns tool/both entries', () => {
+    const map = computeVectorSearchState([
+      { stores: ['memory'], mode: 'auto', toolName: 'auto_search' } as any,
+      { stores: ['memory'], mode: 'both', toolName: 'both_search' } as any
+    ]);
+
+    expect(getVectorSearchEntryForToolName({ toolName: 'auto_search', byToolName: map })).toBeUndefined();
+    expect(getVectorSearchEntryForToolName({ toolName: 'both_search', byToolName: map })).toBeDefined();
+  });
+
+  test('translateVectorSearchArgs returns original args without alias map and remaps with aliases', () => {
+    const args = { q: 'query', k: 3 };
+    expect(translateVectorSearchArgs(args, undefined)).toBe(args);
+    expect(translateVectorSearchArgs(args, { q: 'query', k: 'topK' })).toEqual({
+      query: 'query',
+      topK: 3
+    });
+  });
+});

--- a/tests/unit/utils/tool-coordinator.vector-search.test.ts
+++ b/tests/unit/utils/tool-coordinator.vector-search.test.ts
@@ -37,7 +37,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
   });
 
   describe('isVectorSearchTool', () => {
-    test('returns false when no vectorContext configured', () => {
+    test('returns false when no vectorContexts configured', () => {
       const coordinator = new ToolCoordinator([]);
       const result = (coordinator as any).isVectorSearchTool('vector_search');
       expect(result).toBe(false);
@@ -50,7 +50,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry
       });
 
@@ -65,7 +65,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry
       });
 
@@ -80,7 +80,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry
       });
 
@@ -96,7 +96,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry
       });
 
@@ -111,7 +111,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry
       });
 
@@ -119,17 +119,17 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
     });
   });
 
-  describe('setVectorContext', () => {
+  describe('setVectorContexts', () => {
     test('updates vector context and tool name', () => {
       const coordinator = new ToolCoordinator([]);
 
       expect((coordinator as any).isVectorSearchTool('vector_search')).toBe(false);
 
-      coordinator.setVectorContext({
+      coordinator.setVectorContexts([{
         stores: ['docs'],
         mode: 'tool',
         toolName: 'custom_search'
-      }, mockRegistry);
+      }], mockRegistry);
 
       expect((coordinator as any).isVectorSearchTool('custom_search')).toBe(true);
       expect((coordinator as any).isVectorSearchTool('vector_search')).toBe(false);
@@ -137,13 +137,13 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
 
     test('clears vector context when set to undefined', () => {
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: { stores: ['docs'], mode: 'tool' },
+        vectorContexts: [{ stores: ['docs'], mode: 'tool' }],
         registry: mockRegistry
       });
 
       expect((coordinator as any).isVectorSearchTool('vector_search')).toBe(true);
 
-      coordinator.setVectorContext(undefined);
+      coordinator.setVectorContexts(undefined);
 
       expect((coordinator as any).isVectorSearchTool('vector_search')).toBe(false);
     });
@@ -151,14 +151,13 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
     test('uses default tool name when config has no toolName', () => {
       const coordinator = new ToolCoordinator([]);
 
-      coordinator.setVectorContext({
+      coordinator.setVectorContexts([{
         stores: ['docs'],
         mode: 'tool'
         // No toolName specified - should default to 'vector_search'
-      }, mockRegistry);
+      }], mockRegistry);
 
       expect((coordinator as any).isVectorSearchTool('vector_search')).toBe(true);
-      expect((coordinator as any).vectorToolName).toBe('vector_search');
     });
   });
 
@@ -178,7 +177,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry
       });
 
@@ -218,7 +217,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry
       });
 
@@ -253,7 +252,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([processRoute as any], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry
       });
 
@@ -288,7 +287,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config
+        vectorContexts: [config]
         // No registry!
       });
 
@@ -318,7 +317,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry
       });
 
@@ -368,9 +367,9 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry,
-        vectorSearchAliasMap: aliasMap
+        vectorSearchAliasMaps: { vector_search: aliasMap }
       });
 
       await coordinator.routeAndInvoke(
@@ -410,9 +409,9 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry,
-        vectorSearchAliasMap: aliasMap
+        vectorSearchAliasMaps: { vector_search: aliasMap }
       });
 
       // Using canonical name directly (not in alias map as key)
@@ -454,9 +453,9 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry,
-        vectorSearchAliasMap: aliasMap
+        vectorSearchAliasMaps: { vector_search: aliasMap }
       });
 
       await coordinator.routeAndInvoke(
@@ -491,7 +490,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry
         // No aliasMap
       });
@@ -512,7 +511,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       );
     });
 
-    test('setVectorContext updates alias map', async () => {
+    test('setVectorContexts updates alias map', async () => {
       mockExecuteVectorSearch.mockResolvedValue({
         success: true,
         results: [],
@@ -522,7 +521,7 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       mockFormatVectorSearchResults.mockReturnValue('No results found');
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: { stores: ['docs'], mode: 'tool' },
+        vectorContexts: [{ stores: ['docs'], mode: 'tool' }],
         registry: mockRegistry
       });
 
@@ -532,10 +531,10 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
         results: 'topK'
       };
 
-      coordinator.setVectorContext(
-        { stores: ['docs'], mode: 'tool' },
+      coordinator.setVectorContexts(
+        [{ stores: ['docs'], mode: 'tool' }],
         mockRegistry,
-        newAliasMap
+        { vector_search: newAliasMap }
       );
 
       await coordinator.routeAndInvoke(
@@ -575,9 +574,9 @@ describe('utils/tools/tool-coordinator vector search integration', () => {
       };
 
       const coordinator = new ToolCoordinator([], undefined, {
-        vectorContext: config,
+        vectorContexts: [config],
         registry: mockRegistry,
-        vectorSearchAliasMap: aliasMap
+        vectorSearchAliasMaps: { vector_search: aliasMap }
       });
 
       await coordinator.routeAndInvoke(

--- a/tests/unit/utils/tools/tool-discovery.test.ts
+++ b/tests/unit/utils/tools/tool-discovery.test.ts
@@ -522,6 +522,54 @@ describe('utils/tools/tool-discovery', () => {
     expect(result.tools).toEqual([]);
   });
 
+  test('collectTools skips non-object vectorContexts entries', async () => {
+    const spec = {
+      messages: [],
+      llmPriority: [],
+      settings: {},
+      vectorContexts: [null, { stores: ['memory'], mode: 'tool' }]
+    } as unknown as LLMCallSpec;
+
+    const registry = {
+      getTool: jest.fn()
+    } as unknown as PluginRegistry;
+
+    const result = await collectTools({
+      spec,
+      registry
+    });
+
+    expect(result.tools.some(tool => tool.name === 'vector_search')).toBe(true);
+    expect(result.vectorSearchAliasMaps?.vector_search).toBeDefined();
+  });
+
+  test('collectTools rejects vector tool name collisions', async () => {
+    const spec = {
+      messages: [],
+      llmPriority: [],
+      settings: {},
+      tools: [
+        {
+          name: 'vector_search',
+          description: 'existing tool',
+          parametersJsonSchema: { type: 'object' }
+        }
+      ],
+      vectorContexts: [{ stores: ['memory'], mode: 'tool' }]
+    } as unknown as LLMCallSpec;
+
+    const registry = {
+      getTool: jest.fn()
+    } as unknown as PluginRegistry;
+
+    await expect(
+      collectTools({
+        spec,
+        registry
+      })
+    ).rejects.toThrow("Vector search tool name 'vector_search' conflicts with an existing tool.");
+  });
+
   describe('shouldCreateVectorSearchTool', () => {
     test('returns true for tool mode', () => {
       expect(shouldCreateVectorSearchTool('tool')).toBe(true);
@@ -1038,15 +1086,15 @@ describe('utils/tools/tool-discovery', () => {
     });
   });
 
-  test('collectTools creates vector_search tool when vectorContext.mode is tool', async () => {
+  test('collectTools creates vector_search tool when vectorContexts[].mode is tool', async () => {
     const spec = {
       messages: [],
       llmPriority: [],
       settings: {},
-      vectorContext: {
+      vectorContexts: [{
         stores: ['qdrant-cloud'],
         mode: 'tool'
-      }
+      }]
     } as unknown as LLMCallSpec;
 
     const registry = {
@@ -1062,16 +1110,16 @@ describe('utils/tools/tool-discovery', () => {
     expect(result.tools[0].name).toBe('vector_search');
   });
 
-  test('collectTools creates vector_search tool when vectorContext.mode is both', async () => {
+  test('collectTools creates vector_search tool when vectorContexts[].mode is both', async () => {
     const spec = {
       messages: [],
       llmPriority: [],
       settings: {},
-      vectorContext: {
+      vectorContexts: [{
         stores: ['memory'],
         mode: 'both',
         toolName: 'context_search'
-      }
+      }]
     } as unknown as LLMCallSpec;
 
     const registry = {
@@ -1092,10 +1140,10 @@ describe('utils/tools/tool-discovery', () => {
       messages: [],
       llmPriority: [],
       settings: {},
-      vectorContext: {
+      vectorContexts: [{
         stores: ['memory'],
         mode: 'auto'
-      }
+      }]
     } as unknown as LLMCallSpec;
 
     const registry = {


### PR DESCRIPTION
## Summary
This PR merges Optimy parity features into `universal_llm_adapter` with a hard API cleanup and production guardrails:

- `vectorContext` removed (hard break), `vectorContexts` only.
- Multi-context vector support across coordinator + tool routing.
- Request-level vector guardrails and embedding reuse.
- Streaming pre-first-delta failover with bounded pre-delta buffering.
- Langfuse naming + high-fidelity serialization parity updates.
- Noop terminal module + process route assets.
- Package-root dotenv isolation fix.

## Key implementation details
- Added coordinator internal helpers for vector contexts/policy resolution.
- Updated non-stream and stream coordinator flows for multi-context behavior.
- Updated tool discovery to produce per-context vector tools and alias maps.
- Updated tool coordinator to route by `toolName -> { config, aliasMap }` and reuse vector runtime objects.
- Added validator migration error when legacy `vectorContext` is used.

## Tests
- `npm test -- --coverage` (passes, 100% statements/branches/functions/lines)
- `npm run test:live:openrouter -- --transport=both` (passes)
- `npm run test:live:realtime -- --transport=both` (passes)
- `npm run test:live` blocked by missing required env var: `OPENAI_ASSISTANTS_ASSISTANT_ID`

## Notes
- Included live test enhancement proving two vector stores in one request path (`tests/live/test-files/18-vector-auto-inject.live.test.ts`).
