### PR TITLE
Issue #1300 Langfuse level-specific signal span names with Core payload compatibility

### DIFF
--- a/plugins/observability-compat/langfuse/README.md
+++ b/plugins/observability-compat/langfuse/README.md
@@ -86,6 +86,17 @@ LLM events are mapped onto OTLP spans that Langfuse interprets as observations:
 
 Events with matching `traceId` are grouped into a single trace in Langfuse.
 
+### Signal and Trace Update Mapping
+
+Telemetry `signal` submissions are exported as Langfuse `event` observations with level-specific span names:
+
+- `ERROR` -> `llm.telemetry.error`
+- `WARNING` -> `llm.telemetry.warning`
+- `DEBUG` -> `llm.telemetry.debug`
+- fallback (all other levels) -> `llm.telemetry.signal`
+
+`trace_update` submissions remain exported as `event` observations using `llm.telemetry.event` to preserve trace context update behavior.
+
 ## Cost Ingestion (OTLP)
 
 This compat emits **token usage** and **cost** as separate OTLP attributes:

--- a/plugins/observability-compat/langfuse/internal/langfuse-helpers.ts
+++ b/plugins/observability-compat/langfuse/internal/langfuse-helpers.ts
@@ -33,6 +33,14 @@ export function normalizeLangfuseObservationLevel(level: unknown): 'DEBUG' | 'DE
   return 'DEFAULT';
 }
 
+export function resolveLangfuseSignalSpanName(level: unknown): string {
+  const normalized = normalizeLangfuseObservationLevel(level);
+  if (normalized === 'ERROR') return 'llm.telemetry.error';
+  if (normalized === 'WARNING') return 'llm.telemetry.warning';
+  if (normalized === 'DEBUG') return 'llm.telemetry.debug';
+  return 'llm.telemetry.signal';
+}
+
 export function buildCommonTraceAttributes(options: {
   traceId: string;
   sessionId?: string;

--- a/plugins/observability-compat/langfuse/internal/langfuse.ts
+++ b/plugins/observability-compat/langfuse/internal/langfuse.ts
@@ -32,6 +32,7 @@ import {
   isRequestEvent,
   isResponseEvent,
   normalizeLangfuseObservationLevel,
+  resolveLangfuseSignalSpanName,
   resolveMaxAttributeBytes,
   resolveTraceContext,
   resolveIngestionUrl
@@ -244,15 +245,16 @@ export class LangfuseCompat implements IObservabilityCompat {
 
         const envelopeId = getEnvelopeId(eventIds, i, `signal-${i}`);
         const endTimeIso = eventTimestampToIso(signalEvent as any);
+        const normalizedSignalLevel = normalizeLangfuseObservationLevel(signalEvent.level);
 
         spans.push({
           traceIdHex: deriveOtlpTraceIdHex(String(signalEvent.traceId)),
           spanIdHex: deriveOtlpSpanIdHex(String(envelopeId)),
           ...(signalEvent.generationId ? { parentSpanIdHex: deriveOtlpSpanIdHex(String(signalEvent.generationId)) } : {}),
-          name: DEFAULT_EVENT_SPAN_NAME,
+          name: resolveLangfuseSignalSpanName(signalEvent.level),
           startTimeIso: endTimeIso,
           endTimeIso,
-          status: signalEvent.level === 'error'
+          status: normalizedSignalLevel === 'ERROR'
             ? { code: 'ERROR', message: String(signalEvent.message || 'error') }
             : { code: 'OK' },
           attributes: {
@@ -265,7 +267,7 @@ export class LangfuseCompat implements IObservabilityCompat {
               batchId
             }),
             'langfuse.observation.type': 'event',
-            'langfuse.observation.level': normalizeLangfuseObservationLevel(signalEvent.level),
+            'langfuse.observation.level': normalizedSignalLevel,
             ...(signalEvent.message ? { 'langfuse.observation.status_message': String(signalEvent.message) } : {}),
             'langfuse.observation.output': safeJsonStringify(
               {

--- a/tests/unit/core/telemetry-submit.test.ts
+++ b/tests/unit/core/telemetry-submit.test.ts
@@ -241,4 +241,132 @@ describe('modules/observability/internal/telemetry-submit', () => {
       expect(evt.metadata.access_token).toBe('***1234');
     });
   });
+
+  test('records full Core-like signal payload fields unchanged apart from normalization/redaction', async () => {
+    await jest.isolateModulesAsync(async () => {
+      const recordSignal = jest.fn(() => ({ eventId: 'evt_core_signal', queued: true }));
+      const recordTraceUpdate = jest.fn();
+
+      const createObservabilityRuntime = jest.fn(async () => ({
+        exporter: { recordSignal, recordTraceUpdate },
+        baseTraceId: 'trace_core_signal',
+        sessionId: 'sess_core'
+      }));
+
+      jest.unstable_mockModule('../../../modules/observability/internal/runtime.js', () => ({
+        createObservabilityRuntime
+      }));
+
+      const { submitTelemetry } = await import('@/modules/observability/index.ts');
+      const registry = {};
+
+      const payload: any = {
+        type: 'signal',
+        traceId: ' trace_core_signal ',
+        generationId: ' gen_core_123 ',
+        timestampMs: 1739060000000.9,
+        level: 'warning',
+        message: 'tool fallback used',
+        source: 'llm_adapter_client',
+        code: 'tool_call_budget_exhausted',
+        tags: ['subassistant'],
+        metadata: {
+          assistant: 'inventory',
+          apiKey: 'secret1234'
+        },
+        observability: {
+          enabled: true,
+          traceId: 'ignored',
+          targets: [{ provider: 'obs-a', export: { signals: true } }]
+        }
+      };
+
+      const result = await submitTelemetry(registry as any, payload);
+      expect(result).toEqual({ traceId: 'trace_core_signal', eventId: 'evt_core_signal', queued: true });
+
+      expect(createObservabilityRuntime).toHaveBeenCalledWith(
+        registry as any,
+        expect.objectContaining({
+          enabled: true,
+          traceId: 'trace_core_signal',
+          targets: [{ provider: 'obs-a', export: { signals: true } }]
+        }),
+        expect.objectContaining({ sessionIdFallback: 'batch' })
+      );
+
+      const event = recordSignal.mock.calls[0]?.[0] as any;
+      expect(event.traceId).toBe('trace_core_signal');
+      expect(event.generationId).toBe('gen_core_123');
+      expect(event.sessionId).toBe('sess_core');
+      expect(event.timestampMs).toBe(1739060000000);
+      expect(event.level).toBe('warning');
+      expect(event.message).toBe('tool fallback used');
+      expect(event.source).toBe('llm_adapter_client');
+      expect(event.code).toBe('tool_call_budget_exhausted');
+      expect(event.tags).toEqual(['subassistant']);
+      expect(event.metadata.assistant).toBe('inventory');
+      expect(event.metadata.apiKey).toBe('***1234');
+    });
+  });
+
+  test('records full Core-like trace_update payload fields unchanged apart from normalization/redaction', async () => {
+    await jest.isolateModulesAsync(async () => {
+      const recordTraceUpdate = jest.fn(() => ({ eventId: 'evt_core_update', queued: true }));
+      const recordSignal = jest.fn();
+
+      const createObservabilityRuntime = jest.fn(async () => ({
+        exporter: { recordSignal, recordTraceUpdate },
+        baseTraceId: 'trace_core_update',
+        sessionId: 'sess_core_update'
+      }));
+
+      jest.unstable_mockModule('../../../modules/observability/internal/runtime.js', () => ({
+        createObservabilityRuntime
+      }));
+
+      const { submitTelemetry } = await import('@/modules/observability/index.ts');
+      const registry = {};
+
+      const payload: any = {
+        type: 'trace_update',
+        traceId: ' trace_core_update ',
+        generationId: ' gen_core_456 ',
+        timestampMs: 1739060001000.9,
+        tags: ['subassistant', 'fn_inventory_search'],
+        metadata: {
+          source: 'llm_adapter_client',
+          step: 'subassistant',
+          accessToken: 'abcd'
+        },
+        observability: {
+          enabled: true,
+          traceId: 'ignored',
+          targets: [{ provider: 'obs-a', export: { traceUpdates: true } }]
+        }
+      };
+
+      const result = await submitTelemetry(registry as any, payload);
+      expect(result).toEqual({ traceId: 'trace_core_update', eventId: 'evt_core_update', queued: true });
+
+      expect(createObservabilityRuntime).toHaveBeenCalledWith(
+        registry as any,
+        expect.objectContaining({
+          enabled: true,
+          traceId: 'trace_core_update',
+          targets: [{ provider: 'obs-a', export: { traceUpdates: true } }]
+        }),
+        expect.objectContaining({ sessionIdFallback: 'batch' })
+      );
+
+      const event = recordTraceUpdate.mock.calls[0]?.[0] as any;
+      expect(event.traceId).toBe('trace_core_update');
+      expect(event.generationId).toBe('gen_core_456');
+      expect(event.sessionId).toBe('sess_core_update');
+      expect(event.timestampMs).toBe(1739060001000);
+      expect(event.tags).toEqual(['subassistant', 'fn_inventory_search']);
+      expect(event.metadata.source).toBe('llm_adapter_client');
+      expect(event.metadata.step).toBe('subassistant');
+      expect(event.metadata.accessToken).toBe('***');
+    });
+  });
 });

--- a/tests/unit/plugins/observability-compat/langfuse.test.ts
+++ b/tests/unit/plugins/observability-compat/langfuse.test.ts
@@ -349,6 +349,7 @@ describe('LangfuseCompat (OTLP)', () => {
 
       const span = spans[0];
       expect(span.parentSpanIdHex).toBe(deriveOtlpSpanIdHex(generationId));
+      expect(span.name).toBe('llm.telemetry.warning');
       const attrs = span.attributes ?? {};
       expect(attrs['langfuse.observation.type']).toBe('event');
       expect(attrs['langfuse.observation.level']).toBe('WARNING');
@@ -376,6 +377,7 @@ describe('LangfuseCompat (OTLP)', () => {
 
       const errorMsgSpan = errorMsgSpans[0];
       expect(errorMsgSpan.parentSpanIdHex).toBeUndefined();
+      expect(errorMsgSpan.name).toBe('llm.telemetry.error');
       expect(errorMsgSpan.status).toEqual({ code: 'ERROR', message: 'boom' });
       expect(errorMsgSpan.attributes?.['langfuse.observation.level']).toBe('ERROR');
       expect(errorMsgSpan.attributes?.['langfuse.observation.status_message']).toBe('boom');
@@ -395,6 +397,7 @@ describe('LangfuseCompat (OTLP)', () => {
       expect(errorNoMsgSpans).toHaveLength(1);
 
       const errorNoMsgSpan = errorNoMsgSpans[0];
+      expect(errorNoMsgSpan.name).toBe('llm.telemetry.error');
       expect(errorNoMsgSpan.status).toEqual({ code: 'ERROR', message: 'error' });
 
       const errorNoMsgAttrs = errorNoMsgSpan.attributes ?? {};
@@ -403,6 +406,21 @@ describe('LangfuseCompat (OTLP)', () => {
 
       const errorNoMsgOutput = JSON.parse(String(errorNoMsgAttrs['langfuse.observation.output'] || '{}'));
       expect(errorNoMsgOutput).toEqual({ level: 'error', message: '', stack: 'stack' });
+
+      const signalErrorUpperTrimmed: any = {
+        type: 'signal',
+        traceId,
+        generationId,
+        timestampMs: 17040672007015,
+        level: ' Error ',
+        message: 'upper error'
+      };
+
+      const errorUpperBatch = compat.buildBatch([signalErrorUpperTrimmed], mockManifest, { eventIds: ['event-signal-error-upper'] } as any);
+      const errorUpperSpan = (errorUpperBatch.payload as any)?.spans?.[0];
+      expect(errorUpperSpan.name).toBe('llm.telemetry.error');
+      expect(errorUpperSpan.status).toEqual({ code: 'ERROR', message: 'upper error' });
+      expect(errorUpperSpan.attributes?.['langfuse.observation.level']).toBe('ERROR');
 
       const signalDebug: any = {
         type: 'signal',
@@ -414,7 +432,9 @@ describe('LangfuseCompat (OTLP)', () => {
       };
 
       const debugBatch = compat.buildBatch([signalDebug], mockManifest, { eventIds: ['event-signal-debug'] } as any);
-      const debugAttrs = (debugBatch.payload as any)?.spans?.[0]?.attributes ?? {};
+      const debugSpan = (debugBatch.payload as any)?.spans?.[0];
+      const debugAttrs = debugSpan?.attributes ?? {};
+      expect(debugSpan?.name).toBe('llm.telemetry.debug');
       expect(debugAttrs['langfuse.observation.level']).toBe('DEBUG');
 
       const signalWarn: any = {
@@ -427,8 +447,25 @@ describe('LangfuseCompat (OTLP)', () => {
       };
 
       const warnBatch = compat.buildBatch([signalWarn], mockManifest, { eventIds: ['event-signal-warn'] } as any);
-      const warnAttrs = (warnBatch.payload as any)?.spans?.[0]?.attributes ?? {};
+      const warnSpan = (warnBatch.payload as any)?.spans?.[0];
+      const warnAttrs = warnSpan?.attributes ?? {};
+      expect(warnSpan?.name).toBe('llm.telemetry.warning');
       expect(warnAttrs['langfuse.observation.level']).toBe('WARNING');
+
+      const signalInfo: any = {
+        type: 'signal',
+        traceId,
+        generationId,
+        timestampMs: 17040672007035,
+        level: 'info',
+        message: 'info'
+      };
+
+      const infoBatch = compat.buildBatch([signalInfo], mockManifest, { eventIds: ['event-signal-info'] } as any);
+      const infoSpan = (infoBatch.payload as any)?.spans?.[0];
+      const infoAttrs = infoSpan?.attributes ?? {};
+      expect(infoSpan?.name).toBe('llm.telemetry.signal');
+      expect(infoAttrs['langfuse.observation.level']).toBe('DEFAULT');
 
       const signalNonString: any = {
         type: 'signal',
@@ -440,7 +477,9 @@ describe('LangfuseCompat (OTLP)', () => {
       };
 
       const nonStringBatch = compat.buildBatch([signalNonString], mockManifest, { eventIds: ['event-signal-non-string'] } as any);
-      const nonStringAttrs = (nonStringBatch.payload as any)?.spans?.[0]?.attributes ?? {};
+      const nonStringSpan = (nonStringBatch.payload as any)?.spans?.[0];
+      const nonStringAttrs = nonStringSpan?.attributes ?? {};
+      expect(nonStringSpan?.name).toBe('llm.telemetry.signal');
       expect(nonStringAttrs['langfuse.observation.level']).toBe('DEFAULT');
     });
 
@@ -462,6 +501,7 @@ describe('LangfuseCompat (OTLP)', () => {
       const updateBatch = compat.buildBatch([{ ...updateEvent, type: 'trace_update' } as any], mockManifest, { eventIds: ['event-update'] } as any);
       const updateSpans = (updateBatch.payload as any)?.spans ?? [];
       expect(updateSpans).toHaveLength(1);
+      expect(updateSpans[0].name).toBe('llm.telemetry.event');
       expect(updateSpans[0].attributes?.['langfuse.trace.name']).toBe('batch-xyz');
       expect(updateSpans[0].attributes?.['llm.adapter.correlation_id']).toBe('corr-updated');
 
@@ -545,6 +585,7 @@ describe('LangfuseCompat (OTLP)', () => {
       const uncachedBatch = compat.buildBatch([uncachedEmptyUpdate], mockManifest, { eventIds: ['update-empty'] } as any);
       const uncachedSpans = (uncachedBatch.payload as any)?.spans ?? [];
       expect(uncachedSpans).toHaveLength(1);
+      expect(uncachedSpans[0].name).toBe('llm.telemetry.event');
 
       const uncachedAttrs = uncachedSpans[0]?.attributes ?? {};
       expect(uncachedAttrs['langfuse.trace.metadata.payload']).toBeUndefined();

--- a/tests/unit/utils/server/spec-validator.test.ts
+++ b/tests/unit/utils/server/spec-validator.test.ts
@@ -115,6 +115,32 @@ describe('utils/server assertValidSpec', () => {
     ).not.toThrow();
   });
 
+  test('assertValidTelemetrySubmission accepts full Core-like signal payload with timestampMs', () => {
+    expect(() =>
+      assertValidTelemetrySubmission({
+        type: 'signal',
+        traceId: 'trace_core_signal',
+        generationId: 'gen_123',
+        timestampMs: 1739060000000,
+        level: 'warning',
+        message: 'tool fallback used',
+        source: 'llm_adapter_client',
+        code: 'tool_call_budget_exhausted',
+        metadata: {
+          assistant: 'inventory',
+          correlationId: 'corr_abc'
+        },
+        observability: {
+          enabled: true,
+          targets: [
+            { provider: 'obs-a', export: { signals: true } },
+            { provider: 'obs-b', export: { signals: true } }
+          ]
+        }
+      } as any)
+    ).not.toThrow();
+  });
+
   test('assertValidTelemetrySubmission rejects whitespace-only traceId', () => {
     expect(() =>
       assertValidTelemetrySubmission({
@@ -131,6 +157,28 @@ describe('utils/server assertValidSpec', () => {
       assertValidTelemetrySubmission({
         type: 'trace_update',
         traceId: 'trace_2'
+      } as any)
+    ).not.toThrow();
+  });
+
+  test('assertValidTelemetrySubmission accepts full Core-like trace_update payload with timestampMs', () => {
+    expect(() =>
+      assertValidTelemetrySubmission({
+        type: 'trace_update',
+        traceId: 'trace_core_update',
+        generationId: 'gen_123',
+        timestampMs: 1739060000000,
+        tags: ['subassistant', 'fn_inventory_search'],
+        metadata: {
+          source: 'llm_adapter_client',
+          step: 'subassistant'
+        },
+        observability: {
+          enabled: true,
+          targets: [
+            { provider: 'obs-a', export: { traceUpdates: true } }
+          ]
+        }
       } as any)
     ).not.toThrow();
   });


### PR DESCRIPTION
## Summary
Implements #1300 by restoring level-specific Langfuse signal span names while preserving Core telemetry payload compatibility and keeping `trace_update` behavior unchanged.

## Changes
- Added `resolveLangfuseSignalSpanName(level)` in:
  - `plugins/observability-compat/langfuse/internal/langfuse-helpers.ts`
- Updated signal span mapping in:
  - `plugins/observability-compat/langfuse/internal/langfuse.ts`
  - `ERROR -> llm.telemetry.error`
  - `WARNING -> llm.telemetry.warning`
  - `DEBUG -> llm.telemetry.debug`
  - fallback -> `llm.telemetry.signal`
- Kept `trace_update` span name unchanged (`llm.telemetry.event`) and preserved cached trace-context mutation flow.
- Kept Sentry compat unchanged.
- Fixed signal status classification to use normalized level (`" Error "` now correctly maps to error status).
- Documented mapping behavior in:
  - `plugins/observability-compat/langfuse/README.md`

## Tests (TDD-first updates)
- `tests/unit/plugins/observability-compat/langfuse.test.ts`
- `tests/unit/utils/server/spec-validator.test.ts`
- `tests/unit/core/telemetry-submit.test.ts`

## Validation
- `npm test` ✅ (279/279 suites, 4878/4878 tests, 100% coverage)
- `npm run test:extensions` ✅ (36/36 suites, 674/674 tests, 100% coverage)
- `npm run test:live:realtime -- --transport=both` ✅ (6/6 suites, 24/24 tests)
- `npm run test:live:openrouter -- --transport=both` ❌ blocked by missing env vars: `SENTRY_API_KEY`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`, `SENTRY_DSN`
- `npm run test:live` ❌ blocked by missing env vars: `OPENAI_ASSISTANTS_ASSISTANT_ID`, `SENTRY_API_KEY`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`, `SENTRY_DSN`

## Notes
- No public API shape changes.
- `langfuse.observation.type` for signals remains `event`.
